### PR TITLE
Update ExportAllCode2_3.csx

### DIFF
--- a/UndertaleModTool/TechnicalScripts/ExportAllCode2_3.csx
+++ b/UndertaleModTool/TechnicalScripts/ExportAllCode2_3.csx
@@ -51,8 +51,8 @@ void DumpCode()
     for (var i = 0; i < Data.Code.Count; i++)
     {
         UndertaleCode code = Data.Code[i];
-        index_text += code.Name.Content;
         index_text += "\n";
+        index_text += code.Name.Content;
     }
     File.WriteAllText(index_path, index_text);
     for (var i = 0; i < Data.Code.Count; i++)


### PR DESCRIPTION
Swapped two lines of code around so that the LUT file actually starts to list the code names at line 2 (currently it does so from line 1 right after the text explaining it's at line 2).