### PR TITLE
cli: fix publish by disabling single file build

### DIFF
--- a/.github/workflows/cli_build.yml
+++ b/.github/workflows/cli_build.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Build
       run: dotnet build UndertaleModCli --no-restore
     - name: Publish Windows x86 CLI
-      run: dotnet publish UndertaleModCli -c Release -r win-x86 --self-contained false -p:PublishSingleFile=true --output cli_win_x86
+      run: dotnet publish UndertaleModCli -c Release -r win-x86 --self-contained false -p:PublishSingleFile=false --output cli_win_x86
     - name: Publish Windows x64 CLI
-      run: dotnet publish UndertaleModCli -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true --output cli_win_x64
+      run: dotnet publish UndertaleModCli -c Release -r win-x64 --self-contained false -p:PublishSingleFile=false --output cli_win_x64
     - name: Publish Windows ARM CLI
-      run: dotnet publish UndertaleModCli -c Release -r win-arm --self-contained false -p:PublishSingleFile=true --output cli_win_arm
+      run: dotnet publish UndertaleModCli -c Release -r win-arm --self-contained false -p:PublishSingleFile=false --output cli_win_arm
     - name: Copy external files
       run: |
         Copy-Item "README.md" -Destination "./cli_win_x86/"

--- a/.github/workflows/cli_build_net.yml
+++ b/.github/workflows/cli_build_net.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Build
       run: dotnet build UndertaleModCli --no-restore
     - name: Publish Windows x86 NET CLI Bundled
-      run: dotnet publish UndertaleModCli -c Release -r win-x86 --self-contained true -p:PublishSingleFile=true --output cli_win_x86
+      run: dotnet publish UndertaleModCli -c Release -r win-x86 --self-contained true -p:PublishSingleFile=false --output cli_win_x86
     - name: Publish Windows x64 NET CLI Bundled
-      run: dotnet publish UndertaleModCli -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true --output cli_win_x64
+      run: dotnet publish UndertaleModCli -c Release -r win-x64 --self-contained true -p:PublishSingleFile=false --output cli_win_x64
     - name: Copy external files
       run: |
         Copy-Item "README.md" -Destination "./cli_win_x86/"


### PR DESCRIPTION
Not ideal, but no more crashes about unable to find CodeAnalysis
assembly locations.

Not sure what is different from the GUI, but we can probably figure that out later.

![image](https://user-images.githubusercontent.com/28968644/137807337-b5090af4-df27-41e2-acd5-35f23e8f864a.png)