### PR TITLE
Minor fix of the "Scripts improvements"

### DIFF
--- a/UndertaleModTool/HelperScripts/ExportAllSoundsOld.csx
+++ b/UndertaleModTool/HelperScripts/ExportAllSoundsOld.csx
@@ -41,7 +41,6 @@ async Task DumpSounds()
 {
     await Task.Run(() => Parallel.ForEach(Data.Sounds, DumpSound));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Repackers/ImportAllTilesets.csx
+++ b/UndertaleModTool/Repackers/ImportAllTilesets.csx
@@ -47,7 +47,6 @@ async Task ImportTilesets()
 {
     await Task.Run(() => Parallel.ForEach(Data.Backgrounds, ImportTileset));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/SampleScripts/Search.csx
+++ b/UndertaleModTool/SampleScripts/Search.csx
@@ -62,7 +62,6 @@ async Task DumpCode()
 
     await Task.Run(() => Parallel.ForEach(Data.Code, DumpCode));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/SampleScripts/SearchASM.csx
+++ b/UndertaleModTool/SampleScripts/SearchASM.csx
@@ -56,7 +56,6 @@ async Task DumpCode()
 {
     await Task.Run(() => Parallel.ForEach(Data.Code, DumpCode));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Unpackers/ExportASM.csx
+++ b/UndertaleModTool/Unpackers/ExportASM.csx
@@ -41,7 +41,6 @@ async Task DumpCode()
 {
     await Task.Run(() => Parallel.ForEach(Data.Code, DumpCode));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Unpackers/ExportAllCode.csx
+++ b/UndertaleModTool/Unpackers/ExportAllCode.csx
@@ -54,7 +54,6 @@ async Task DumpCode()
 
     await Task.Run(() => Parallel.ForEach(toDump, DumpCode));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Unpackers/ExportAllSprites.csx
+++ b/UndertaleModTool/Unpackers/ExportAllSprites.csx
@@ -46,7 +46,6 @@ async Task DumpSprites()
 {
     await Task.Run(() => Parallel.ForEach(Data.Sprites, DumpSprite));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Unpackers/ExportAllTilesets.csx
+++ b/UndertaleModTool/Unpackers/ExportAllTilesets.csx
@@ -44,7 +44,6 @@ async Task DumpTilesets()
 {
     await Task.Run(() => Parallel.ForEach(Data.Backgrounds, DumpTileset));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Unpackers/ExportFontData.csx
+++ b/UndertaleModTool/Unpackers/ExportFontData.csx
@@ -46,7 +46,6 @@ async Task DumpFonts()
 {
     await Task.Run(() => Parallel.ForEach(Data.Fonts, DumpFont));
 
-    UpdateProgress();
     progress--;
 }
 

--- a/UndertaleModTool/Unpackers/ExportMasks.csx
+++ b/UndertaleModTool/Unpackers/ExportMasks.csx
@@ -46,7 +46,6 @@ async Task DumpSprites()
 {
     await Task.Run(() => Parallel.ForEach(Data.Sprites, DumpSprite));
 
-    UpdateProgress();
     progress--;
 }
 


### PR DESCRIPTION
Removed redundant `UpdateProgress()` _(before progress bar window closes)_ that caused displaying results like _"5/4 code entries"_.