### PR TITLE
Refactor from System.Drawing.Common to Skiasharp.

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Buffers.Binary;
 using System.ComponentModel;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -490,7 +489,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         // Automatically set the grid size to whatever most tiles are sized
 
-        Dictionary<Point, uint> tileSizes = new();
+        Dictionary<(int w, int h), uint> tileSizes = new();
         IEnumerable<Tile> tileList;
 
         if (Layers.Count > 0)
@@ -502,9 +501,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                     tileList = tileList.Concat(layer.AssetsData.LegacyTiles);
                 else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0)
                 {
-                    int w = (int) (Width / layer.TilesData.TilesX);
-                    int h = (int) (Height / layer.TilesData.TilesY);
-                    tileSizes[new(w, h)] = layer.TilesData.TilesX * layer.TilesData.TilesY;
+                    int w = (int)(Width / layer.TilesData.TilesX);
+                    int h = (int)(Height / layer.TilesData.TilesY);
+                    tileSizes[(w, h)] = layer.TilesData.TilesX * layer.TilesData.TilesY;
                 }
             }
 
@@ -515,7 +514,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         // Loop through each tile and save how many times their sizes are used
         foreach (Tile tile in tileList)
         {
-            Point scale = new((int) tile.Width, (int) tile.Height);
+            (int w, int h) scale = ((int)tile.Width, (int)tile.Height);
             if (tileSizes.ContainsKey(scale))
                 tileSizes[scale]++;
             else
@@ -535,9 +534,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         // If tiles exist at all, grab the most used tile size and use that as our grid size
         var largestKey = tileSizes.Aggregate((x, y) => x.Value > y.Value ? x : y).Key;
         if (calculateGridWidth)
-            GridWidth = largestKey.X;
+            GridWidth = largestKey.w;
         if (calculateGridHeight)
-            GridHeight = largestKey.Y;
+            GridHeight = largestKey.h;
     }
 
     /// <inheritdoc />

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Drawing;
+using SkiaSharp;
 using UndertaleModLib.Util;
 
 namespace UndertaleModLib.Models;
@@ -146,19 +147,18 @@ public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyC
     /// </summary>
     /// <param name="replaceImage">The new image that shall be applied to this texture page item.</param>
     /// <param name="disposeImage">Whether to dispose <paramref name="replaceImage"/> afterwards.</param>
-    public void ReplaceTexture(Image replaceImage, bool disposeImage = true)
+    public void ReplaceTexture(SKBitmap replaceImage, bool disposeImage = true)
     {
-        Image finalImage = TextureWorker.ResizeImage(replaceImage, SourceWidth, SourceHeight);
+        SKBitmap finalImage = TextureWorker.ResizeImage(replaceImage, SourceWidth, SourceHeight);
 
         // Apply the image to the TexturePage.
         lock (TexturePage.TextureData)
         {
             TextureWorker worker = new TextureWorker();
-            Bitmap embImage = worker.GetEmbeddedTexture(TexturePage); // Use SetPixel if needed.
+            SKBitmap embImage = worker.GetEmbeddedTexture(TexturePage); // Use SetPixel if needed.
 
-            Graphics g = Graphics.FromImage(embImage);
-            g.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
-            g.DrawImage(finalImage, SourceX, SourceY);
+            SKCanvas g = new SKCanvas(embImage);
+            g.DrawBitmap(finalImage, SourceX, SourceY);
             g.Dispose();
 
             TexturePage.TextureData.TextureBlob = TextureWorker.GetImageBytes(embImage);

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -157,7 +157,7 @@ public class UndertaleTexturePageItem : UndertaleNamedResource, INotifyPropertyC
             TextureWorker worker = new TextureWorker();
             SKBitmap embImage = worker.GetEmbeddedTexture(TexturePage); // Use SetPixel if needed.
 
-            SKCanvas g = new SKCanvas(embImage);
+            SKCanvas g = new(embImage);
             g.DrawBitmap(finalImage, SourceX, SourceY);
             g.Dispose();
 

--- a/UndertaleModLib/Models/UndertaleTexturePageItem.cs
+++ b/UndertaleModLib/Models/UndertaleTexturePageItem.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Drawing;
 using SkiaSharp;
 using UndertaleModLib.Util;
 

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -30,8 +30,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="version.txt" />

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -66,7 +66,7 @@ namespace UndertaleModLib.Util
         /// <summary>
         /// Creates a <see cref="SKBitmap"/> from a <see cref="ReadOnlySpan{TKey}"/> of <see cref="byte"/>s.
         /// </summary>
-        /// <param name="bytes">The <see cref="Span{TKey}"/> of <see cref="byte"/>s to create the PNG image from.</param>
+        /// <param name="bytes">The <see cref="ReadOnlySpan{TKey}"/> of <see cref="byte"/>s to create the PNG image from.</param>
         /// <returns>The QOI image as a PNG.</returns>
         /// <exception cref="Exception">If there is an invalid QOIF magic header or there was an error with stride width.</exception>
         public static SKBitmap GetImageFromSpan(ReadOnlySpan<byte> bytes) => GetImageFromSpan(bytes, out _);

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using SkiaSharp;
 

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -70,7 +70,6 @@ namespace UndertaleModLib.Util
         public static SKBitmap GetImageFromSpan(ReadOnlySpan<byte> bytes) => GetImageFromSpan(bytes, out _);
 
         /// <summary><inheritdoc cref="GetImageFromSpan(System.ReadOnlySpan{byte})"/></summary>
-        /// <param name="bytes"><inheritdoc cref="GetImageFromSpan(System.ReadOnlySpan{byte})"/></param>
         /// <param name="length">The total amount of data read from the <see cref="Span{TKey}"/>.</param>
         /// <returns><inheritdoc cref="GetImageFromSpan(System.ReadOnlySpan{byte})"/></returns>
         /// <exception cref="Exception"><inheritdoc cref="GetImageFromSpan(System.ReadOnlySpan{byte})"/></exception>

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -168,7 +168,8 @@ namespace UndertaleModLib.Util
 
         public static byte[] GetImageBytes(SKBitmap image, bool disposeImage = true)
         {
-            byte[] result = image.Bytes;
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            byte[] result = data.ToArray();
             if (disposeImage)
                 image.Dispose();
             return result;

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -99,11 +99,24 @@ namespace UndertaleModLib.Util
             return bm;
         }
 
-        // This should perform a high quality resize.
-        public static SKBitmap ResizeImage(SKBitmap image, int width, int height)
+        public static SKSizeI GetImageSizeFromFile(string filePath)
+        {
+            using SKCodec codec = SKCodec.Create(filePath);
+
+            return codec?.Info.Size ?? default;
+        }
+        public static SKSizeI GetImageSizeFromByteArray(byte[] byteArray)
+        {
+            using MemoryStream stream = new(byteArray);
+            using SKCodec codec = SKCodec.Create(stream);
+
+            return codec?.Info.Size ?? default;
+        }
+
+        public static SKBitmap ResizeImage(SKBitmap image, int width, int height, bool useNearestNeighbor = false)
         {
             var destImage = new SKBitmap(width, height);
-            image.ScalePixels(destImage, SKFilterQuality.High);
+            image.ScalePixels(destImage, useNearestNeighbor ? SKFilterQuality.None : SKFilterQuality.High);
             return destImage;
         }
 

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -51,7 +51,7 @@ namespace UndertaleModLib.Util
         {
             int exportWidth = texPageItem.BoundingWidth; // sprite.Width
             int exportHeight = texPageItem.BoundingHeight; // sprite.Height
-            using SKBitmap embeddedImage = GetEmbeddedTexture(texPageItem.TexturePage);
+            SKBitmap embeddedImage = GetEmbeddedTexture(texPageItem.TexturePage);
 
             // Sanity checks.
             if (includePadding && ((texPageItem.TargetWidth > exportWidth) || (texPageItem.TargetHeight > exportHeight)))

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -99,24 +99,11 @@ namespace UndertaleModLib.Util
             return bm;
         }
 
-        public static SKSizeI GetImageSizeFromFile(string filePath)
-        {
-            using SKCodec codec = SKCodec.Create(filePath);
-
-            return codec?.Info.Size ?? default;
-        }
-        public static SKSizeI GetImageSizeFromByteArray(byte[] byteArray)
-        {
-            using MemoryStream stream = new(byteArray);
-            using SKCodec codec = SKCodec.Create(stream);
-
-            return codec?.Info.Size ?? default;
-        }
-
-        public static SKBitmap ResizeImage(SKBitmap image, int width, int height, bool useNearestNeighbor = false)
+        // This should perform a high quality resize.
+        public static SKBitmap ResizeImage(SKBitmap image, int width, int height)
         {
             var destImage = new SKBitmap(width, height);
-            image.ScalePixels(destImage, useNearestNeighbor ? SKFilterQuality.None : SKFilterQuality.High);
+            image.ScalePixels(destImage, SKFilterQuality.High);
             return destImage;
         }
 

--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
 using System.IO;
 using SkiaSharp;
 using UndertaleModLib.Models;

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -176,6 +176,7 @@ namespace UndertaleModTool
             using SKBitmap spriteBMP = CreateSpriteBitmap(rect, in texture, diffW, diffH, isTile);
             using var data = spriteBMP.Encode(SKEncodedImageFormat.Png, 100);
 
+            // The `CacheOption` must be set after `BeginInit()`, otherwise it won't work.
             BitmapImage spriteSrc = new();
             spriteSrc.BeginInit();
             spriteSrc.CacheOption = BitmapCacheOption.OnLoad;
@@ -295,7 +296,7 @@ namespace UndertaleModTool
     }
     public class CachedImageLoaderWithIndex : IMultiValueConverter
     {
-        private static UndertaleCachedImageLoader loader = new();
+        private static readonly UndertaleCachedImageLoader loader = new();
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values.Any(x => x is null))

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -175,8 +175,8 @@ namespace UndertaleModTool
         }
         private ImageSource CreateSpriteSource(in Rectangle rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
         {
-            SKBitmap spriteBMP = CreateSpriteBitmap(rect, in texture, diffW, diffH, isTile);
-            var data = spriteBMP.Encode(SKEncodedImageFormat.Png, 100);
+            using SKBitmap spriteBMP = CreateSpriteBitmap(rect, in texture, diffW, diffH, isTile);
+            using var data = spriteBMP.Encode(SKEncodedImageFormat.Png, 100);
 
             BitmapImage spriteSrc = new();
             spriteSrc.BeginInit();
@@ -184,8 +184,6 @@ namespace UndertaleModTool
             spriteSrc.StreamSource = data.AsStream();
             spriteSrc.EndInit();
 
-            spriteBMP.Dispose();
-            data.Dispose();
             spriteSrc.Freeze(); // allow UI thread access
 
             return spriteSrc;
@@ -248,18 +246,16 @@ namespace UndertaleModTool
                     }
                 }
 
-                SKBitmap tileBMP = new(w, h);
+                using SKBitmap tileBMP = new(w, h);
                 Marshal.Copy(bufferRes, 0, tileBMP.GetPixels(), bufferResLen);
                 ArrayPool<byte>.Shared.Return(bufferRes);
 
-                var data = tileBMP.Encode(SKEncodedImageFormat.Png, 100);
+                using var data = tileBMP.Encode(SKEncodedImageFormat.Png, 100);
                 BitmapImage spriteSrc = new();
                 spriteSrc.BeginInit();
                 spriteSrc.CacheOption = BitmapCacheOption.OnLoad;
                 spriteSrc.StreamSource = data.AsStream();
                 spriteSrc.EndInit();
-                tileBMP.Dispose();
-                data.Dispose();
 
                 spriteSrc.Freeze(); // allow UI thread access
 
@@ -530,7 +526,7 @@ namespace UndertaleModTool
             }
             layerG.Dispose();
 
-            var data = layerBMP.Encode(SKEncodedImageFormat.Png, 100);
+            using var data = layerBMP.Encode(SKEncodedImageFormat.Png, 100);
 
             BitmapImage spriteSrc = new();
             spriteSrc.BeginInit();
@@ -538,7 +534,6 @@ namespace UndertaleModTool
             spriteSrc.StreamSource = data.AsStream();
             spriteSrc.EndInit();
 
-            data.Dispose();
             spriteSrc.Freeze();
 
             return spriteSrc;

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -276,7 +276,7 @@ namespace UndertaleModTool
     // UndertaleCachedImageLoader wrappers
     public class CachedTileImageLoader : IMultiValueConverter
     {
-        private static UndertaleCachedImageLoader loader = new();
+        private static readonly UndertaleCachedImageLoader loader = new();
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values[0] is null) // tile
@@ -496,17 +496,21 @@ namespace UndertaleModTool
                                 tileSurf.Canvas.Scale(-1, -1, srcBMP.Width / 2, srcBMP.Height / 2);
                                 break;
                             case 4:
+                                // Rotate 90 degrees clockwise
                                 tileSurf.Canvas.RotateDegrees(90);
                                 break;
                             case 5:
+                                // Rotate 270 degrees clockwise and flip Y
                                 tileSurf.Canvas.RotateDegrees(270);
                                 tileSurf.Canvas.Scale(1, -1, 0, srcBMP.Height / 2);
                                 break;
                             case 6:
+                                // Rotate 90 degrees clockwise and flip Y
                                 tileSurf.Canvas.RotateDegrees(90);
                                 tileSurf.Canvas.Scale(1, -1, 0, srcBMP.Height / 2);
                                 break;
                             case 7:
+                                // Rotate 270 degrees clockwise
                                 tileSurf.Canvas.RotateDegrees(270);
                                 break;
 

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -3,8 +3,6 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Imaging;
 using SkiaSharp;
 using System.Globalization;
 using System.IO;
@@ -95,7 +93,7 @@ namespace UndertaleModTool
 
             if (tileRectList is not null)
             {
-                Rectangle rect = new(texture.SourceX, texture.SourceY, texture.SourceWidth, texture.SourceHeight);
+                Rect rect = new(texture.SourceX, texture.SourceY, texture.SourceWidth, texture.SourceHeight);
                 ProcessTileSet(texName, CreateSpriteBitmap(rect, in texture), tileRectList, texture.TargetX, texture.TargetY);
 
                 return null;
@@ -110,7 +108,7 @@ namespace UndertaleModTool
 
             if (!imageCache.ContainsKey(texName) || !cacheEnabled)
             {
-                Rectangle rect;
+                Rect rect;
 
                 // how many pixels are out of bounds of tile texture page
                 int diffW = 0;
@@ -152,9 +150,9 @@ namespace UndertaleModTool
             currBufferSize = 1048576;
         }
 
-        public static SKBitmap CreateSpriteBitmap(Rectangle rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
+        public static SKBitmap CreateSpriteBitmap(Rect rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
         {
-            SKBitmap spriteBMP = new(rect.Width, rect.Height);
+            SKBitmap spriteBMP = new((int)rect.Width, (int)rect.Height);
 
             rect.Width -= (diffW > 0) ? diffW : 0;
             rect.Height -= (diffH > 0) ? diffH : 0;
@@ -165,15 +163,15 @@ namespace UndertaleModTool
             {
                 using SKBitmap img = SKBitmap.Decode(texture.TexturePage.TextureData.TextureBlob);
                 
-                var rectDest = SKRect.Create(x, y, rect.Width, rect.Height);
-                var rectSrc = SKRect.Create(rect.Left, rect.Top, rect.Width, rect.Height);
+                var rectDest = SKRect.Create(x, y, (float)rect.Width, (float)rect.Height);
+                var rectSrc = SKRect.Create((float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
                 g.DrawBitmap(img, rectSrc, rectDest);
             }
             spriteBMP.SetImmutable();
 
             return spriteBMP;
         }
-        private ImageSource CreateSpriteSource(in Rectangle rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
+        private ImageSource CreateSpriteSource(in Rect rect, in UndertaleTexturePageItem texture, int diffW = 0, int diffH = 0, bool isTile = false)
         {
             using SKBitmap spriteBMP = CreateSpriteBitmap(rect, in texture, diffW, diffH, isTile);
             using var data = spriteBMP.Encode(SKEncodedImageFormat.Png, 100);

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -481,6 +481,7 @@ namespace UndertaleModTool
                         SKBitmap srcBMP = TileCache[new(tilesBG.Texture.Name.Content, realID)];
                         tileSurf.Canvas.ResetMatrix();
 
+                        // Don't forget to also modify `TileRectanglesConverter.Convert()` in "Editors/UndertaleRoomEditor.cs"
                         switch (id >> 28)
                         {
                             case 1:

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -167,7 +167,6 @@ namespace UndertaleModTool
                 var rectSrc = SKRect.Create((float)rect.Left, (float)rect.Top, (float)rect.Width, (float)rect.Height);
                 g.DrawBitmap(img, rectSrc, rectDest);
             }
-            spriteBMP.SetImmutable();
 
             return spriteBMP;
         }

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -24,10 +24,6 @@ namespace UndertaleModTool
 {
     public class UndertaleCachedImageLoader : IValueConverter
     {
-        [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DeleteObject([In] IntPtr hObject);
-
         private static readonly ConcurrentDictionary<string, ImageSource> imageCache = new();
         private static readonly ConcurrentDictionary<Tuple<string, Tuple<uint, uint, uint, uint>>, ImageSource> tileCache = new();
         private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
@@ -335,10 +331,6 @@ namespace UndertaleModTool
 
     public class CachedTileDataLoader : IMultiValueConverter
     {
-        [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DeleteObject([In] IntPtr hObject);
-
         // Tile text. page, tile ID - tile pixel data
         public static ConcurrentDictionary<Tuple<string, uint>, SKBitmap> TileCache { get; set; } = new();
         private static readonly ConcurrentDictionary<string, SKBitmap> tilePageCache = new();
@@ -547,7 +539,7 @@ namespace UndertaleModTool
             spriteSrc.EndInit();
 
             data.Dispose();
-            // TODO: spriteSrc.Freeze() ?
+            spriteSrc.Freeze();
 
             return spriteSrc;
         }

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -473,6 +473,8 @@ namespace UndertaleModTool
             SKCanvas layerG = new(layerBMP);
             uint maxID = tilesData.Background.GMS2TileIds.Select(x => x.ID).Max();
 
+            using SKSurface tileSurf = SKSurface.Create(new SKImageInfo(w, h));
+
             for (int y = 0; y < tilesData.TilesY; y++)
             {
                 for (int x = 0; x < tilesData.TilesX; x++)
@@ -491,7 +493,7 @@ namespace UndertaleModTool
                         }
 
                         SKBitmap srcBMP = TileCache[new(tilesBG.Texture.Name.Content, realID)];
-                        using SKSurface tileSurf = SKSurface.Create(srcBMP.Info);
+                        tileSurf.Canvas.ResetMatrix();
 
                         switch (id >> 28)
                         {

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -14,7 +14,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
-using System.Drawing;
+using SkiaSharp;
 using UndertaleModLib.Models;
 using UndertaleModLib.Util;
 using System.Globalization;
@@ -154,12 +154,7 @@ namespace UndertaleModTool
             {
                 try
                 {
-                    Bitmap bmp;
-                    using (var ms = new MemoryStream(TextureWorker.ReadTextureBlob(dlg.FileName)))
-                    {
-                        bmp = new Bitmap(ms);
-                    }
-                    bmp.SetResolution(96.0F, 96.0F);
+                    using SKBitmap bmp = SKBitmap.Decode(TextureWorker.ReadTextureBlob(dlg.FileName));
 
                     var width = (uint)bmp.Width;
                     var height = (uint)bmp.Height;
@@ -169,14 +164,12 @@ namespace UndertaleModTool
                         mainWindow.ShowWarning("WARNING: texture page dimensions are not powers of 2. Sprite blurring is very likely in game.", "Unexpected texture dimensions");
                     }
 
-                    using (var stream = new MemoryStream())
-                    {
-                        bmp.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
-                        target.TextureData.TextureBlob = stream.ToArray();
+                    using var stream = new MemoryStream();
+                    bmp.Encode(stream, SKEncodedImageFormat.Png, 100);
+                    target.TextureData.TextureBlob = stream.ToArray();
 
-                        TexWidth.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();
-                        TexHeight.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();
-                    }
+                    TexWidth.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();
+                    TexHeight.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();
                 }
                 catch (Exception ex)
                 {

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -2497,10 +2497,6 @@ namespace UndertaleModTool
     }
     public class TileRectanglesConverter : IMultiValueConverter
     {
-        [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool DeleteObject([In] IntPtr hObject);
-
         public static ConcurrentDictionary<Tuple<string, uint>, ImageSource> TileCache { get; set; } = new();
         private static CachedTileDataLoader loader = new();
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.Win32;
+using SkiaSharp;
 using System;
 using System.Buffers;
 using System.Collections;
@@ -2534,9 +2535,16 @@ namespace UndertaleModTool
                     {
                         Tuple<string, uint> tileKey = new(tilesBG.Texture.Name.Content, id);
 
-                        IntPtr bmpPtr = CachedTileDataLoader.TileCache[tileKey].GetHbitmap();
-                        ImageSource spriteSrc = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(bmpPtr, IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
-                        DeleteObject(bmpPtr);
+                        SKBitmap bmp = CachedTileDataLoader.TileCache[tileKey];
+                        var data = bmp.Encode(SKEncodedImageFormat.Png, 100);
+
+                        BitmapImage spriteSrc = new();
+                        spriteSrc.BeginInit();
+                        spriteSrc.CacheOption = BitmapCacheOption.OnLoad;
+                        spriteSrc.StreamSource = data.AsStream();
+                        spriteSrc.EndInit();
+                        data.Dispose();
+
                         spriteSrc.Freeze(); // allow UI thread access
 
                         TileCache.TryAdd(tileKey, spriteSrc);

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml.cs
@@ -2498,7 +2498,7 @@ namespace UndertaleModTool
     public class TileRectanglesConverter : IMultiValueConverter
     {
         public static ConcurrentDictionary<Tuple<string, uint>, ImageSource> TileCache { get; set; } = new();
-        private static CachedTileDataLoader loader = new();
+        private static readonly CachedTileDataLoader loader = new();
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
@@ -2568,6 +2568,7 @@ namespace UndertaleModTool
                                 return;
                             }
 
+                            // Don't forget to also modify `CachedTileDataLoader.CreateLayerSource()` in "Converters/UndertaleCachedImageLoader.cs"
                             switch (id >> 28)
                             {
                                 case 1:

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -36,8 +36,7 @@ namespace UndertaleModTool
 
             try
             {
-                Bitmap image = TextureWorker.ReadImageFromFile(dlg.FileName);
-                image.SetResolution(96.0F, 96.0F);
+                SkiaSharp.SKBitmap image = TextureWorker.ReadImageFromFile(dlg.FileName);
                 (this.DataContext as UndertaleTexturePageItem).ReplaceTexture(image);
 
                 // Refresh the image of "ItemDisplay"

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Drawing;
 using System.Windows;
 using System.IO;
 using UndertaleModLib.Models;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -540,7 +540,7 @@ namespace UndertaleModTool
             {
                 foreach (var pair in appDarkStyle)
                     resources[pair.Key] = pair.Value;
-
+                
                 Windows.TextInput.BGColor = System.Drawing.Color.FromArgb(darkColor.R,
                                                                           darkColor.G,
                                                                           darkColor.B);

--- a/UndertaleModTool/Scripts/Builtin Scripts/UndertaleDialogSimulator.csx
+++ b/UndertaleModTool/Scripts/Builtin Scripts/UndertaleDialogSimulator.csx
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System;
+using System.Drawing;
 using System.Windows.Forms;
 using UndertaleModLib.Util;
 
@@ -24,10 +25,10 @@ else if (GameName == "deltarune chapter 1&2")
 }
 if (Data.GeneralInfo.Name.Content == "NXTALE" || Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE")) 
 {
-    if (!ScriptQuestion("Would you like to apply this mod?"))
-    {
-        return;
-    }
+	if (!ScriptQuestion("Would you like to apply this mod?"))
+	{
+		return;
+	}
 }
 else if (Data.GeneralInfo.DisplayName.Content == "SURVEY_PROGRAM" || Data.GeneralInfo.DisplayName.Content == "DELTARUNE Chapter 1")
 {

--- a/UndertaleModTool/Scripts/Builtin Scripts/UndertaleDialogSimulator.csx
+++ b/UndertaleModTool/Scripts/Builtin Scripts/UndertaleDialogSimulator.csx
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System;
-using System.Drawing;
 using System.Windows.Forms;
 using UndertaleModLib.Util;
 
@@ -25,10 +24,10 @@ else if (GameName == "deltarune chapter 1&2")
 }
 if (Data.GeneralInfo.Name.Content == "NXTALE" || Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE")) 
 {
-	if (!ScriptQuestion("Would you like to apply this mod?"))
-	{
-		return;
-	}
+    if (!ScriptQuestion("Would you like to apply this mod?"))
+    {
+        return;
+    }
 }
 else if (Data.GeneralInfo.DisplayName.Content == "SURVEY_PROGRAM" || Data.GeneralInfo.DisplayName.Content == "DELTARUNE Chapter 1")
 {

--- a/UndertaleModTool/Scripts/Community Scripts/FontEditor.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/FontEditor.csx
@@ -1,4 +1,5 @@
 //by porog
+// TODO: this heavily uses windows stuff, should be made cross platform
 
 using System.Drawing;
 using System.Drawing.Imaging;

--- a/UndertaleModTool/Scripts/Community Scripts/ImportGMS2FontData.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ImportGMS2FontData.csx
@@ -2,7 +2,7 @@
 
 using System;
 using System.IO;
-using System.Drawing;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +11,7 @@ using UndertaleModLib;
 using UndertaleModLib.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using UndertaleModLib.Util;
 
 EnsureDataLoaded();
 
@@ -96,10 +97,10 @@ else if (attemptToFixFontNotAppearing)
         fontTexGroup.Fonts.Add(new UndertaleResourceById<UndertaleFont, UndertaleChunkFONT>() { Resource = font });
 }
 
-// Prepare font texture
-Bitmap textureBitmap = new Bitmap(fontTexturePath);
-// Make the DPI exactly 96 for this bitmap
-textureBitmap.SetResolution(96.0F, 96.0F);
+// Get texture properties
+var imgSize = TextureWorker.GetImageSizeFromFile(fontTexturePath);
+ushort width = (ushort)imgSize.Width;
+ushort height = (ushort)imgSize.Height;
 
 UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
 // ??? Why?
@@ -115,14 +116,14 @@ texturePageItem.Name = new UndertaleString("PageItem " + Data.TexturePageItems.C
 texturePageItem.TexturePage = texture;
 texturePageItem.SourceX = 0;
 texturePageItem.SourceY = 0;
-texturePageItem.SourceWidth = (ushort)textureBitmap.Width;
-texturePageItem.SourceHeight = (ushort)textureBitmap.Height;
+texturePageItem.SourceWidth = width;
+texturePageItem.SourceHeight = height;
 texturePageItem.TargetX = 0;
 texturePageItem.TargetY = 0;
-texturePageItem.TargetWidth = (ushort)textureBitmap.Width;
-texturePageItem.TargetHeight = (ushort)textureBitmap.Height;
-texturePageItem.BoundingWidth = (ushort)textureBitmap.Width;
-texturePageItem.BoundingHeight = (ushort)textureBitmap.Height;
+texturePageItem.TargetWidth = width;
+texturePageItem.TargetHeight = height;
+texturePageItem.BoundingWidth = width;
+texturePageItem.BoundingHeight = height;
 Data.TexturePageItems.Add(texturePageItem);
 
 font.DisplayName = Data.Strings.MakeString((string)fontData["fontName"]);

--- a/UndertaleModTool/Scripts/Community Scripts/ImportGMS2FontData.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ImportGMS2FontData.csx
@@ -2,7 +2,7 @@
 
 using System;
 using System.IO;
-using SkiaSharp;
+using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +11,6 @@ using UndertaleModLib;
 using UndertaleModLib.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using UndertaleModLib.Util;
 
 EnsureDataLoaded();
 
@@ -97,10 +96,10 @@ else if (attemptToFixFontNotAppearing)
         fontTexGroup.Fonts.Add(new UndertaleResourceById<UndertaleFont, UndertaleChunkFONT>() { Resource = font });
 }
 
-// Get texture properties
-var imgSize = TextureWorker.GetImageSizeFromFile(fontTexturePath);
-ushort width = (ushort)imgSize.Width;
-ushort height = (ushort)imgSize.Height;
+// Prepare font texture
+Bitmap textureBitmap = new Bitmap(fontTexturePath);
+// Make the DPI exactly 96 for this bitmap
+textureBitmap.SetResolution(96.0F, 96.0F);
 
 UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
 // ??? Why?
@@ -116,14 +115,14 @@ texturePageItem.Name = new UndertaleString("PageItem " + Data.TexturePageItems.C
 texturePageItem.TexturePage = texture;
 texturePageItem.SourceX = 0;
 texturePageItem.SourceY = 0;
-texturePageItem.SourceWidth = width;
-texturePageItem.SourceHeight = height;
+texturePageItem.SourceWidth = (ushort)textureBitmap.Width;
+texturePageItem.SourceHeight = (ushort)textureBitmap.Height;
 texturePageItem.TargetX = 0;
 texturePageItem.TargetY = 0;
-texturePageItem.TargetWidth = width;
-texturePageItem.TargetHeight = height;
-texturePageItem.BoundingWidth = width;
-texturePageItem.BoundingHeight = height;
+texturePageItem.TargetWidth = (ushort)textureBitmap.Width;
+texturePageItem.TargetHeight = (ushort)textureBitmap.Height;
+texturePageItem.BoundingWidth = (ushort)textureBitmap.Width;
+texturePageItem.BoundingHeight = (ushort)textureBitmap.Height;
 Data.TexturePageItems.Add(texturePageItem);
 
 font.DisplayName = Data.Strings.MakeString((string)fontData["fontName"]);

--- a/UndertaleModTool/Scripts/Community Scripts/ScaleAllTextures.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ScaleAllTextures.csx
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Drawing.Drawing2D;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,9 +19,9 @@ if (!ScriptQuestion("Visual glitches are very likely to occur in game. Do you ac
 
 TextureWorker worker = new TextureWorker();
 double scale = -1;
-bool SelectScale = true;
+bool selectScale = true;
 
-if (SelectScale)
+if (selectScale)
 {
     bool success = false;
     while (scale <= 0 || scale > 10)
@@ -131,9 +129,8 @@ ChangeSelection(Data.Rooms.ByName("room_ruins1"));
 
 void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
 {
-    Bitmap embImage = worker.GetEmbeddedTexture(tex);
-    embImage = ResizeBitmap(embImage, (int)(embImage.Width * scale), (int)(embImage.Height * scale));
-    embImage.SetResolution(96.0F, 96.0F);
+    SKBitmap embImage = worker.GetEmbeddedTexture(tex);
+    embImage = TextureWorker.ResizeImage(embImage, (int)(embImage.Width * scale), (int)(embImage.Height * scale), useNearestNeighbor: true);
     try
     {
         var width = (uint)embImage.Width;
@@ -144,7 +141,7 @@ void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
         }
         using (var stream = new MemoryStream())
         {
-            embImage.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+            embImage.Encode(stream, SKEncodedImageFormat.Png, 100);
             tex.TextureData.TextureBlob = stream.ToArray();
         }
     }
@@ -152,15 +149,4 @@ void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
     {
         //ScriptError("Failed to import file: " + ex.Message, "Failed to import file");
     }
-}
-
-private Bitmap ResizeBitmap(Bitmap sourceBMP, int width, int height)
-{
-    Bitmap result = new Bitmap(width, height);
-    using (Graphics g = Graphics.FromImage(result))
-    {
-        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
-        g.DrawImage(sourceBMP, 0, 0, width, height);
-    }
-    return result;
 }

--- a/UndertaleModTool/Scripts/Community Scripts/ScaleAllTextures.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ScaleAllTextures.csx
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Drawing.Drawing2D;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,9 +19,9 @@ if (!ScriptQuestion("Visual glitches are very likely to occur in game. Do you ac
 
 TextureWorker worker = new TextureWorker();
 double scale = -1;
-bool SelectScale = true;
+bool selectScale = true;
 
-if (SelectScale)
+if (selectScale)
 {
     bool success = false;
     while (scale <= 0 || scale > 10)
@@ -131,9 +129,8 @@ ChangeSelection(Data.Rooms.ByName("room_ruins1"));
 
 void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
 {
-    Bitmap embImage = worker.GetEmbeddedTexture(tex);
-    embImage = ResizeBitmap(embImage, (int)(embImage.Width * scale), (int)(embImage.Height * scale));
-    embImage.SetResolution(96.0F, 96.0F);
+    SKBitmap embImage = worker.GetEmbeddedTexture(tex);
+    embImage = worker.ResizeImage(embImage, (int)(embImage.Width * scale), (int)(embImage.Height * scale), true);
     try
     {
         var width = (uint)embImage.Width;
@@ -144,7 +141,7 @@ void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
         }
         using (var stream = new MemoryStream())
         {
-            embImage.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+            embImage.Encode(stream, SKEncodedImageFormat.Png, 100);
             tex.TextureData.TextureBlob = stream.ToArray();
         }
     }
@@ -152,15 +149,4 @@ void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
     {
         //ScriptError("Failed to import file: " + ex.Message, "Failed to import file");
     }
-}
-
-private Bitmap ResizeBitmap(Bitmap sourceBMP, int width, int height)
-{
-    Bitmap result = new Bitmap(width, height);
-    using (Graphics g = Graphics.FromImage(result))
-    {
-        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
-        g.DrawImage(sourceBMP, 0, 0, width, height);
-    }
-    return result;
 }

--- a/UndertaleModTool/Scripts/Community Scripts/ScaleAllTextures.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ScaleAllTextures.csx
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
-using SkiaSharp;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Drawing.Drawing2D;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,9 +21,9 @@ if (!ScriptQuestion("Visual glitches are very likely to occur in game. Do you ac
 
 TextureWorker worker = new TextureWorker();
 double scale = -1;
-bool selectScale = true;
+bool SelectScale = true;
 
-if (selectScale)
+if (SelectScale)
 {
     bool success = false;
     while (scale <= 0 || scale > 10)
@@ -129,8 +131,9 @@ ChangeSelection(Data.Rooms.ByName("room_ruins1"));
 
 void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
 {
-    SKBitmap embImage = worker.GetEmbeddedTexture(tex);
-    embImage = worker.ResizeImage(embImage, (int)(embImage.Width * scale), (int)(embImage.Height * scale), true);
+    Bitmap embImage = worker.GetEmbeddedTexture(tex);
+    embImage = ResizeBitmap(embImage, (int)(embImage.Width * scale), (int)(embImage.Height * scale));
+    embImage.SetResolution(96.0F, 96.0F);
     try
     {
         var width = (uint)embImage.Width;
@@ -141,7 +144,7 @@ void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
         }
         using (var stream = new MemoryStream())
         {
-            embImage.Encode(stream, SKEncodedImageFormat.Png, 100);
+            embImage.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
             tex.TextureData.TextureBlob = stream.ToArray();
         }
     }
@@ -149,4 +152,15 @@ void ScaleEmbeddedTexture(UndertaleEmbeddedTexture tex)
     {
         //ScriptError("Failed to import file: " + ex.Message, "Failed to import file");
     }
+}
+
+private Bitmap ResizeBitmap(Bitmap sourceBMP, int width, int height)
+{
+    Bitmap result = new Bitmap(width, height);
+    using (Graphics g = Graphics.FromImage(result))
+    {
+        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+        g.DrawImage(sourceBMP, 0, 0, width, height);
+    }
+    return result;
 }

--- a/UndertaleModTool/Scripts/Resource Repackers/ApplyBasicGraphicsMod.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ApplyBasicGraphicsMod.csx
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using System.Drawing;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,12 +105,7 @@ await Task.Run(() => {
         {
             try
             {
-                Bitmap bmp;
-                using (var ms = new MemoryStream(TextureWorker.ReadTextureBlob(file)))
-                {
-                    bmp = new Bitmap(ms);
-                }
-                bmp.SetResolution(96.0F, 96.0F);
+                SKBitmap bmp = SKBitmap.Decode(file);
                 var width = (uint)bmp.Width;
                 var height = (uint)bmp.Height;
                 var CheckWidth = (uint)(sprite.Textures[frame].Texture.TargetWidth);

--- a/UndertaleModTool/Scripts/Resource Repackers/ApplyBasicGraphicsMod.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ApplyBasicGraphicsMod.csx
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,12 +104,7 @@ await Task.Run(() => {
         {
             try
             {
-                Bitmap bmp;
-                using (var ms = new MemoryStream(TextureWorker.ReadTextureBlob(file)))
-                {
-                    bmp = new Bitmap(ms);
-                }
-                bmp.SetResolution(96.0F, 96.0F);
+                SKBitmap bmp = SKBitmap.Decode(file);
                 var width = (uint)bmp.Width;
                 var height = (uint)bmp.Height;
                 var CheckWidth = (uint)(sprite.Textures[frame].Texture.TargetWidth);

--- a/UndertaleModTool/Scripts/Resource Repackers/ApplyBasicGraphicsMod.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ApplyBasicGraphicsMod.csx
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -104,7 +105,12 @@ await Task.Run(() => {
         {
             try
             {
-                SKBitmap bmp = SKBitmap.Decode(file);
+                Bitmap bmp;
+                using (var ms = new MemoryStream(TextureWorker.ReadTextureBlob(file)))
+                {
+                    bmp = new Bitmap(ms);
+                }
+                bmp.SetResolution(96.0F, 96.0F);
                 var width = (uint)bmp.Width;
                 var height = (uint)bmp.Height;
                 var CheckWidth = (uint)(sprite.Textures[frame].Texture.TargetWidth);

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportAllTilesets.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportAllTilesets.csx
@@ -1,5 +1,6 @@
 // Adapted from original script by Grossley
 
+// TODO: remove system.drawing from here, used for bitmaps 
 using System.Text;
 using System;
 using System.IO;

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportFontData.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportFontData.csx
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using System.Drawing;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,7 +37,6 @@ int atlasCount = 0;
 foreach (Atlas atlas in packer.Atlasses)
 {
     string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
-    Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
     texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
@@ -85,8 +84,6 @@ foreach (Atlas atlas in packer.Atlasses)
     }
     atlasCount++;
 }
-
-
 
 HideProgressBar();
 ScriptMessage("Import Complete!");
@@ -176,10 +173,17 @@ public enum BestFitHeuristic
     Area,
     MaxOneAxis,
 }
+public struct Rect
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+}
 
 public class Node
 {
-    public Rectangle Bounds;
+    public Rect Bounds;
     public TextureInfo Texture;
     public SplitType SplitType;
 }
@@ -201,6 +205,26 @@ public class Packer
     public bool DebugMode;
     public BestFitHeuristic FitHeuristic;
     public List<Atlas> Atlasses;
+    public static readonly SKPaint paintGreen = new()
+    {
+        Color = SKColors.Green,
+        BlendMode = SKBlendMode.Src
+    };
+    public static readonly SKPaint paintBlack = new()
+    {
+        Color = SKColors.Black,
+        BlendMode = SKBlendMode.Src
+    };
+    public static readonly SKPaint paintWhite = new()
+    {
+        Color = SKColors.White,
+        BlendMode = SKBlendMode.Src
+    };
+    public static readonly SKPaint paintDarkMagenta = new()
+    {
+        Color = SKColors.DarkMagenta,
+        BlendMode = SKBlendMode.Src
+    };
 
     public Packer()
     {
@@ -256,13 +280,10 @@ public class Packer
         {
             string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
             //1: Save images
-            Image img = CreateAtlasImage(atlas);
-            //DPI fix start
-            Bitmap ResolutionFix = new Bitmap(img);
-            ResolutionFix.SetResolution(96.0F, 96.0F);
-            Image img2 = ResolutionFix;
-            //DPI fix end
-            img2.Save(atlasName, System.Drawing.Imaging.ImageFormat.Png);
+            using SKBitmap img = CreateAtlasImage(atlas);
+            using FileStream fs = new(atlasName, FileMode.Create, FileAccess.Write);
+            img.Encode(fs, SKEncodedImageFormat.Png, 100);
+            fs.Close();
             //2: save description in file
             foreach (Node n in atlas.Nodes)
             {
@@ -293,25 +314,27 @@ public class Packer
         FileInfo[] files = di.GetFiles(_Wildcard, SearchOption.AllDirectories);
         foreach (FileInfo fi in files)
         {
-            Image img = Image.FromFile(fi.FullName);
-            if (img != null)
+            var imgSize = TextureWorker.GetImageSizeFromFile(fi.FullName);
+            if (imgSize == default)
+                continue;
+            int width = imgSize.Width;
+            int height = imgSize.Height;
+
+            if (width <= AtlasSize && height <= AtlasSize)
             {
-                if (img.Width <= AtlasSize && img.Height <= AtlasSize)
-                {
-                    TextureInfo ti = new TextureInfo();
+                TextureInfo ti = new TextureInfo();
 
-                    ti.Source = fi.FullName;
-                    ti.Width = img.Width;
-                    ti.Height = img.Height;
+                ti.Source = fi.FullName;
+                ti.Width = width;
+                ti.Height = height;
 
-                    SourceTextures.Add(ti);
+                SourceTextures.Add(ti);
 
-                    Log.WriteLine("Added " + fi.FullName);
-                }
-                else
-                {
-                    Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
-                }
+                Log.WriteLine("Added " + fi.FullName);
+            }
+            else
+            {
+                Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
             }
         }
     }
@@ -404,7 +427,8 @@ public class Packer
         _Atlas.Nodes = new List<Node>();
         textures = _Textures.ToList();
         Node root = new Node();
-        root.Bounds.Size = new Size(_Atlas.Width, _Atlas.Height);
+        root.Bounds.Width = _Atlas.Width;
+        root.Bounds.Height = _Atlas.Height;
         root.SplitType = SplitType.Horizontal;
         freeList.Add(root);
         while (freeList.Count > 0 && textures.Count > 0)
@@ -432,42 +456,46 @@ public class Packer
         return textures;
     }
 
-    private Image CreateAtlasImage(Atlas _Atlas)
+    private SKBitmap CreateAtlasImage(Atlas _Atlas)
     {
-        Image img = new Bitmap(_Atlas.Width, _Atlas.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        Graphics g = Graphics.FromImage(img);
+        SKBitmap img = new(_Atlas.Width, _Atlas.Height);
+        using SKCanvas g = new(img);
         if (DebugMode)
-        {
-            g.FillRectangle(Brushes.Green, new Rectangle(0, 0, _Atlas.Width, _Atlas.Height));
-        }
+            g.DrawRect(0, 0, _Atlas.Width, _Atlas.Height, paintGreen);
+
         foreach (Node n in _Atlas.Nodes)
         {
+            SKRect rect = SKRect.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+
             if (n.Texture != null)
             {
-                Image sourceImg = Image.FromFile(n.Texture.Source);
-                g.DrawImage(sourceImg, n.Bounds);
+                using SKBitmap sourceImg = SKBitmap.Decode(n.Texture.Source);
+                g.DrawBitmap(sourceImg, rect);
                 if (DebugMode)
                 {
                     string label = Path.GetFileNameWithoutExtension(n.Texture.Source);
-                    SizeF labelBox = g.MeasureString(label, SystemFonts.MenuFont, new SizeF(n.Bounds.Size));
-                    RectangleF rectBounds = new Rectangle(n.Bounds.Location, new Size((int)labelBox.Width, (int)labelBox.Height));
-                    g.FillRectangle(Brushes.Black, rectBounds);
-                    g.DrawString(label, SystemFonts.MenuFont, Brushes.White, rectBounds);
+                    SKRect labelBox = default;
+                    paintWhite.MeasureText(label, ref labelBox);
+                    SKRect rectBounds = SKRect.Create(n.Bounds.X, n.Bounds.Y, labelBox.Width, labelBox.Height);
+                    g.DrawRect(rectBounds, paintBlack);
+                    g.DrawText(label, rectBounds.Left, rectBounds.Top, paintWhite);
                 }
             }
             else
             {
-                g.FillRectangle(Brushes.DarkMagenta, n.Bounds);
+                g.DrawRect(rect, paintDarkMagenta);
                 if (DebugMode)
                 {
-                    string label = n.Bounds.Width.ToString() + "x" + n.Bounds.Height.ToString();
-                    SizeF labelBox = g.MeasureString(label, SystemFonts.MenuFont, new SizeF(n.Bounds.Size));
-                    RectangleF rectBounds = new Rectangle(n.Bounds.Location, new Size((int)labelBox.Width, (int)labelBox.Height));
-                    g.FillRectangle(Brushes.Black, rectBounds);
-                    g.DrawString(label, SystemFonts.MenuFont, Brushes.White, rectBounds);
+                    string label = $"{n.Bounds.Width}x{n.Bounds.Height}";
+                    SKRect labelBox = default;
+                    paintWhite.MeasureText(label, ref labelBox);
+                    SKRect rectBounds = SKRect.Create(n.Bounds.X, n.Bounds.Y, labelBox.Width, labelBox.Height);
+                    g.DrawRect(rectBounds, paintBlack);
+                    g.DrawText(label, rectBounds.Left, rectBounds.Top, paintWhite);
                 }
             }
         }
+
         return img;
     }
 }

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportFontData.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportFontData.csx
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using System.Drawing;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,7 +37,6 @@ int atlasCount = 0;
 foreach (Atlas atlas in packer.Atlasses)
 {
     string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
-    Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
     texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
@@ -85,8 +84,6 @@ foreach (Atlas atlas in packer.Atlasses)
     }
     atlasCount++;
 }
-
-
 
 HideProgressBar();
 ScriptMessage("Import Complete!");
@@ -176,10 +173,17 @@ public enum BestFitHeuristic
     Area,
     MaxOneAxis,
 }
+public struct Rect
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+}
 
 public class Node
 {
-    public Rectangle Bounds;
+    public Rect Bounds;
     public TextureInfo Texture;
     public SplitType SplitType;
 }
@@ -201,6 +205,26 @@ public class Packer
     public bool DebugMode;
     public BestFitHeuristic FitHeuristic;
     public List<Atlas> Atlasses;
+    public static readonly SKPaint paintGreen = new()
+    {
+        Color = SKColors.Green,
+        BlendMode = SKBlendMode.Src
+    };
+    public static readonly SKPaint paintBlack = new()
+    {
+        Color = SKColors.Black,
+        BlendMode = SKBlendMode.Src
+    };
+    public static readonly SKPaint paintWhite = new()
+    {
+        Color = SKColors.White,
+        BlendMode = SKBlendMode.Src
+    };
+    public static readonly SKPaint paintDarkMagenta = new()
+    {
+        Color = SKColors.DarkMagenta,
+        BlendMode = SKBlendMode.Src
+    };
 
     public Packer()
     {
@@ -256,13 +280,8 @@ public class Packer
         {
             string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
             //1: Save images
-            Image img = CreateAtlasImage(atlas);
-            //DPI fix start
-            Bitmap ResolutionFix = new Bitmap(img);
-            ResolutionFix.SetResolution(96.0F, 96.0F);
-            Image img2 = ResolutionFix;
-            //DPI fix end
-            img2.Save(atlasName, System.Drawing.Imaging.ImageFormat.Png);
+            using SKBitmap img = CreateAtlasImage(atlas);
+            TextureWorker.SaveImageToFile(atlasName, img);
             //2: save description in file
             foreach (Node n in atlas.Nodes)
             {
@@ -293,25 +312,27 @@ public class Packer
         FileInfo[] files = di.GetFiles(_Wildcard, SearchOption.AllDirectories);
         foreach (FileInfo fi in files)
         {
-            Image img = Image.FromFile(fi.FullName);
-            if (img != null)
+            var imgSize = TextureWorker.GetImageSizeFromFile(fi.FullName);
+            if (imgSize == default)
+                continue;
+            int width = imgSize.Width;
+            int height = imgSize.Height;
+
+            if (width <= AtlasSize && height <= AtlasSize)
             {
-                if (img.Width <= AtlasSize && img.Height <= AtlasSize)
-                {
-                    TextureInfo ti = new TextureInfo();
+                TextureInfo ti = new TextureInfo();
 
-                    ti.Source = fi.FullName;
-                    ti.Width = img.Width;
-                    ti.Height = img.Height;
+                ti.Source = fi.FullName;
+                ti.Width = width;
+                ti.Height = height;
 
-                    SourceTextures.Add(ti);
+                SourceTextures.Add(ti);
 
-                    Log.WriteLine("Added " + fi.FullName);
-                }
-                else
-                {
-                    Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
-                }
+                Log.WriteLine("Added " + fi.FullName);
+            }
+            else
+            {
+                Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
             }
         }
     }
@@ -404,7 +425,8 @@ public class Packer
         _Atlas.Nodes = new List<Node>();
         textures = _Textures.ToList();
         Node root = new Node();
-        root.Bounds.Size = new Size(_Atlas.Width, _Atlas.Height);
+        root.Bounds.Width = _Atlas.Width;
+        root.Bounds.Height = _Atlas.Height;
         root.SplitType = SplitType.Horizontal;
         freeList.Add(root);
         while (freeList.Count > 0 && textures.Count > 0)
@@ -432,42 +454,48 @@ public class Packer
         return textures;
     }
 
-    private Image CreateAtlasImage(Atlas _Atlas)
+    private SKBitmap CreateAtlasImage(Atlas _Atlas)
     {
-        Image img = new Bitmap(_Atlas.Width, _Atlas.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        Graphics g = Graphics.FromImage(img);
+        SKBitmap img = new(_Atlas.Width, _Atlas.Height);
+        using SKCanvas g = new(img);
         if (DebugMode)
-        {
-            g.FillRectangle(Brushes.Green, new Rectangle(0, 0, _Atlas.Width, _Atlas.Height));
-        }
+            g.DrawRect(0, 0, _Atlas.Width, _Atlas.Height, paintGreen);
+
         foreach (Node n in _Atlas.Nodes)
         {
+            SKRect rect = SKRect.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+
             if (n.Texture != null)
             {
-                Image sourceImg = Image.FromFile(n.Texture.Source);
-                g.DrawImage(sourceImg, n.Bounds);
+                using SKBitmap sourceImg = SKBitmap.Decode(n.Texture.Source);
+                g.DrawBitmap(sourceImg, rect);
                 if (DebugMode)
                 {
                     string label = Path.GetFileNameWithoutExtension(n.Texture.Source);
-                    SizeF labelBox = g.MeasureString(label, SystemFonts.MenuFont, new SizeF(n.Bounds.Size));
-                    RectangleF rectBounds = new Rectangle(n.Bounds.Location, new Size((int)labelBox.Width, (int)labelBox.Height));
-                    g.FillRectangle(Brushes.Black, rectBounds);
-                    g.DrawString(label, SystemFonts.MenuFont, Brushes.White, rectBounds);
+                    SKRect labelBox = default;
+                    paintWhite.MeasureText(label, ref labelBox);
+                    SKRect rectBounds = SKRect.Create(n.Bounds.X, n.Bounds.Y, labelBox.Width, labelBox.Height);
+                    float yOff = paintWhite.FontMetrics.Ascent - paintWhite.FontMetrics.Descent - 1; // I am not sure if it's the correct way, but it works
+                    g.DrawRect(rectBounds, paintBlack);
+                    g.DrawText(label, rectBounds.Left, rectBounds.Top - yOff, paintWhite);
                 }
             }
             else
             {
-                g.FillRectangle(Brushes.DarkMagenta, n.Bounds);
+                g.DrawRect(rect, paintDarkMagenta);
                 if (DebugMode)
                 {
-                    string label = n.Bounds.Width.ToString() + "x" + n.Bounds.Height.ToString();
-                    SizeF labelBox = g.MeasureString(label, SystemFonts.MenuFont, new SizeF(n.Bounds.Size));
-                    RectangleF rectBounds = new Rectangle(n.Bounds.Location, new Size((int)labelBox.Width, (int)labelBox.Height));
-                    g.FillRectangle(Brushes.Black, rectBounds);
-                    g.DrawString(label, SystemFonts.MenuFont, Brushes.White, rectBounds);
+                    string label = $"{n.Bounds.Width}x{n.Bounds.Height}";
+                    SKRect labelBox = default;
+                    paintWhite.MeasureText(label, ref labelBox);
+                    SKRect rectBounds = SKRect.Create(n.Bounds.X, n.Bounds.Y, labelBox.Width, labelBox.Height);
+                    float yOff = paintWhite.FontMetrics.Ascent - paintWhite.FontMetrics.Descent - 1;
+                    g.DrawRect(rectBounds, paintBlack);
+                    g.DrawText(label, rectBounds.Left, rectBounds.Top - yOff, paintWhite);
                 }
             }
         }
+
         return img;
     }
 }

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using SkiaSharp;
+using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,7 +43,7 @@ int atlasCount = 0;
 foreach (Atlas atlas in packer.Atlasses)
 {
     string atlasName = Path.Combine(packDir, String.Format(prefix + "{0:000}" + ".png", atlasCount));
-    SKBitmap atlasBitmap = SKBitmap.Decode(atlasName);
+    Bitmap atlasBitmap = new Bitmap(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
     texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
@@ -148,23 +148,19 @@ foreach (Atlas atlas in packer.Atlasses)
                             newSprite.Textures.Add(null);
                     }
                     newSprite.CollisionMasks.Add(newSprite.NewMaskEntry());
-
-                    SKBitmap cloneBitmap = new();
-                    var bmpRect = SKRectI.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
-                    atlasBitmap.ExtractSubset(cloneBitmap, bmpRect);
-                    cloneBitmap = cloneBitmap.Copy();
-
+                    Rectangle bmpRect = new Rectangle(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+                    System.Drawing.Imaging.PixelFormat format = atlasBitmap.PixelFormat;
+                    Bitmap cloneBitmap = atlasBitmap.Clone(bmpRect, format);
                     int width = ((n.Bounds.Width + 7) / 8) * 8;
                     BitArray maskingBitArray = new BitArray(width * n.Bounds.Height);
                     for (int y = 0; y < n.Bounds.Height; y++)
                     {
                         for (int x = 0; x < n.Bounds.Width; x++)
                         {
-                            SKColor pixelColor = cloneBitmap.GetPixel(x, y);
-                            maskingBitArray[y * width + x] = (pixelColor.Alpha > 0);
+                            Color pixelColor = cloneBitmap.GetPixel(x, y);
+                            maskingBitArray[y * width + x] = (pixelColor.A > 0);
                         }
                     }
-                    cloneBitmap.Dispose();
                     BitArray tempBitArray = new BitArray(width * n.Bounds.Height);
                     for (int i = 0; i < maskingBitArray.Length; i += 8)
                     {
@@ -238,16 +234,9 @@ public enum BestFitHeuristic
     MaxOneAxis,
 }
 
-public struct Rect
-{
-    public int X { get; set; }
-    public int Y { get; set; }
-    public int Width { get; set; }
-    public int Height { get; set; }
-}
 public class Node
 {
-    public Rect Bounds;
+    public Rectangle Bounds;
     public TextureInfo Texture;
     public SplitType SplitType;
 }
@@ -324,10 +313,8 @@ public class Packer
         {
             string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
             //1: Save images
-            using SKBitmap img = CreateAtlasImage(atlas);
-            using FileStream fs = new(atlasName, FileMode.Create, FileAccess.Write);
-            img.Encode(fs, SKEncodedImageFormat.Png, 100);
-            fs.Close();
+            Image img = CreateAtlasImage(atlas);
+            img.Save(atlasName, System.Drawing.Imaging.ImageFormat.Png);
             //2: save description in file
             foreach (Node n in atlas.Nodes)
             {
@@ -358,27 +345,25 @@ public class Packer
         FileInfo[] files = di.GetFiles(_Wildcard, SearchOption.AllDirectories);
         foreach (FileInfo fi in files)
         {
-            var imgSize = TextureWorker.GetImageSizeFromFile(fi.FullName);
-            if (imgSize == default)
-                continue;
-            int width = imgSize.Width;
-            int height = imgSize.Height;
-
-            if (width <= AtlasSize && height <= AtlasSize)
+            Image img = Image.FromFile(fi.FullName);
+            if (img != null)
             {
-                TextureInfo ti = new TextureInfo();
+                if (img.Width <= AtlasSize && img.Height <= AtlasSize)
+                {
+                    TextureInfo ti = new TextureInfo();
 
-                ti.Source = fi.FullName;
-                ti.Width = width;
-                ti.Height = height;
+                    ti.Source = fi.FullName;
+                    ti.Width = img.Width;
+                    ti.Height = img.Height;
 
-                SourceTextures.Add(ti);
+                    SourceTextures.Add(ti);
 
-                Log.WriteLine("Added " + fi.FullName);
-            }
-            else
-            {
-                Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
+                    Log.WriteLine("Added " + fi.FullName);
+                }
+                else
+                {
+                    Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
+                }
             }
         }
     }
@@ -471,8 +456,7 @@ public class Packer
         _Atlas.Nodes = new List<Node>();
         textures = _Textures.ToList();
         Node root = new Node();
-        root.Bounds.Width = _Atlas.Width;
-        root.Bounds.Height = _Atlas.Height;
+        root.Bounds.Size = new Size(_Atlas.Width, _Atlas.Height);
         root.SplitType = SplitType.Horizontal;
         freeList.Add(root);
         while (freeList.Count > 0 && textures.Count > 0)
@@ -500,21 +484,24 @@ public class Packer
         return textures;
     }
 
-    private SKBitmap CreateAtlasImage(Atlas _Atlas)
+    private Image CreateAtlasImage(Atlas _Atlas)
     {
-        SKBitmap img = new(_Atlas.Width, _Atlas.Height);
-        using SKCanvas g = new(img);
+        Image img = new Bitmap(_Atlas.Width, _Atlas.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        Graphics g = Graphics.FromImage(img);
         foreach (Node n in _Atlas.Nodes)
         {
             if (n.Texture != null)
             {
-                using SKBitmap sourceImg = SKBitmap.Decode(n.Texture.Source);
-                SKRect rect = SKRect.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
-                g.DrawBitmap(sourceImg, rect);
+                Image sourceImg = Image.FromFile(n.Texture.Source);
+                g.DrawImage(sourceImg, n.Bounds);
             }
         }
-
-        return img;
+        // DPI FIX START
+        Bitmap ResolutionFix = new Bitmap(img);
+        ResolutionFix.SetResolution(96.0F, 96.0F);
+        Image img2 = ResolutionFix;
+        return img2;
+        // DPI FIX END
     }
 }
 

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using System.Drawing;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,7 +43,7 @@ int atlasCount = 0;
 foreach (Atlas atlas in packer.Atlasses)
 {
     string atlasName = Path.Combine(packDir, String.Format(prefix + "{0:000}" + ".png", atlasCount));
-    Bitmap atlasBitmap = new Bitmap(atlasName);
+    SKBitmap atlasBitmap = SKBitmap.Decode(atlasName);
     UndertaleEmbeddedTexture texture = new UndertaleEmbeddedTexture();
     texture.Name = new UndertaleString("Texture " + ++lastTextPage);
     texture.TextureData.TextureBlob = File.ReadAllBytes(atlasName);
@@ -148,19 +148,23 @@ foreach (Atlas atlas in packer.Atlasses)
                             newSprite.Textures.Add(null);
                     }
                     newSprite.CollisionMasks.Add(newSprite.NewMaskEntry());
-                    Rectangle bmpRect = new Rectangle(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
-                    System.Drawing.Imaging.PixelFormat format = atlasBitmap.PixelFormat;
-                    Bitmap cloneBitmap = atlasBitmap.Clone(bmpRect, format);
+
+                    SKBitmap cloneBitmap = new();
+                    var bmpRect = SKRectI.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+                    atlasBitmap.ExtractSubset(cloneBitmap, bmpRect);
+                    cloneBitmap = cloneBitmap.Copy();
+
                     int width = ((n.Bounds.Width + 7) / 8) * 8;
                     BitArray maskingBitArray = new BitArray(width * n.Bounds.Height);
                     for (int y = 0; y < n.Bounds.Height; y++)
                     {
                         for (int x = 0; x < n.Bounds.Width; x++)
                         {
-                            Color pixelColor = cloneBitmap.GetPixel(x, y);
-                            maskingBitArray[y * width + x] = (pixelColor.A > 0);
+                            SKColor pixelColor = cloneBitmap.GetPixel(x, y);
+                            maskingBitArray[y * width + x] = (pixelColor.Alpha > 0);
                         }
                     }
+                    cloneBitmap.Dispose();
                     BitArray tempBitArray = new BitArray(width * n.Bounds.Height);
                     for (int i = 0; i < maskingBitArray.Length; i += 8)
                     {
@@ -234,9 +238,16 @@ public enum BestFitHeuristic
     MaxOneAxis,
 }
 
+public struct Rect
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+}
 public class Node
 {
-    public Rectangle Bounds;
+    public Rect Bounds;
     public TextureInfo Texture;
     public SplitType SplitType;
 }
@@ -313,8 +324,10 @@ public class Packer
         {
             string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
             //1: Save images
-            Image img = CreateAtlasImage(atlas);
-            img.Save(atlasName, System.Drawing.Imaging.ImageFormat.Png);
+            using SKBitmap img = CreateAtlasImage(atlas);
+            using FileStream fs = new(atlasName, FileMode.Create, FileAccess.Write);
+            img.Encode(fs, SKEncodedImageFormat.Png, 100);
+            fs.Close();
             //2: save description in file
             foreach (Node n in atlas.Nodes)
             {
@@ -345,25 +358,27 @@ public class Packer
         FileInfo[] files = di.GetFiles(_Wildcard, SearchOption.AllDirectories);
         foreach (FileInfo fi in files)
         {
-            Image img = Image.FromFile(fi.FullName);
-            if (img != null)
+            var imgSize = TextureWorker.GetImageSizeFromFile(fi.FullName);
+            if (imgSize == default)
+                continue;
+            int width = imgSize.Width;
+            int height = imgSize.Height;
+
+            if (width <= AtlasSize && height <= AtlasSize)
             {
-                if (img.Width <= AtlasSize && img.Height <= AtlasSize)
-                {
-                    TextureInfo ti = new TextureInfo();
+                TextureInfo ti = new TextureInfo();
 
-                    ti.Source = fi.FullName;
-                    ti.Width = img.Width;
-                    ti.Height = img.Height;
+                ti.Source = fi.FullName;
+                ti.Width = width;
+                ti.Height = height;
 
-                    SourceTextures.Add(ti);
+                SourceTextures.Add(ti);
 
-                    Log.WriteLine("Added " + fi.FullName);
-                }
-                else
-                {
-                    Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
-                }
+                Log.WriteLine("Added " + fi.FullName);
+            }
+            else
+            {
+                Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
             }
         }
     }
@@ -456,7 +471,8 @@ public class Packer
         _Atlas.Nodes = new List<Node>();
         textures = _Textures.ToList();
         Node root = new Node();
-        root.Bounds.Size = new Size(_Atlas.Width, _Atlas.Height);
+        root.Bounds.Width = _Atlas.Width;
+        root.Bounds.Height = _Atlas.Height;
         root.SplitType = SplitType.Horizontal;
         freeList.Add(root);
         while (freeList.Count > 0 && textures.Count > 0)
@@ -484,24 +500,21 @@ public class Packer
         return textures;
     }
 
-    private Image CreateAtlasImage(Atlas _Atlas)
+    private SKBitmap CreateAtlasImage(Atlas _Atlas)
     {
-        Image img = new Bitmap(_Atlas.Width, _Atlas.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        Graphics g = Graphics.FromImage(img);
+        SKBitmap img = new(_Atlas.Width, _Atlas.Height);
+        using SKCanvas g = new(img);
         foreach (Node n in _Atlas.Nodes)
         {
             if (n.Texture != null)
             {
-                Image sourceImg = Image.FromFile(n.Texture.Source);
-                g.DrawImage(sourceImg, n.Bounds);
+                using SKBitmap sourceImg = SKBitmap.Decode(n.Texture.Source);
+                SKRect rect = SKRect.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+                g.DrawBitmap(sourceImg, rect);
             }
         }
-        // DPI FIX START
-        Bitmap ResolutionFix = new Bitmap(img);
-        ResolutionFix.SetResolution(96.0F, 96.0F);
-        Image img2 = ResolutionFix;
-        return img2;
-        // DPI FIX END
+
+        return img;
     }
 }
 

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,15 +37,13 @@ foreach (string file in dirFiles)
     {
         throw new ScriptException("Getting the sprite name of " + FileNameWithExtension + " failed.");
     }
-    if (Data.Sprites.ByName(spriteName) == null) // Reject non-existing sprites
-    {
-        throw new ScriptException(FileNameWithExtension + " could not be imported as the sprite " + spriteName + " does not exist.");
-    }
-    using (Image img = Image.FromFile(file))
-    {
-        if ((Data.Sprites.ByName(spriteName).Width != (uint)img.Width) || (Data.Sprites.ByName(spriteName).Height != (uint)img.Height))
-            throw new ScriptException(FileNameWithExtension + " is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: " + Data.Sprites.ByName(spriteName).Width.ToString() + " px, height: " + Data.Sprites.ByName(spriteName).Height.ToString() + " px.");
-    }
+    var sprite = Data.Sprites.ByName(spriteName);
+    if (sprite is null) // Reject non-existing sprites
+        throw new ScriptException($"{FileNameWithExtension} could not be imported as the sprite {spriteName} does not exist.");
+
+    var imgSize = TextureWorker.GetImageSizeFromFile(file);
+    if ((sprite.Width != (uint)imgSize.Width) || (sprite.Height != (uint)imgSize.Height))
+        throw new ScriptException($"{FileNameWithExtension} is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: {sprite.Width} px, height: {sprite.Height} px.");
 
     Int32 validFrameNumber = 0;
     try

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,13 +38,15 @@ foreach (string file in dirFiles)
     {
         throw new ScriptException("Getting the sprite name of " + FileNameWithExtension + " failed.");
     }
-    var sprite = Data.Sprites.ByName(spriteName);
-    if (sprite is null) // Reject non-existing sprites
+    if (Data.Sprites.ByName(spriteName) == null) // Reject non-existing sprites
+    {
         throw new ScriptException(FileNameWithExtension + " could not be imported as the sprite " + spriteName + " does not exist.");
-
-    var imgSize = TextureWorker.GetImageSizeFromFile(file);
-    if ((sprite.Width != (uint)imgSize.Width) || (sprite.Height != (uint)imgSize.Height))
-        throw new ScriptException(FileNameWithExtension + " is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: " + sprite.Width.ToString() + " px, height: " + sprite.Height.ToString() + " px.");
+    }
+    using (Image img = Image.FromFile(file))
+    {
+        if ((Data.Sprites.ByName(spriteName).Width != (uint)img.Width) || (Data.Sprites.ByName(spriteName).Height != (uint)img.Height))
+            throw new ScriptException(FileNameWithExtension + " is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: " + Data.Sprites.ByName(spriteName).Width.ToString() + " px, height: " + Data.Sprites.ByName(spriteName).Height.ToString() + " px.");
+    }
 
     Int32 validFrameNumber = 0;
     try

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,15 +37,13 @@ foreach (string file in dirFiles)
     {
         throw new ScriptException("Getting the sprite name of " + FileNameWithExtension + " failed.");
     }
-    if (Data.Sprites.ByName(spriteName) == null) // Reject non-existing sprites
-    {
+    var sprite = Data.Sprites.ByName(spriteName);
+    if (sprite is null) // Reject non-existing sprites
         throw new ScriptException(FileNameWithExtension + " could not be imported as the sprite " + spriteName + " does not exist.");
-    }
-    using (Image img = Image.FromFile(file))
-    {
-        if ((Data.Sprites.ByName(spriteName).Width != (uint)img.Width) || (Data.Sprites.ByName(spriteName).Height != (uint)img.Height))
-            throw new ScriptException(FileNameWithExtension + " is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: " + Data.Sprites.ByName(spriteName).Width.ToString() + " px, height: " + Data.Sprites.ByName(spriteName).Height.ToString() + " px.");
-    }
+
+    var imgSize = TextureWorker.GetImageSizeFromFile(file);
+    if ((sprite.Width != (uint)imgSize.Width) || (sprite.Height != (uint)imgSize.Height))
+        throw new ScriptException(FileNameWithExtension + " is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: " + sprite.Width.ToString() + " px, height: " + sprite.Height.ToString() + " px.");
 
     Int32 validFrameNumber = 0;
     try

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportAllTextures.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportAllTextures.csx
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportAllTexturesGrouped.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportAllTexturesGrouped.csx
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportFontData.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportFontData.csx
@@ -1,4 +1,5 @@
 // Made by mono21400
+// TODO: this heavily uses windows stuff, should be made cross platform
 
 using System.Text;
 using System;

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportTextureGroups.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportTextureGroups.csx
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/UndertaleModTool/Scripts/Resource Unpackers/MergeImages.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/MergeImages.csx
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Drawing.Drawing2D;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,19 +8,16 @@ using System.Text;
 using UndertaleModLib.Util;
 
 string importFolderA = PromptChooseDirectory();
-if (importFolderA == null) {
+if (importFolderA is null)
     throw new ScriptException("The import folder was not set.");
-}
 
 string importFolderB = PromptChooseDirectory();
-if (importFolderB == null) {
+if (importFolderB is null)
     throw new ScriptException("The import folder was not set.");
-}
 
 string exportFolder = PromptChooseDirectory();
-if (exportFolder == null) {
+if (exportFolder is null)
     throw new ScriptException("The export folder was not set.");
-}
 
 string searchPattern = "*.png";
 
@@ -30,31 +25,25 @@ DirectoryInfo textureDirectoryA = new DirectoryInfo(importFolderA);
 DirectoryInfo textureDirectoryB = new DirectoryInfo(importFolderB);
 FileInfo[] filesA = textureDirectoryA.GetFiles(searchPattern, SearchOption.AllDirectories);
 
-foreach (FileInfo fileA in filesA) {
+foreach (FileInfo fileA in filesA)
+{
     FileInfo[] fileMatch = textureDirectoryB.GetFiles(fileA.Name);
-    if (fileMatch == null) {
+    if (fileMatch is null)
         continue;
-    }
     FileInfo fileB = fileMatch[0];
-    Bitmap bitmapA = new Bitmap(System.IO.Path.Combine(importFolderA, fileA.Name));
-    Bitmap bitmapB = new Bitmap(System.IO.Path.Combine(importFolderB, fileA.Name));
-    int width = bitmapA.Size.Width + bitmapB.Size.Width;
-    int height = bitmapA.Size.Width;
-    if (bitmapB.Size.Width > height) {
-        height = bitmapB.Size.Width;
+    using SKBitmap bitmapA = SKBitmap.Decode(Path.Combine(importFolderA, fileA.Name));
+    using SKBitmap bitmapB = SKBitmap.Decode(Path.Combine(importFolderB, fileA.Name));
+    int width = bitmapA.Width + bitmapB.Width;
+    int height = bitmapA.Height;
+    if (bitmapB.Width > height)
+        height = bitmapB.Width;
+
+    using SKBitmap outputBitmap = new(width, height);
+    using (SKCanvas g = new(outputBitmap))
+    {
+        g.DrawBitmap(bitmapA, 0, 0);
+        g.DrawBitmap(bitmapB, bitmapA.Width, 0);
     }
 
-    Bitmap outputBitmap = new Bitmap(width, height);
-
-    outputBitmap = SuperimposeOntoBitmap(bitmapA, outputBitmap, 0);
-    outputBitmap = SuperimposeOntoBitmap(bitmapB, outputBitmap, bitmapA.Size.Width);
-
-    outputBitmap.Save(System.IO.Path.Combine(exportFolder, fileA.Name), ImageFormat.Png);
-}
-
-Bitmap SuperimposeOntoBitmap(Bitmap bitmapToAdd, Bitmap baseBitmap, int x) {
-    Graphics g = Graphics.FromImage(baseBitmap);
-    g.CompositingMode = CompositingMode.SourceOver;
-    g.DrawImage(bitmapToAdd, new System.Drawing.Point(x, 0));
-    return baseBitmap;
+    TextureWorker.SaveImageToFile(Path.Combine(exportFolder, fileA.Name), outputBitmap);
 }

--- a/UndertaleModTool/Scripts/Technical Scripts/ImportGraphics_Full_Repack.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/ImportGraphics_Full_Repack.csx
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using System.Drawing;
+using SkiaSharp;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -338,19 +338,23 @@ foreach (Atlas atlas in packer.Atlasses)
                             newSprite.Textures.Add(null);
                     }
                     newSprite.CollisionMasks.Add(newSprite.NewMaskEntry());
-                    Rectangle bmpRect = new Rectangle(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
-                    System.Drawing.Imaging.PixelFormat format = atlasBitmap.PixelFormat;
-                    Bitmap cloneBitmap = atlasBitmap.Clone(bmpRect, format);
+
+                    SKBitmap cloneBitmap = new();
+                    var bmpRect = SKRectI.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+                    atlasBitmap.ExtractSubset(cloneBitmap, bmpRect);
+                    cloneBitmap = cloneBitmap.Copy();
+                    
                     int width = ((n.Bounds.Width + 7) / 8) * 8;
                     BitArray maskingBitArray = new BitArray(width * n.Bounds.Height);
                     for (int y = 0; y < n.Bounds.Height; y++)
                     {
                         for (int x = 0; x < n.Bounds.Width; x++)
                         {
-                            Color pixelColor = cloneBitmap.GetPixel(x, y);
-                            maskingBitArray[y * width + x] = (pixelColor.A > 0);
+                            SKColor pixelColor = cloneBitmap.GetPixel(x, y);
+                            maskingBitArray[y * width + x] = (pixelColor.Alpha > 0);
                         }
                     }
+                    cloneBitmap.Dispose();
                     BitArray tempBitArray = new BitArray(width * n.Bounds.Height);
                     for (int i = 0; i < maskingBitArray.Length; i += 8)
                     {
@@ -428,9 +432,17 @@ public enum BestFitHeuristic
     MaxOneAxis,
 }
 
+public struct Rect
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+}
+
 public class Node
 {
-    public Rectangle Bounds;
+    public Rect Bounds;
     public TextureInfo Texture;
     public SplitType SplitType;
 }
@@ -507,8 +519,8 @@ public class Packer
         {
             string atlasName = String.Format(prefix + "{0:000}" + ".png", atlasCount);
             //1: Save images
-            Image img = CreateAtlasImage(atlas);
-            img.Save(atlasName, System.Drawing.Imaging.ImageFormat.Png);
+            using SKBitmap img = CreateAtlasImage(atlas);
+            TextureWorker.SaveImageToFile(atlasName, img);
             //2: save description in file
             foreach (Node n in atlas.Nodes)
             {
@@ -539,25 +551,27 @@ public class Packer
         FileInfo[] files = di.GetFiles(_Wildcard, SearchOption.AllDirectories);
         foreach (FileInfo fi in files)
         {
-            Image img = Image.FromFile(fi.FullName);
-            if (img != null)
+            var imgSize = TextureWorker.GetImageSizeFromFile(fi.FullName);
+            if (imgSize == default)
+                continue;
+            int width = imgSize.Width;
+            int height = imgSize.Height;
+
+            if (width <= AtlasSize && height <= AtlasSize)
             {
-                if (img.Width <= AtlasSize && img.Height <= AtlasSize)
-                {
-                    TextureInfo ti = new TextureInfo();
+                TextureInfo ti = new TextureInfo();
 
-                    ti.Source = fi.FullName;
-                    ti.Width = img.Width;
-                    ti.Height = img.Height;
+                ti.Source = fi.FullName;
+                ti.Width = width;
+                ti.Height = height;
 
-                    SourceTextures.Add(ti);
+                SourceTextures.Add(ti);
 
-                    Log.WriteLine("Added " + fi.FullName);
-                }
-                else
-                {
-                    Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
-                }
+                Log.WriteLine("Added " + fi.FullName);
+            }
+            else
+            {
+                Error.WriteLine(fi.FullName + " is too large to fix in the atlas. Skipping!");
             }
         }
     }
@@ -650,7 +664,8 @@ public class Packer
         _Atlas.Nodes = new List<Node>();
         textures = _Textures.ToList();
         Node root = new Node();
-        root.Bounds.Size = new Size(_Atlas.Width, _Atlas.Height);
+        root.Bounds.Width = _Atlas.Width;
+        root.Bounds.Height = _Atlas.Height;
         root.SplitType = SplitType.Horizontal;
         freeList.Add(root);
         while (freeList.Count > 0 && textures.Count > 0)
@@ -678,23 +693,20 @@ public class Packer
         return textures;
     }
 
-    private Image CreateAtlasImage(Atlas _Atlas)
+    private SKBitmap CreateAtlasImage(Atlas _Atlas)
     {
-        Image img = new Bitmap(_Atlas.Width, _Atlas.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        Graphics g = Graphics.FromImage(img);
+        SKBitmap img = new(_Atlas.Width, _Atlas.Height);
+        using SKCanvas g = new(img);
         foreach (Node n in _Atlas.Nodes)
         {
             if (n.Texture != null)
             {
-                Image sourceImg = Image.FromFile(n.Texture.Source);
-                g.DrawImage(sourceImg, n.Bounds);
+                using SKBitmap sourceImg = SKBitmap.Decode(n.Texture.Source);
+                SKRect rect = SKRect.Create(n.Bounds.X, n.Bounds.Y, n.Bounds.Width, n.Bounds.Height);
+                g.DrawBitmap(sourceImg, rect);
             }
         }
-        // DPI FIX START
-        Bitmap ResolutionFix = new Bitmap(img);
-        ResolutionFix.SetResolution(96.0F, 96.0F);
-        Image img2 = ResolutionFix;
-        return img2;
-        // DPI FIX END
+
+        return img;
     }
 }


### PR DESCRIPTION
## Description
This PR attempts to refactor from System.Drawing.Common to Skiasharp. Doing this successfully means, that we'll be finally able to bump the .NET version for the project and not make the project Windows only by doing so.
Fixes #875 

### Caveats
This is not finished yet

### Notes
TODO: 
- [x] Opening this, because I need help with the GUI part (CC @VladiStep ), as I'm unable to do meaningful changes there due to me using Linux.
- [ ] Someone should test this with QOI games (I don't have any on me).
- [x] Ensure that basic graphic functionality didn't get lost (i.e. viewing embedded texture pages, texture page entries, rooms etc.) once the GUI part has been refactored 
- [x] Make sure that all the graphic related scripts (importAllTilesets, importAllSprites, newTextureRepacker etc.) still work as they should
- [ ] Check if these behave properly on different display scales