### PR TITLE
Export sprites into subfolders for each sprite

### DIFF
--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportAllSprites.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportAllSprites.csx
@@ -10,7 +10,7 @@ EnsureDataLoaded();
 
 bool padded = (!ScriptQuestion("Export all sprites unpadded?"));
 
-bool useSubDirectories = ScriptQuestion("Export sprites into subdirectories?")
+bool useSubDirectories = ScriptQuestion("Export sprites into subdirectories?");
 
 string texFolder = GetFolder(FilePath) + "Export_Sprites" + Path.DirectorySeparatorChar;
 TextureWorker worker = new TextureWorker();
@@ -46,8 +46,8 @@ async Task DumpSprites()
 void DumpSprite(UndertaleSprite sprite)
 {
     string outputFolder = texFolder;
-    if (useSubDirectoriesPath)
-        Path.Combine(outputFolder, sprite.Name.Content);
+    if (useSubDirectories)
+        outputFolder = Path.Combine(outputFolder, sprite.Name.Content);
     if (sprite.Textures.Count > 0)
         Directory.CreateDirectory(outputFolder);
         

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportAllSprites.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportAllSprites.csx
@@ -43,9 +43,15 @@ async Task DumpSprites()
 
 void DumpSprite(UndertaleSprite sprite)
 {
+    string outputFolder = Path.Combine(texFolder, sprite.Name.Content);
+    if (sprite.Textures.Count > 0)
+        Directory.CreateDirectory(outputFolder);
+        
     for (int i = 0; i < sprite.Textures.Count; i++)
+    {
         if (sprite.Textures[i]?.Texture != null)
-            worker.ExportAsPNG(sprite.Textures[i].Texture, texFolder + sprite.Name.Content + "_" + i + ".png", null, padded); // Include padding to make sprites look neat!
+            worker.ExportAsPNG(sprite.Textures[i].Texture, Path.Combine(outputFolder, sprite.Name.Content + "_" + i + ".png"), null, padded); // Include padding to make sprites look neat!
+    }
 
     IncrementProgressParallel();
 }

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportAllSprites.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportAllSprites.csx
@@ -10,6 +10,8 @@ EnsureDataLoaded();
 
 bool padded = (!ScriptQuestion("Export all sprites unpadded?"));
 
+bool useSubDirectories = ScriptQuestion("Export sprites into subdirectories?")
+
 string texFolder = GetFolder(FilePath) + "Export_Sprites" + Path.DirectorySeparatorChar;
 TextureWorker worker = new TextureWorker();
 if (Directory.Exists(texFolder))
@@ -43,7 +45,9 @@ async Task DumpSprites()
 
 void DumpSprite(UndertaleSprite sprite)
 {
-    string outputFolder = Path.Combine(texFolder, sprite.Name.Content);
+    string outputFolder = texFolder;
+    if (useSubDirectoriesPath)
+        Path.Combine(outputFolder, sprite.Name.Content);
     if (sprite.Textures.Count > 0)
         Directory.CreateDirectory(outputFolder);
         


### PR DESCRIPTION
## Description
Modifies the ExportAllSprites script, so that every sprite that has frames, gets its own subfolder.

### Caveats
If you're using the export sprites script not for mass-modification, but instead to visually look at every sprite in the game, then this will make it slightly more cumbersome

### Notes
Obsoletes #1380 