### PR TITLE
Move most of .dll files into "Libraries" subdirectory ("NetCoreBeauty")

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -40,6 +40,11 @@ jobs:
       run: |
         cp ./README.md ./CLI-${{ matrix.os }}/
         cp ./LICENSE.txt ./CLI-${{ matrix.os }}/
+    - name: Remove residual files from NetCoreBeauty 
+      continue-on-error: true
+      run: |
+        rm -f ./CLI-${{ matrix.os }}/NetCoreBeauty
+        rm -f ./CLI-${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} CLI
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -43,8 +43,8 @@ jobs:
     - name: Remove residual files from NetCoreBeauty 
       continue-on-error: true
       run: |
-        rm -f ./CLI-${{ matrix.os }}/NetCoreBeauty
-        rm -f ./CLI-${{ matrix.os }}/hostfxr.dll.bak
+        rm -Force ./CLI-${{ matrix.os }}/NetCoreBeauty
+        rm -Force ./CLI-${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} CLI
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_gui.yml
+++ b/.github/workflows/publish_gui.yml
@@ -42,8 +42,8 @@ jobs:
     - name: Remove residual files from NetCoreBeauty 
       continue-on-error: true
       run: |
-        rm -f ./${{ matrix.os }}/NetCoreBeauty
-        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
+        rm -Force ./${{ matrix.os }}/NetCoreBeauty
+        rm -Force ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} GUI
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_gui.yml
+++ b/.github/workflows/publish_gui.yml
@@ -39,6 +39,11 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
+    - name: Remove residual files from NetCoreBeauty 
+      continue-on-error: true
+      run: |
+        rm -f ./${{ matrix.os }}/NetCoreBeauty
+        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} GUI
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_gui_32bit.yml
+++ b/.github/workflows/publish_gui_32bit.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Remove residual files from NetCoreBeauty 
       continue-on-error: true
       run: |
-        rm -f ./${{ matrix.os }}/NetCoreBeauty
-        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
+        rm -Force ./${{ matrix.os }}/NetCoreBeauty
+        rm -Force ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} GUI 32Bit
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_gui_32bit.yml
+++ b/.github/workflows/publish_gui_32bit.yml
@@ -43,6 +43,11 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
+    - name: Remove residual files from NetCoreBeauty 
+      continue-on-error: true
+      run: |
+        rm -f ./${{ matrix.os }}/NetCoreBeauty
+        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} GUI 32Bit
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Remove residual files from NetCoreBeauty 
       continue-on-error: true
       run: |
-        rm -f ./${{ matrix.os }}/NetCoreBeauty
-        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
+        rm -Force ./${{ matrix.os }}/NetCoreBeauty
+        rm -Force ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Create zip for nightly release Windows GUI
       run: |
         7z a -tzip GUI-${{ matrix.os }}-${{ matrix.configuration }}-isBundled-${{ matrix.bundled }}-isSingleFile-${{ matrix.singlefile }}.zip ./${{ matrix.os }}/* -mx0 

--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -43,6 +43,11 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
+    - name: Remove residual files from NetCoreBeauty 
+      continue-on-error: true
+      run: |
+        rm -f ./${{ matrix.os }}/NetCoreBeauty
+        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Create zip for nightly release Windows GUI
       run: |
         7z a -tzip GUI-${{ matrix.os }}-${{ matrix.configuration }}-isBundled-${{ matrix.bundled }}-isSingleFile-${{ matrix.singlefile }}.zip ./${{ matrix.os }}/* -mx0 

--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -41,6 +41,11 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
+    - name: Remove residual files from NetCoreBeauty 
+      continue-on-error: true
+      run: |
+        rm -f ./${{ matrix.os }}/NetCoreBeauty
+        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} GUI
       uses: actions/upload-artifact@v4
       with:
@@ -81,6 +86,11 @@ jobs:
       run: |
         cp ./README.md ./CLI-${{ matrix.os }}/
         cp ./LICENSE.txt ./CLI-${{ matrix.os }}/
+    - name: Remove residual files from NetCoreBeauty 
+      continue-on-error: true
+      run: |
+        rm -f ./CLI-${{ matrix.os }}/NetCoreBeauty
+        rm -f ./CLI-${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} CLI
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Remove residual files from NetCoreBeauty 
       continue-on-error: true
       run: |
-        rm -f ./${{ matrix.os }}/NetCoreBeauty
-        rm -f ./${{ matrix.os }}/hostfxr.dll.bak
+        rm -Force ./${{ matrix.os }}/NetCoreBeauty
+        rm -Force ./${{ matrix.os }}/hostfxr.dll.bak
     - name: Upload ${{ matrix.os }} GUI
       uses: actions/upload-artifact@v4
       with:

--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -16,9 +16,21 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+    <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.9.5" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
+    <BeautyLibsDir Condition="$(BeautySharedRuntimeMode) == 'True'">../Libraries</BeautyLibsDir>
+    <BeautyLibsDir Condition="$(BeautySharedRuntimeMode) != 'True'">./Libraries</BeautyLibsDir>
+    <DisableBeauty>False</DisableBeauty>
+    <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
+    <BeautyEnableDebugging>True</BeautyEnableDebugging>
+    <BeautyUsePatch>True</BeautyUsePatch>
+    <BeautyLogLevel>Info</BeautyLogLevel>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\UndertaleModLib\UndertaleModLib.csproj" />

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -29,10 +29,21 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.9.5" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.3.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
   </ItemGroup>
+  <PropertyGroup>
+    <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
+    <BeautyLibsDir Condition="$(BeautySharedRuntimeMode) == 'True'">../Libraries</BeautyLibsDir>
+    <BeautyLibsDir Condition="$(BeautySharedRuntimeMode) != 'True'">./Libraries</BeautyLibsDir>
+    <DisableBeauty>False</DisableBeauty>
+    <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
+    <BeautyEnableDebugging>True</BeautyEnableDebugging>
+    <BeautyUsePatch>True</BeautyUsePatch>
+    <BeautyLogLevel>Info</BeautyLogLevel>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="version.txt" />
   </ItemGroup>

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -11,7 +11,7 @@
         <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
         <LangVersion>10</LangVersion>
         <ApplicationIcon>icon.ico</ApplicationIcon>
-        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <GenerateDocumentationFile>False</GenerateDocumentationFile>
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
         <StartupObject>UndertaleModTool.Program</StartupObject>
         <NeutralLanguage>en</NeutralLanguage>
@@ -85,6 +85,7 @@
         <PackageReference Include="Newtonsoft.Json">
             <Version>13.0.2</Version>
         </PackageReference>
+        <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.9.5" />
         <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
         <PackageReference Include="PropertyChanged.Fody" Version="3.3.3" />
         <PackageReference Include="System.AppContext">
@@ -128,6 +129,16 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
     </ItemGroup>
+    <PropertyGroup>
+        <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
+        <BeautyLibsDir Condition="$(BeautySharedRuntimeMode) == 'True'">../Libraries</BeautyLibsDir>
+        <BeautyLibsDir Condition="$(BeautySharedRuntimeMode) != 'True'">./Libraries</BeautyLibsDir>
+        <DisableBeauty>False</DisableBeauty>
+        <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
+        <BeautyEnableDebugging>True</BeautyEnableDebugging>
+        <BeautyUsePatch>True</BeautyUsePatch>
+        <BeautyLogLevel>Info</BeautyLogLevel>
+    </PropertyGroup>
     <Target Name="AfterResolveReferences">
         <ItemGroup>
             <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'">


### PR DESCRIPTION
## Description
1) Removed the "UndertaleModTool.xml" file from output directory.
2) Moved most of .dll files into "Libraries" subdirectory using the ["NetCoreBeauty"](https://github.com/nulastudio/NetBeauty2/tree/v1) library.
![image](https://github.com/krzys-h/UndertaleModTool/assets/45438625/1739a377-c80a-4a74-99c0-a61d0f014787)


If everything will be good, then we even can get rid of the single file version.

### Caveats
I didn't test the workflow actions changes.