### PR TITLE
Fix sprite_0_0 not importing as frame 1 of sprite_0

### DIFF
--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
@@ -14,6 +14,7 @@ EnsureDataLoaded();
 
 bool importAsSprite = false;
 
+// TODO: see if this can be reimplemented using substring instead of regex?
 // "(.+?)" - match everything; "?" = match as few characters as possible.
 // "(?:_(\d+))" - an underscore followed by digits;
 // "?:" = don't make a separate group for the whole part, "?" = make this part optional.

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
@@ -15,9 +15,9 @@ EnsureDataLoaded();
 bool importAsSprite = false;
 
 // "(.+?)" - match everything; "?" = match as few characters as possible.
-// "(?:_(-*\d+))*" - an underscore + (optional minus + several digits);
-// "?:" = don't make a separate group for the whole part, "*" = make this part optional.
-Regex sprFrameRegex = new(@"^(.+?)(?:_(-*\d+))*$", RegexOptions.Compiled);
+// "(?:_(\d+))" - an underscore followed by digits;
+// "?:" = don't make a separate group for the whole part, "?" = make this part optional.
+Regex sprFrameRegex = new(@"^(.+?)(?:_(\d+))$", RegexOptions.Compiled);
 string importFolder = CheckValidity();
 
 string packDir = Path.Combine(ExePath, "Packager");

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
@@ -17,7 +17,7 @@ bool importAsSprite = false;
 // TODO: see if this can be reimplemented using substring instead of regex?
 // "(.+?)" - match everything; "?" = match as few characters as possible.
 // "(?:_(\d+))" - an underscore followed by digits;
-// "?:" = don't make a separate group for the whole part, "?" = make this part optional.
+// "?:" = don't make a separate group for the whole part
 Regex sprFrameRegex = new(@"^(.+?)(?:_(\d+))$", RegexOptions.Compiled);
 string importFolder = CheckValidity();
 


### PR DESCRIPTION
## Description
Before, `sprite_0_0` would import as the first frame as `sprite`. This PR fixes that, allowing `sprite_0_0` to be imported as the first frame of `sprite_0`.

### Caveats
None

### Notes
None
