### PR TITLE
Fixed spine sprites in >= 2023.1

### DIFF
--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -49,9 +49,12 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
         writer.Write(PageWidth);
         writer.Write(PageHeight);
         // TODO: check if this is also the case on earlier versions
-        if (writer.undertaleData.IsVersionAtLeast(2023, 4)) {
+        if (writer.undertaleData.IsVersionAtLeast(2023, 4))
+        {
             writer.Write(Unknown);
-        } else {
+        } 
+        else 
+        {
             writer.Write(TexBlob.Length);
             writer.Write(TexBlob);
         }
@@ -63,9 +66,9 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
         PageWidth = reader.ReadInt32();
         PageHeight = reader.ReadInt32();
         // TODO: check if this is also the case on earlier versions
-        if (reader.undertaleData.IsVersionAtLeast(2023, 4)) {
+        if (reader.undertaleData.IsVersionAtLeast(2023, 4))
             Unknown = reader.ReadInt32();
-        } else
+        else
             TexBlob = reader.ReadBytes(reader.ReadInt32());
     }
 
@@ -74,9 +77,9 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
     {
         reader.Position += 8;                        // Size
         // TODO: check if this is also the case on earlier versions
-        if (reader.undertaleData.IsVersionAtLeast(2023, 4)) {
+        if (reader.undertaleData.IsVersionAtLeast(2023, 4))
             reader.Position += 4; // unknown
-        } else
+        else
             reader.Position += (uint)reader.ReadInt32(); // "TexBlob"
 
         return 0;
@@ -610,7 +613,8 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
                     reader.Align(4);
 
                     // TODO: check if this is also the case on earlier versions
-                    if (reader.undertaleData.IsVersionAtLeast(2023, 4)) {
+                    if (reader.undertaleData.IsVersionAtLeast(2023, 4))
+                    {
                         Textures = reader.ReadUndertaleObject<UndertaleSimpleList<TextureEntry>>();
                         SpineHasTextureData = false;
                     }

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -31,7 +31,13 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
     /// The atlas as raw bytes, can be a GameMaker QOI texture or a PNG file.
     /// </summary>
     public byte[] TexBlob { get; set; }
-    
+
+    // TODO: figure out what these bytes mean
+    /// <summary>
+    /// Unknown for >= 2023.4
+    /// </summary>
+    public int Unknown { get; set; }
+
     /// <summary>
     /// Indicates whether <see cref="TexBlob"/> contains a GameMaker QOI texture (the header is qoif reversed).
     /// </summary>
@@ -44,8 +50,7 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
         writer.Write(PageHeight);
         // TODO: check if this is also the case on earlier versions
         if (writer.undertaleData.IsVersionAtLeast(2023, 4)) {
-            // TODO: figure out what these bytes mean
-            writer.Write(0);
+            writer.Write(Unknown);
         } else {
             writer.Write(TexBlob.Length);
             writer.Write(TexBlob);
@@ -59,8 +64,7 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
         PageHeight = reader.ReadInt32();
         // TODO: check if this is also the case on earlier versions
         if (reader.undertaleData.IsVersionAtLeast(2023, 4)) {
-            // TODO: figure out what these bytes mean
-            reader.ReadInt32();
+            Unknown = reader.ReadInt32();
         } else
             TexBlob = reader.ReadBytes(reader.ReadInt32());
     }
@@ -71,7 +75,6 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
         reader.Position += 8;                        // Size
         // TODO: check if this is also the case on earlier versions
         if (reader.undertaleData.IsVersionAtLeast(2023, 4)) {
-            // TODO: figure out what these bytes mean
             reader.Position += 4; // unknown
         } else
             reader.Position += (uint)reader.ReadInt32(); // "TexBlob"

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -28,15 +28,14 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
     public int PageHeight { get; set; }
     
     /// <summary>
-    /// The atlas as raw bytes, can be a GameMaker QOI texture or a PNG file.
+    /// The atlas as raw bytes, can be a GameMaker QOI texture or a PNG file. Null for versions >= 2023.1.
     /// </summary>
     public byte[] TexBlob { get; set; }
 
-    // TODO: figure out what these bytes mean
     /// <summary>
-    /// Unknown for >= 2023.4
+    /// The length of the corresponding sprite texture entry for versions >= 2023.1.
     /// </summary>
-    public int Unknown { get; set; }
+    public int TextureEntryLength { get; set; }
 
     /// <summary>
     /// Indicates whether <see cref="TexBlob"/> contains a GameMaker QOI texture (the header is qoif reversed).
@@ -48,10 +47,9 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
     {
         writer.Write(PageWidth);
         writer.Write(PageHeight);
-        // TODO: check if this is also the case on earlier versions
-        if (writer.undertaleData.IsVersionAtLeast(2023, 4))
+        if (writer.undertaleData.IsVersionAtLeast(2023, 1))
         {
-            writer.Write(Unknown);
+            writer.Write(TextureEntryLength);
         } 
         else 
         {
@@ -65,9 +63,8 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
     {
         PageWidth = reader.ReadInt32();
         PageHeight = reader.ReadInt32();
-        // TODO: check if this is also the case on earlier versions
-        if (reader.undertaleData.IsVersionAtLeast(2023, 4))
-            Unknown = reader.ReadInt32();
+        if (reader.undertaleData.IsVersionAtLeast(2023, 1))
+            TextureEntryLength = reader.ReadInt32();
         else
             TexBlob = reader.ReadBytes(reader.ReadInt32());
     }
@@ -76,9 +73,8 @@ public class UndertaleSpineTextureEntry : UndertaleObject, IDisposable
     public static uint UnserializeChildObjectCount(UndertaleReader reader)
     {
         reader.Position += 8;                        // Size
-        // TODO: check if this is also the case on earlier versions
-        if (reader.undertaleData.IsVersionAtLeast(2023, 4))
-            reader.Position += 4; // unknown
+        if (reader.undertaleData.IsVersionAtLeast(2023, 1))
+            reader.Position += 4; // "TextureEntryLength"
         else
             reader.Position += (uint)reader.ReadInt32(); // "TexBlob"
 
@@ -428,8 +424,7 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
                     byte[] encodedJson = EncodeSpineBlob(Encoding.UTF8.GetBytes(SpineJSON));
                     byte[] encodedAtlas = EncodeSpineBlob(Encoding.UTF8.GetBytes(SpineAtlas));
 
-                    // TODO: check if this is also the case on earlier versions
-                    if (writer.undertaleData.IsVersionAtLeast(2023, 4))
+                    if (writer.undertaleData.IsVersionAtLeast(2023, 1))
                         writer.WriteUndertaleObject(Textures);
 
                     // the header.
@@ -612,8 +607,7 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
                 {
                     reader.Align(4);
 
-                    // TODO: check if this is also the case on earlier versions
-                    if (reader.undertaleData.IsVersionAtLeast(2023, 4))
+                    if (reader.undertaleData.IsVersionAtLeast(2023, 1))
                     {
                         Textures = reader.ReadUndertaleObject<UndertaleSimpleList<TextureEntry>>();
                         SpineHasTextureData = false;
@@ -748,8 +742,7 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
                 {
                     reader.Align(4);
 
-                    // TODO: check if this is also the case on earlier versions
-                    if (reader.undertaleData.IsVersionAtLeast(2023, 4))
+                    if (reader.undertaleData.IsVersionAtLeast(2023, 1))
                         count += 1 + UndertaleSimpleList<TextureEntry>.UnserializeChildObjectCount(reader);
 
                     int spineVersion = reader.ReadInt32();

--- a/UndertaleModLib/UndertaleIO.cs
+++ b/UndertaleModLib/UndertaleIO.cs
@@ -344,6 +344,7 @@ namespace UndertaleModLib
             if (poolSize != 0 && poolSize != objectPool.Count)
             {
                 SubmitWarning("Warning - the estimated object pool size differs from the actual size.\n" +
+                             $"Estimated: {poolSize}, Actual: {objectPool.Count}\n" +
                               "Please report this on UndertaleModTool GitHub.");
             }
 

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -51,11 +51,16 @@ namespace UndertaleModTool
                         Directory.CreateDirectory(path);
 
                         // textures
-                        if (sprite.SpineHasTextureData) {
-                            foreach (var tex in sprite.SpineTextures.Select((tex, id) => new { id, tex })) {
-                                try {
+                        if (sprite.SpineHasTextureData)
+                        {
+                            foreach (var tex in sprite.SpineTextures.Select((tex, id) => new { id, tex }))
+                            {
+                                try
+                                {
                                     File.WriteAllBytes(Path.Combine(path, tex.id + ext), tex.tex.TexBlob);
-                                } catch (Exception ex) {
+                                } 
+                                catch (Exception ex) 
+                                {
                                     mainWindow.ShowError("Failed to export file: " + ex.Message, "Failed to export file");
                                 }
                             }

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -51,15 +51,13 @@ namespace UndertaleModTool
                         Directory.CreateDirectory(path);
 
                         // textures
-                        foreach (var tex in sprite.SpineTextures.Select((tex, id) => new { id,tex }))
-                        {
-                            try
-                            {
-                                File.WriteAllBytes(Path.Combine(path, tex.id + ext), tex.tex.TexBlob);
-                            }
-                            catch (Exception ex)
-                            {
-                                mainWindow.ShowError("Failed to export file: " + ex.Message, "Failed to export file");
+                        if (sprite.SpineHasTextureData) {
+                            foreach (var tex in sprite.SpineTextures.Select((tex, id) => new { id, tex })) {
+                                try {
+                                    File.WriteAllBytes(Path.Combine(path, tex.id + ext), tex.tex.TexBlob);
+                                } catch (Exception ex) {
+                                    mainWindow.ShowError("Failed to export file: " + ex.Message, "Failed to export file");
+                                }
                             }
                         }
 
@@ -88,7 +86,8 @@ namespace UndertaleModTool
             if (sprite.IsSpineSprite)
             {
                 ExportAllSpine(dlg, sprite);
-                return;
+                if (sprite.SpineHasTextureData)
+                    return;
             }
 
             TextureWorker worker = new TextureWorker();


### PR DESCRIPTION
Submachine Legacy did not work with before changing this.

## Description
In gamemaker version past 2023.4, the image data for a spine sprite is held within UndertaleSprite.TextureEntry rather than the UndertaleSpineTextureEntry.

This fixes that by checking the version and populating UndertaleSprite.Textures but excluding UndertaleSpineTextureEntry.TexBlob.

### Caveats
* There are 4 bytes in the UndertaleSpineTextureEntry part of the binary that I do not know the purpose of, but it doesn't seem to affect anything.
* I have not fully tested every version, but it works on at least 2023.4 and 2023.8, and it is possible this change is needed for before 2023.4.

### Notes
I was able to add this smiley face to the spined flame with this change:
![spine change example](https://github.com/krzys-h/UndertaleModTool/assets/135391005/2e4ed8ec-44b0-4575-b027-2e61c8262eba)
