### PR TITLE
fixed disappearing returns

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -217,7 +217,7 @@ namespace UndertaleModLib.Decompiler
                         if (!(nextBlock is not null
                             && nextBlock.Instructions.Count > 0
                             && nextBlock.Instructions[0].Kind == UndertaleInstruction.Opcode.Push
-                            && nextBlock.Instructions[0].Value.GetType() != typeof(int)))
+                            && nextBlock.Instructions[0].Value is UndertaleInstruction.Reference<UndertaleFunction>))
                         {
                             ReturnStatement stmt = new ReturnStatement(instr.Kind == UndertaleInstruction.Opcode.Ret ? stack.Pop() : null);
                             /*


### PR DESCRIPTION
## Description
This fixes issue #1456 caused by pr #1191. This issue occurred because the pr would remove any `exit` instruction that wasn't followed by an operation starting with `push int`, which removed simple `return;`s that didn't meet that req because they compile to `exit` (while `return value;` compiles to `ret`). Thanks to @Jacky720 for a better way than my initial solution in #1680

### Caveats
Haven't done proper testing

### Notes
N/A