### PR TITLE
Compiler self call support

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -2249,10 +2249,16 @@ namespace UndertaleModLib.Compiler
                 else if (s.Kind == Parser.Statement.StatementKind.ExprFuncName)
                 {
                     // Until further notice, I'm assuming this only comes up in 2.3 script definition.
+
+                    // sub funcs in an object store the self variable without the object function name suffix
+                    string funcName = s.Text;
+                    if (funcName.Contains("_gml_Object_"))
+                        funcName = funcName[..funcName.LastIndexOf("_gml_Object_")];
+
                     cw.varPatches.Add(new VariablePatch()
                     {
                         Target = cw.EmitRef(Opcode.Pop, DataType.Variable, DataType.Variable),
-                        Name = s.Text,
+                        Name = funcName,
                         InstType = InstanceType.Self,
                         VarType = VariableType.StackTop
                     });

--- a/UndertaleModLib/Compiler/Lexer.cs
+++ b/UndertaleModLib/Compiler/Lexer.cs
@@ -506,6 +506,9 @@ namespace UndertaleModLib.Compiler
                     "then" => new Token(Token.TokenKind.KeywordThen, cr.GetPositionInfo(index)),
                     "mod" => new Token(Token.TokenKind.Mod, cr.GetPositionInfo(index)),
                     "div" => new Token(Token.TokenKind.Div, cr.GetPositionInfo(index)),
+                    // In GMS2.3, these keywords are special function calls instead of constants
+                    "self" when CompileContext.GMS2_3 => new Token(Token.TokenKind.KeywordSelf, cr.GetPositionInfo(index)),
+                    "other" when CompileContext.GMS2_3 => new Token(Token.TokenKind.KeywordOther, cr.GetPositionInfo(index)),
                     _ => new Token(Token.TokenKind.Identifier, identifierText, cr.GetPositionInfo(index)),
                 };
             }
@@ -813,6 +816,8 @@ namespace UndertaleModLib.Compiler
                     KeywordContinue,
                     KeywordStruct, // Apparently this exists
                     KeywordFunction,
+                    KeywordSelf,
+                    KeywordOther,
                     OpenBlock, // {
                     CloseBlock, // }
                     OpenArray, // [

--- a/UndertaleModLib/Compiler/Parser.cs
+++ b/UndertaleModLib/Compiler/Parser.cs
@@ -709,12 +709,13 @@ namespace UndertaleModLib.Compiler
             {
                 Lexer.Token token = remainingStageOne.Dequeue().Token;
                 Statement result = new Statement(Statement.StatementKind.ExprFunctionCall, token);
+
                 // They literally convert into function calls
-                if (token.Kind == TokenKind.KeywordSelf) {
+                if (token.Kind == TokenKind.KeywordSelf)
                     result.Text = "@@This@@";
-                } else {
+                else
                     result.Text = "@@Other@@";
-                }
+
                 return result;
             }
 
@@ -1407,7 +1408,8 @@ namespace UndertaleModLib.Compiler
 
             private static Statement ParseSingleVar(CompileContext context)
             {
-                if (IsNextToken(TokenKind.ProcFunction)) {
+                if (IsNextToken(TokenKind.ProcFunction))
+                {
                     Statement procFunc = EnsureTokenKind(TokenKind.ProcFunction);
                     EnsureTokenKind(TokenKind.OpenParen); // this should be guaranteed
                     Statement funcCall = new Statement(Statement.StatementKind.ExprFunctionCall, procFunc.Token);

--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionConstant.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionConstant.cs
@@ -98,8 +98,11 @@ public static partial class Decompiler
             // Archie: If statements are inefficient! Use a switch jump table!
             if (AssetType == AssetIDType.GameObject && !(Value is Int64)) // When the value is Int64, an example value is 343434343434. It is unknown what it represents, but it's not an InstanceType.
             {
-                int? val = ConvertToInt(Value);
-                if (val != null && val < 0 && val >= -16)
+                int? val = ConvertToInt(Value);                    
+                // Instance types past -5 are builtin, local, stacktop, arg and static.
+                // None of them are constants in GML.
+                // In GMS2.3, `self` and `other` are function calls instead of being -1 and -2.
+                if (val != null && val < (DecompileContext.GMS2_3 ? -2 : 0) && val >= -5)
                     return ((UndertaleInstruction.InstanceType)Value).ToString().ToLower(CultureInfo.InvariantCulture);
             }
             else switch (AssetType) // Need to put else because otherwise it gets terribly unoptimized with GameObject type


### PR DESCRIPTION
Resolves #1133 

## Description
1. Adds support for GMS2.3+ self calls in the compiler, cherrypicked from [UndertaleModTool Community Edition](https://github.com/XDOneDude/UndertaleModToolCE/).

2. Fixed an issue where sub functions in an object should be stored in a self variable without the object function name suffix.
Example: the utmt compiler would make `gml_Script_act_gml_Object_menu_chapter_btn_Create_0` be stored in `self.act_gml_Object_menu_chapter_btn_Create_0` when the original game code had `self.act`.

### Caveats
None

### Notes
I've tested this with Submachine Legacy (2023.8), and the one from #1133 (2022.5)

How to Reproduce:
1. Create a function in a GlobalScript or Object code, then call that function from another function
![image](https://github.com/krzys-h/UndertaleModTool/assets/135391005/ab89fdf8-ac08-4267-8bfa-172e90a226de)

2. In gamemaker (I've only tested this for 2023.8), make a function in an object, then call that function from another one in the same object
![image](https://github.com/krzys-h/UndertaleModTool/assets/135391005/f38d12a5-4fc4-47a0-8e27-e603ecb7e5a7)
