### PR TITLE
Verify changes were made in ReplaceTextInGML

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -657,11 +657,13 @@ public partial class Program : IScriptInterface
         {
             try
             {
-                if (code is null) // It would just be recompiling an empty string and messing with null entries seems bad
+                // It would just be recompiling an empty string and messing with null entries seems bad
+                if (code is null)
                     return;
-                string original = Decompiler.Decompile(code, decompileContext);
-                passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
-                if (passBack == original) // No need to compile something unchanged
+                string originalCode = Decompiler.Decompile(code, decompileContext);
+                passBack = GetPassBack(originalCode, keyword, replacement, caseSensitive, isRegex);
+                // No need to compile something unchanged
+                if (passBack == originalCode)
                     return;
                 code.ReplaceGML(passBack, Data);
             }

--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -657,7 +657,12 @@ public partial class Program : IScriptInterface
         {
             try
             {
-                passBack = GetPassBack(Decompiler.Decompile(code, decompileContext), keyword, replacement, caseSensitive, isRegex);
+                if (code is null) // It would just be recompiling an empty string and messing with null entries seems bad
+                    return;
+                string original = Decompiler.Decompile(code, decompileContext);
+                passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
+                if (passBack == original) // No need to compile something unchanged
+                    return;
                 code.ReplaceGML(passBack, Data);
             }
             catch (Exception exc)
@@ -665,27 +670,9 @@ public partial class Program : IScriptInterface
                 throw new Exception("Error during GML code replacement:\n" + exc);
             }
         }
-        else if (Data.ToolInfo.ProfileMode)
+        else
         {
-            try
-            {
-                try
-                {
-                    if (context is null)
-                        passBack = GetPassBack(Decompiler.Decompile(code, new GlobalDecompileContext(Data, false)), keyword, replacement, caseSensitive, isRegex);
-                    else
-                        passBack = GetPassBack(Decompiler.Decompile(code, context), keyword, replacement, caseSensitive, isRegex);
-                    code.ReplaceGML(passBack, Data);
-                }
-                catch (Exception exc)
-                {
-                    throw new Exception("Error during GML code replacement:\n" + exc);
-                }
-            }
-            catch (Exception exc)
-            {
-                throw new Exception("Error during writing of GML code to profile:\n" + exc + "\n\nCode:\n\n" + passBack);
-            }
+            throw new Exception("This UndertaleData is set to use profile mode, but UndertaleModCLI does not support profile mode.");
         }
     }
 

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -120,7 +120,12 @@ namespace UndertaleModTool
             {
                 try
                 {
-                    passBack = GetPassBack((code != null ? Decompiler.Decompile(code, DECOMPILE_CONTEXT ) : ""), keyword, replacement, caseSensitive, isRegex);
+                    if (code is null) // It would just be recompiling an empty string and messing with null entries seems bad
+                        return;
+                    string original = Decompiler.Decompile(code, DECOMPILE_CONTEXT);
+                    passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
+                    if (passBack == original) // No need to compile something unchanged
+                        return;
                     code.ReplaceGML(passBack, Data);
                 }
                 catch (Exception exc)
@@ -135,7 +140,10 @@ namespace UndertaleModTool
                     string path = Path.Combine(ProfilesFolder, Data.ToolInfo.CurrentMD5, "Temp", codeName + ".gml");
                     if (File.Exists(path))
                     {
-                        passBack = GetPassBack(File.ReadAllText(path), keyword, replacement, caseSensitive, isRegex);
+                        string original = File.ReadAllText(path);
+                        passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
+                        if (passBack == original) // No need to compile something unchanged
+                            return;
                         File.WriteAllText(path, passBack);
                         code.ReplaceGML(passBack, Data);
                     }
@@ -143,10 +151,12 @@ namespace UndertaleModTool
                     {
                         try
                         {
-                            if (context is null)
-                                passBack = GetPassBack((code != null ? Decompiler.Decompile(code, new GlobalDecompileContext(Data, false)) : ""), keyword, replacement, caseSensitive, isRegex);
-                            else
-                                passBack = GetPassBack((code != null ? Decompiler.Decompile(code, context) : ""), keyword, replacement, caseSensitive, isRegex);
+                            if (code is null) // It would just be recompiling an empty string and messing with null entries seems bad
+                                return;
+                            string original = Decompiler.Decompile(code, DECOMPILE_CONTEXT);
+                            passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
+                            if (passBack == original) // No need to compile something unchanged
+                                return;
                             code.ReplaceGML(passBack, Data);
                         }
                         catch (Exception exc)

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -120,11 +120,13 @@ namespace UndertaleModTool
             {
                 try
                 {
-                    if (code is null) // It would just be recompiling an empty string and messing with null entries seems bad
+                    // It would just be recompiling an empty string and messing with null entries seems bad
+                    if (code is null)
                         return;
-                    string original = Decompiler.Decompile(code, DECOMPILE_CONTEXT);
-                    passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
-                    if (passBack == original) // No need to compile something unchanged
+                    string originalCode = Decompiler.Decompile(code, DECOMPILE_CONTEXT);
+                    passBack = GetPassBack(originalCode, keyword, replacement, caseSensitive, isRegex);
+                    // No need to compile something unchanged
+                    if (passBack == originalCode)
                         return;
                     code.ReplaceGML(passBack, Data);
                 }
@@ -140,9 +142,10 @@ namespace UndertaleModTool
                     string path = Path.Combine(ProfilesFolder, Data.ToolInfo.CurrentMD5, "Temp", codeName + ".gml");
                     if (File.Exists(path))
                     {
-                        string original = File.ReadAllText(path);
-                        passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
-                        if (passBack == original) // No need to compile something unchanged
+                        string originalCode = File.ReadAllText(path);
+                        passBack = GetPassBack(originalCode, keyword, replacement, caseSensitive, isRegex);
+                        // No need to compile something unchanged
+                        if (passBack == originalCode)
                             return;
                         File.WriteAllText(path, passBack);
                         code.ReplaceGML(passBack, Data);
@@ -151,11 +154,13 @@ namespace UndertaleModTool
                     {
                         try
                         {
-                            if (code is null) // It would just be recompiling an empty string and messing with null entries seems bad
+                            // It would just be recompiling an empty string and messing with null entries seems bad
+                            if (code is null)
                                 return;
-                            string original = Decompiler.Decompile(code, DECOMPILE_CONTEXT);
-                            passBack = GetPassBack(original, keyword, replacement, caseSensitive, isRegex);
-                            if (passBack == original) // No need to compile something unchanged
+                            string originalCode = Decompiler.Decompile(code, DECOMPILE_CONTEXT);
+                            passBack = GetPassBack(originalCode, keyword, replacement, caseSensitive, isRegex);
+                            // No need to compile something unchanged
+                            if (passBack == originalCode)
                                 return;
                             code.ReplaceGML(passBack, Data);
                         }


### PR DESCRIPTION
## Description
Some general cleanup of both the CLI and Tool implementations of the ReplaceTextInGML scripting function. More importantly, adds a check to return early if the text replacement caused no changes, not attempting to recompile, reducing the number of scripts which error. Closes #1644, but while replacing Clover in Undertale Yellow still doesn't work, at least the script causing the error is one that actually contains "Clover". (It's the error with `string()` having an overload the tool doesn't support yet.)

### Caveats
Would cause the CLI version to give an immediate error if the UndertaleData has profile mode enabled. This shouldn't be possible because the CLI doesn't actually have a profile mode save directory. Also, as stated, the example replacement in Undertale Yellow still doesn't work; that would require a change to FindAndReplace to continue after an error in a single code replacement.

### Notes
It's possible the original layout of these implementations (defining a decompile context variable outside the profile mode if-block, then ignoring it and effectively duplicating its definition in one of the blocks, among other oddities) are important and the reworks in this PR could break it. It doesn't seem likely, but it's possible.