### PR TITLE
Rudimentary "line-eating" patch

### DIFF
--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -715,7 +715,7 @@ namespace UndertaleModTool
                                     {
                                         Match match = matches[i];
                                         if (!currDict.TryGetValue(match.Groups[1].Value, out string text))
-                                            continue;
+                                            text = "<localization fetch error>";
 
                                         if (i != matches.Length - 1) // If not the last
                                             decompLinesBuilder.Append($"{text}; ");


### PR DESCRIPTION
## Description
This fixes a bug where the tool would start a localization comment in Undertale (possibly also Deltarune), but would be unable to fetch the localized string and forget the newline, resulting in the following line of code being absorbed by the comment and disappearing on recompile. Closes #1645.

### Caveats
N/A

### Notes
The current solution is to include the text "\<localization fetch error\>", but I'm amenable to other fixes, such as having no text but moving the newline append out of the loop over matches, or constructing a separate list of successful fetches and only including the comment at all if that has any contents.