### PR TITLE
Restore 2.3.1 version check

### DIFF
--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -133,6 +133,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
             Name = reader.ReadUndertaleString();
             Function = (FunctionType)reader.ReadUInt32();
             Iterations = reader.ReadUInt32();
+
             // This check is partly duplicated from UndertaleChunks.cs, but it's necessary to handle embedded curves
             // (for example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
             if (!reader.undertaleData.IsVersionAtLeast(2, 3, 1))
@@ -156,6 +157,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
 
                 reader.AbsPosition = returnPosition;
             }
+
             Points = reader.ReadUndertaleObject<UndertaleSimpleList<Point>>();
         }
 

--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -135,7 +135,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
             Iterations = reader.ReadUInt32();
 
             // This check is partly duplicated from UndertaleChunks.cs, but it's necessary to handle embedded curves
-            // (for example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
+            // (For example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
             if (!reader.undertaleData.IsVersionAtLeast(2, 3, 1))
             {
                 long returnPosition = reader.AbsPosition;
@@ -143,7 +143,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
                 if (numPoints > 0)
                 {
                     reader.AbsPosition += 8;
-                    if (reader.ReadUInt32() != 0) // in 2.3 a int with the value of 0 would be set here,
+                    if (reader.ReadUInt32() != 0) // In 2.3 a int with the value of 0 would be set here,
                     {                             // it cannot be version 2.3 if this value isn't 0
                         reader.undertaleData.SetGMS2Version(2, 3, 1);
                     }

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1504,6 +1504,8 @@ namespace UndertaleModLib
         public override string Name => "ACRV";
 
         private static bool checkedForGMS2_3_1;
+
+        // See also a similar check in UndertaleAnimationCurve.cs, necessary for embedded animation curves.
         private void CheckForGMS2_3_1(UndertaleReader reader)
         {
             if (reader.undertaleData.IsVersionAtLeast(2, 3, 1))
@@ -1522,10 +1524,10 @@ namespace UndertaleModLib
                 return;
             }
 
-            reader.AbsPosition = reader.ReadUInt32(); // go to the first "Point"
+            reader.AbsPosition = reader.ReadUInt32(); // Go to the first "Point"
             reader.Position += 8;
 
-            if (reader.ReadUInt32() != 0) // in 2.3 a int with the value of 0 would be set here,
+            if (reader.ReadUInt32() != 0) // In 2.3 a int with the value of 0 would be set here,
             {                             // it cannot be version 2.3 if this value isn't 0
                 reader.undertaleData.SetGMS2Version(2, 3, 1);
             }


### PR DESCRIPTION
## Description
This re-adds a variant of the UndertaleAnimationCurve version check into UndertaleAnimationCurve.cs itself. (It had previously been moved to UndertaleChunks.cs to match most other chunk-parsing-based version checks.) This is because at least one game-- TS!Underswap, Demo v1.0, makes use of embedded animation curves in its sequences, which are parsed prior to the ACRV check in UndertaleChunks. Closes #1414.

### Caveats
The check is imperfect, but it loads the demo in question correctly. Marking this as draft as it does cause a mismatch in object count unserialization and an associated warning.

### Notes
There's definitely a possibility for the check yielding false positives or negatives, but we had it for a long time back in the day and evidently got no complaints or it would have changed more than just being moved as an optimization measure.
Also, I am amenable to re-removing the check from UndertaleChunks, as *this* may make *that* check redundant.