### PR TITLE
Add GlobalSpaceParticles field to Particle Systems (2023.8+)

### DIFF
--- a/UndertaleModLib/Models/UndertaleParticleSystem.cs
+++ b/UndertaleModLib/Models/UndertaleParticleSystem.cs
@@ -16,7 +16,7 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
 
     public int DrawOrder { get; set; }
 
-    public int Unknown { get; set; }
+    public bool GlobalSpaceParticles { get; set; }
 
     public UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM> Emitters { get; set; } = new();
 
@@ -27,9 +27,8 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
         writer.Write(OriginX);
         writer.Write(OriginY);
         writer.Write(DrawOrder);
-        // TODO: find out when this started happening
         if (writer.undertaleData.IsVersionAtLeast(2023, 8))
-            writer.Write(Unknown);
+            writer.Write(GlobalSpaceParticles);
         writer.WriteUndertaleObject(Emitters);
     }
 
@@ -40,9 +39,8 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
         OriginX = reader.ReadInt32();
         OriginY = reader.ReadInt32();
         DrawOrder = reader.ReadInt32();
-        // TODO: find out when this started happening
         if (reader.undertaleData.IsVersionAtLeast(2023, 8))
-            Unknown = reader.ReadInt32();
+            GlobalSpaceParticles = reader.ReadBoolean();
         Emitters = reader.ReadUndertaleObject<UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM>>();
     }
 
@@ -51,7 +49,6 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
     {
         reader.Position += 16;
 
-        // TODO: find out when this started happening
         if (reader.undertaleData.IsVersionAtLeast(2023, 8))
             reader.Position += 4;
 

--- a/UndertaleModLib/Models/UndertaleParticleSystem.cs
+++ b/UndertaleModLib/Models/UndertaleParticleSystem.cs
@@ -16,6 +16,8 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
 
     public int DrawOrder { get; set; }
 
+    public int Unknown { get; set; }
+
     public UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM> Emitters { get; set; } = new();
 
     /// <inheritdoc />
@@ -25,6 +27,9 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
         writer.Write(OriginX);
         writer.Write(OriginY);
         writer.Write(DrawOrder);
+        // TODO: find out when this started happening
+        if (writer.undertaleData.IsVersionAtLeast(2023, 8))
+            writer.Write(Unknown);
         writer.WriteUndertaleObject(Emitters);
     }
 
@@ -35,6 +40,9 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
         OriginX = reader.ReadInt32();
         OriginY = reader.ReadInt32();
         DrawOrder = reader.ReadInt32();
+        // TODO: find out when this started happening
+        if (reader.undertaleData.IsVersionAtLeast(2023, 8))
+            Unknown = reader.ReadInt32();
         Emitters = reader.ReadUndertaleObject<UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM>>();
     }
 
@@ -42,6 +50,10 @@ public class UndertaleParticleSystem : UndertaleNamedResource, IDisposable
     public static uint UnserializeChildObjectCount(UndertaleReader reader)
     {
         reader.Position += 16;
+
+        // TODO: find out when this started happening
+        if (reader.undertaleData.IsVersionAtLeast(2023, 8))
+            reader.Position += 4;
 
         return 1 + UndertaleSimpleResourcesList<UndertaleParticleSystemEmitter, UndertaleChunkPSEM>.UnserializeChildObjectCount(reader);
     }


### PR DESCRIPTION
### Description
This makes the Kickstarter backer version of GLITCHED load and save correctly ~~(it has this turned on somehow)~~ seems to be always false? In this particular game though it triggered a check to disable padding so it stopped loading on save. 

### Caveats
Not that I know of

### Notes
I'm still not sure what this field does, I haven't been able to find a toggle for it anywhere.