### PR TITLE
Use R instead of G17 for double-to-string round trip

### DIFF
--- a/UndertaleModLib/Decompiler/DoubleToString.cs
+++ b/UndertaleModLib/Decompiler/DoubleToString.cs
@@ -45,6 +45,7 @@ namespace UndertaleModLib.Decompiler
             // As of time of writing this comment, C# does not offer a way to print fixed point notation while preserving precision.
             // You may ask "But why not use F17?". And the answer is, that for everything but R and G, the precision is hard-capped to 15 (according to MSDN: Double.ToString()).
             // Thus we use R to keep our precision, and then manually convert this to fixed point notation.
+            // R is used instead of G17 to prevent things like 0.1 turning into 0.10000000000000001.
             // For anyone unaware of the general algorithm: you get the exponent 'n', then move the decimal point n times to the right if it's positive / left if it's negative.
             ReadOnlySpan<char> exponentAsSpan = numberAsSpan.Slice(indexOfE + 1);
             int exponent = Int32.Parse(exponentAsSpan);

--- a/UndertaleModLib/Decompiler/DoubleToString.cs
+++ b/UndertaleModLib/Decompiler/DoubleToString.cs
@@ -36,7 +36,7 @@ namespace UndertaleModLib.Decompiler
             if (PredefinedValues.TryGetValue(number, out string res))
                 return res;
 
-            ReadOnlySpan<char> numberAsSpan = number.ToString("G17", CultureInfo.InvariantCulture).AsSpan();      // This can sometimes return a scientific notation
+            ReadOnlySpan<char> numberAsSpan = number.ToString("R", CultureInfo.InvariantCulture).AsSpan();      // This can sometimes return a scientific notation
             int indexOfE = numberAsSpan.IndexOf("E".AsSpan());
             if (indexOfE < 0)
                 return numberAsSpan.ToString();
@@ -44,7 +44,7 @@ namespace UndertaleModLib.Decompiler
             // This converts the scientific notation to standard form/fixed point notation
             // As of time of writing this comment, C# does not offer a way to print fixed point notation while preserving precision.
             // You may ask "But why not use F17?". And the answer is, that for everything but R and G, the precision is hard-capped to 15 (according to MSDN: Double.ToString()).
-            // Thus we use G17 to keep our precision, and then manually convert this to fixed point notation.
+            // Thus we use R to keep our precision, and then manually convert this to fixed point notation.
             // For anyone unaware of the general algorithm: you get the exponent 'n', then move the decimal point n times to the right if it's positive / left if it's negative.
             ReadOnlySpan<char> exponentAsSpan = numberAsSpan.Slice(indexOfE + 1);
             int exponent = Int32.Parse(exponentAsSpan);


### PR DESCRIPTION
## Description
Use the R Double.ToString format of G17 in DoubleToString (which is used for numbers in decompiler output). This prevents things like this from happening:
![image](https://github.com/UnderminersTeam/UndertaleModTool/assets/68464103/54339f41-7060-480b-9a06-d151ab9e1579)

This was happening since #1628. The description of said PR says:
> We use G17 instead of R because MSDN recommends it and it's supposedly faster.

Though that causes decimals to look pretty ugly, and i've had at least 2 people report this as a bug in UTMTCE, a fork I work on (which is on the latest UTMT commit), even though it does not actually affect anything.

### Caveats
I don't think there's any precision issues, as the old version of RoundTrip [used the R format](https://github.com/Miepee/UndertaleModTool/blob/65260c4bf3eaf3fd151d2805fa882b423b7a6110/UndertaleModLib/Decompiler/DoubleToString.cs#L50). Though it _might_ be slightly slower, and it's not recommended.