### PR TITLE
Add Newtonsoft.Json to the list of assemblies available in CLI scripts

### DIFF
--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -17,6 +17,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UndertaleModLib.Models;
+using Newtonsoft.Json;
 
 namespace UndertaleModCli;
 
@@ -193,6 +194,7 @@ public partial class Program : IScriptInterface
                 "System.Text.RegularExpressions")
             .AddReferences(typeof(UndertaleObject).GetTypeInfo().Assembly,
                 GetType().GetTypeInfo().Assembly,
+                typeof(JsonConvert).GetTypeInfo().Assembly,
                 typeof(System.Text.RegularExpressions.Regex).GetTypeInfo().Assembly,
                 typeof(TextureWorker).GetTypeInfo().Assembly)
             // "WithEmitDebugInformation(true)" not only lets us to see a script line number which threw an exception,

--- a/UndertaleModCli/UndertaleModCli.csproj
+++ b/UndertaleModCli/UndertaleModCli.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Scripts that use `Newtonsoft.Json` for parsing JSON files fail to execute when using UndertaleModCli. Unlike the GUI tool, the CLI does not add the assembly to the references available to scripts.

This PR fixes that by adding said reference.

### Caveats
Adds `Newtonsoft.Json` as a dependency to the CLI.