### PR TITLE
Fix ExportAllStringsBetter

### DIFF
--- a/UndertaleModTool/Scripts/Community Scripts/ExportAllStringsBetter.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ExportAllStringsBetter.csx
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Text;
+using System.Windows.Forms; // Needed for SaveFileDialog prompt
 
 EnsureDataLoaded();
 
@@ -24,7 +25,7 @@ json.Length -= suffix.Length;
 json.Append("\r\n    ]\r\n}");
 
 File.WriteAllText(saveFileDialog.FileName, json.ToString());
-ScriptMessage($"Successfully exported to\n{saveFileDialog.FileName}", "String export");
+ScriptMessage($"Successfully exported to\n{saveFileDialog.FileName}");
 
 static string JsonifyString(string str)
 {


### PR DESCRIPTION
## Description
Partial revert of #1532 due to lacking a good substitute for the SaveFileDialog used. Closes #1615.

### Caveats
The Windows Forms requirement still should be phased out (can we make the nice file select GUI-only? Do we have a general string-input scripting function?) of both the exporter and importer scripts in question.

### Notes
N/A