### PR TITLE
Add support for new bytecode weirdness

### DIFF
--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -227,8 +227,19 @@ namespace UndertaleModLib.Decompiler
                         instr.Value = breakId;
                         if (breakId == -11) // pushref
                         {
-                            // parse additional int argument
-                            instr.IntArgument = Int32.Parse(line);
+                            // Parse additional int argument
+                            if (Int32.TryParse(line, out int intArgument))
+                            {
+                                instr.IntArgument = intArgument;
+                            }
+                            else
+                            {
+                                // Or alternatively parse function!
+                                var f = data.Functions.ByName(line);
+                                if (f == null)
+                                    throw new Exception("Function in pushref not found: " + line);
+                                instr.Function = new UndertaleInstruction.Reference<UndertaleFunction>(f);
+                            }
                         }
                     }
                     else

--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -706,6 +706,11 @@ namespace UndertaleModLib.Decompiler
                                     // Note that this operator peeks from the stack, it does not pop directly.
                                     break;
                                 case -11: // GM 2023.8+, pushref
+                                    if (instr.Function != null)
+                                    {
+                                        stack.Push(new ExpressionConstant(UndertaleInstruction.DataType.Int32, instr.Function));
+                                        break;
+                                    }
                                     stack.Push(new ExpressionAssetRef(instr.IntArgument));
                                     break;
                             }

--- a/UndertaleModLib/Decompiler/Disassembler.cs
+++ b/UndertaleModLib/Decompiler/Disassembler.cs
@@ -11,7 +11,7 @@ namespace UndertaleModLib.Decompiler
     {
         private static void AppendLocalVarDefinitionsToStringBuilder(StringBuilder sb, UndertaleCode code, IList<UndertaleVariable> vars, UndertaleCodeLocals locals)
         {
-            if (code.WeirdLocalFlag)
+            if (code.WeirdLocalFlag && locals is null)
             {
                 return;
             }


### PR DESCRIPTION
## Description
- Some version between 2024.2 and before 2024.4 can include pushref.i in the function reference chain
- WeirdLocalsFlag appears to be on for many code entries in 2024.2+, so this ensures locals are still disassembled when that happens (if any locals are present)

### Caveats
There's a small chance this causes some existing games to have their code locals appear, but for the ones where it should matter (e.g., bytecode 14 and below), this doesn't seem to cause any problems. 

Also, this does not have compiler support for the new pushref.i function stuff - only disassembler and decompiler. Not sure if it's worth doing for such a short-lived version, or if it has any tangible effect on the game or not.