### PR TITLE
Fail-safe in DecompileContext.BooleanTypeEnabled

### DIFF
--- a/UndertaleModLib/Decompiler/DecompileContext.cs
+++ b/UndertaleModLib/Decompiler/DecompileContext.cs
@@ -14,7 +14,7 @@ public class DecompileContext
     public UndertaleCode TargetCode;
     public UndertaleGameObject Object;
     public static bool GMS2_3;
-    public bool BooleanTypeEnabled => GlobalContext.Data.IsVersionAtLeast(2, 3, 7);
+    public bool BooleanTypeEnabled => GlobalContext.Data?.IsVersionAtLeast(2, 3, 7) ?? false;
     public bool AssetResolutionEnabled => !GlobalContext.Data.IsVersionAtLeast(2023, 8);
 
     public DecompileContext(GlobalDecompileContext globalContext, UndertaleCode code, bool computeObject = true)


### PR DESCRIPTION
## Description
This PR adds a null check to the recently-added `DecompileContext.BooleanTypeEnabled`. Fixes a bug where the first code entry being decompiled would hang indefinitely, and a bug where Undertale textdata localization would always fail.

### Caveats
May cause false negatives on that version match; to be frank, I'm not sure how `GlobalContext.Data` ends up being null myself.

### Notes
We should get this in ASAP.