### PR TITLE
Fix double type being pushed onto the stack for int32 types

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -1651,7 +1651,7 @@ namespace UndertaleModLib.Compiler
                         {
                             cw.typeStack.Pop();
                             cw.Emit(Opcode.Conv, type, DataType.Int32);
-                            cw.typeStack.Push(DataType.Double);
+                            cw.typeStack.Push(DataType.Int32);
                         }
                         break;
                     case Lexer.Token.TokenKind.LogicalAnd:


### PR DESCRIPTION
## Description

Should help quite a bit with matching compilation. I.e. stuff like 
`x -= (1 + (statetime < 2) + (statetime < 4));`
previously had `add.d.v` used, when `add.i.v` should've been used instead

### Caveats
None that im aware of

### Notes
Nice copypaste error lol.