### PR TITLE
Fix short-circuit or turning into ternaries in 2.3.7+ games

### DIFF
--- a/UndertaleModLib/Decompiler/Decompiler.cs
+++ b/UndertaleModLib/Decompiler/Decompiler.cs
@@ -1329,10 +1329,17 @@ namespace UndertaleModLib.Decompiler
             return statement;
         }
 
-        private static bool TestNumber(Statement statement, int number, DecompileContext context = null)
+        private static bool TestNumber(Statement statement, int number)
         {
             statement = UnCast(statement);
             return (statement is ExpressionConstant constant) && constant.EqualsNumber(number);
+        }
+
+        // A bool-like can be either 1, 0, true or false.
+        private static bool TestBoolLike(Statement statement, bool boolean)
+        {
+            statement = UnCast(statement);
+            return (statement is ExpressionConstant constant) && constant.EqualsBoolLike(boolean);
         }
 
         public static List<Statement> HLDecompile(DecompileContext context, Dictionary<uint, Block> blocks, Block entryPoint, Block rootExitPoint)

--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionConstant.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionConstant.cs
@@ -47,6 +47,13 @@ public static partial class Decompiler
             return (Value is Int16 || Value is Int32) && Convert.ToInt32(Value) == TestNumber;
         }
 
+        public bool EqualsBoolLike(bool TestBool)
+        {
+            if (Value is Int16 || Value is Int32)
+                return Convert.ToInt32(Value) == Convert.ToInt32(TestBool);
+            return (Value is bool boolValue) && boolValue == TestBool;
+        }
+
         // Helper function to carefully check if an object is in fact an integer, for asset types.
         public static int? ConvertToInt(object val)
         {

--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionTernary.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionTernary.cs
@@ -35,7 +35,7 @@ public static partial class Decompiler
         public override string ToString(DecompileContext context)
         {
             string condStr = Condition.ToString(context);
-            if (TestNumber(TrueExpression, 1) && TestNumber(FalseExpression, 0))
+            if (TestBoolLike(TrueExpression, true) && TestBoolLike(FalseExpression, false))
                 return condStr; // Default values, yes = true, no = false.
 
             return "(" + condStr + " ? " + TrueExpression.ToString(context) + " : " + FalseExpression.ToString(context) + ")";

--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.IfHLStatement.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.IfHLStatement.cs
@@ -53,9 +53,9 @@ public static partial class Decompiler
                 if (trueAssign != null && falseAssign != null && trueAssign.Var.Var == falseAssign.Var.Var)
                 {
                     TempVarAssignmentStatement newAssign;
-                    if (TestNumber(trueAssign.Value, 1) && (falseAssign.Var.Var.Type == UndertaleInstruction.DataType.Boolean || falseAssign.Value.Type == UndertaleInstruction.DataType.Boolean))
+                    if (TestBoolLike(trueAssign.Value, true) && (falseAssign.Var.Var.Type == UndertaleInstruction.DataType.Boolean || falseAssign.Value.Type == UndertaleInstruction.DataType.Boolean))
                         newAssign = new TempVarAssignmentStatement(trueAssign.Var, new ExpressionTwoSymbol("||", UndertaleInstruction.DataType.Boolean, condition, falseAssign.Value));
-                    else if (TestNumber(falseAssign.Value, 0) && (trueAssign.Var.Var.Type == UndertaleInstruction.DataType.Boolean || trueAssign.Value.Type == UndertaleInstruction.DataType.Boolean))
+                    else if (TestBoolLike(falseAssign.Value, false) && (trueAssign.Var.Var.Type == UndertaleInstruction.DataType.Boolean || trueAssign.Value.Type == UndertaleInstruction.DataType.Boolean))
                         newAssign = new TempVarAssignmentStatement(trueAssign.Var, new ExpressionTwoSymbol("&&", UndertaleInstruction.DataType.Boolean, condition, trueAssign.Value));
                     else
                         newAssign = new TempVarAssignmentStatement(trueAssign.Var, new ExpressionTernary(trueAssign.Value.Type, condition, trueAssign.Value, falseAssign.Value));


### PR DESCRIPTION
Fixes a regression caused by #1717

## Description
This PR should fix || turning into ternaries like `left ? true : right` in 2.3.7 games. This as just caused by the detection for them only checking for the *numbers* 1/0, but now that they can be casted into booleans they must also check for true/false too.

### Caveats
idk

### Notes
<!-- Any notes or closing words -->