### PR TITLE
Fix font size being saved as a uint on gms2.3+

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -24,9 +24,9 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     public bool EmSizeIsFloat { get; set; }
 
     /// <summary>
-    /// The font size in Ems. In Game Maker: Studio 2.3 and above, this is a float instead.
+    /// The font size in Ems. In Game Maker: Studio 2.3 and above, this is a float instead. On versions below, it is an uint.
     /// </summary>
-    public uint EmSize { get; set; }
+    public float EmSize { get; set; }
 
     /// <summary>
     /// Whether to display the font in bold.
@@ -279,7 +279,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
         else
         {
             // pre-GMS2.3
-            writer.Write(EmSize);
+            writer.Write((uint)EmSize);
         }
 
         writer.Write(Bold);
@@ -307,15 +307,19 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
     {
         Name = reader.ReadUndertaleString();
         DisplayName = reader.ReadUndertaleString();
-        EmSize = reader.ReadUInt32();
+        uint readEmSize = reader.ReadUInt32();
         EmSizeIsFloat = false;
 
         // since the float is always written negated, it has the first bit set.
-        if ((EmSize & (1 << 31)) != 0)
+        if ((readEmSize & (1 << 31)) != 0)
         {
             float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(EmSize), 0);
-            EmSize = (uint)fsize;
+            EmSize = fsize;
             EmSizeIsFloat = true;
+        }
+        else
+        {
+            EmSize = readEmSize;
         }
 
         Bold = reader.ReadBoolean();


### PR DESCRIPTION
## Description
Fixes #1654 

### Notes
I did not test this.