### PR TITLE
Don't readd comments to gettext when comments already exist

### DIFF
--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -557,8 +557,8 @@ namespace UndertaleModTool
         }
 
         public static Dictionary<string, string> gettextJSON = null;
-        private static readonly Regex gettextRegex = new("scr_gettext\\(\\\"(.*?)\\\"\\)", RegexOptions.Compiled);
-        private static readonly Regex getlangRegex = new("scr_84_get_lang_string(?:.*?)\\(\\\"(.*?)\\\"\\)", RegexOptions.Compiled);
+        private static readonly Regex gettextRegex = new(@"scr_gettext\(\""(.*?)\""\)(?!(.*?\/\/.*?$))", RegexOptions.Compiled);
+        private static readonly Regex getlangRegex = new(@"scr_84_get_lang_string(?:.*?)\(\""(.*?)\""\)(?!(.*?\/\/.*?$))", RegexOptions.Compiled);
         private string UpdateGettextJSON(string json)
         {
             try


### PR DESCRIPTION
## Description
We use negative lookaheads to determine whether a comment already exists. See https://regex101.com/r/8pI24U/1 for a playground session.
Fixes #1426 

### Caveats
Performance *may* be slightly worse.
