### PR TITLE
Fix BGND parsing on byte code 12

### DIFF
--- a/UndertaleModLib/UndertaleChunkTypes.cs
+++ b/UndertaleModLib/UndertaleChunkTypes.cs
@@ -277,10 +277,22 @@ namespace UndertaleModLib
         {
             uint count = reader.ReadUInt32();
             List.SetCapacity(count);
+            uint realCount = count;
 
             for (int i = 0; i < count; i++)
-                Align &= (reader.ReadUInt32() % Alignment == 0);
-            for (int i = 0; i < count; i++)
+            {
+                uint readValue = reader.ReadUInt32();
+                Align &= (readValue % Alignment == 0);
+                if (readValue != 0) continue;
+
+                if (reader.undertaleData.GeneralInfo.BytecodeVersion >= 13)
+                {
+                    reader.SubmitWarning("Zero values in an AlignUpdatedListChunk encountered on Bytecode 13 or higher!");
+                }
+                realCount--;
+            }
+
+            for (int i = 0; i < realCount; i++)
             {
                 if (Align)
                 {


### PR DESCRIPTION
## Description
This helps reading IDOL. It goes from failing immediately in the BGND chunk, to failing somewhere in the OBJT chunk because it reads a null object.

### Notes
I have only tested this on IDOL