### PR TITLE
Rename ClearDisplayBuffer to DoNotClearDisplayBuffer

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -30,9 +30,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// </summary>
         ShowColor = 2,
         /// <summary>
-        /// Whether the room should clear the display buffer.
+        /// Whether the room should not clear the display buffer.
         /// </summary>
-        ClearDisplayBuffer = 4,
+        DoNotClearDisplayBuffer = 4,
         /// <summary>
         /// Whether the room was made in Game Maker: Studio 2.
         /// </summary>


### PR DESCRIPTION
## Description
Fixes #1072 
Was able to confirm that it's an issue by checking am2r's source code, which for [this room](https://github.com/AM2R-Community-Developers/AM2R-Community-Updates/blob/af36525198de8b9cba3a5acfb06c20541f21669d/rooms/rm_a2a14.room.gmx#L23) has clearDisplayBuffer set to 0, but shows up in UTMT
![grafik](https://github.com/UnderminersTeam/UndertaleModTool/assets/38186597/3c63add1-6f99-4396-a5e7-6ec2e2d8f412)

Renaming the flag was the simplest thing I could think of of fixing it.

### Caveats
API change. Every script which referenced that specific enum value (we dont have any in UTMT) will need to have their code adjusted.

### Notes
N/A