### PR TITLE
Don't show messagebox when profile gets saved

### DIFF
--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -383,7 +383,6 @@ an issue on GitHub.");
                     Directory.CreateDirectory(profDir);
                     Directory.CreateDirectory(Path.Combine(profDir, "Main"));
                     Directory.CreateDirectory(Path.Combine(profDir, "Temp"));
-                    this.ShowMessage("Profile saved successfully to " + ProfileHash);
                 }
                 if (SettingsWindow.DeleteOldProfileOnSave && copyProfile)
                 {


### PR DESCRIPTION
## Description
The current messagebox does nothing to help the user. Either they get confused by the hash, or they know what the hash is for and cant actually copy the text ouf of the MB. 
Removing it should lead to less confusion and a more comfortable workflow.
Fixes #867 

### Caveats
N/A

### Notes
N/A