### PR TITLE
Add parentheses to nested comparison expressions

### DIFF
--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionCompare.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionCompare.cs
@@ -28,7 +28,12 @@ public static partial class Decompiler
         public override string ToString(DecompileContext context)
         {
             string arg1 = Argument1.ToString(context);
+            if (Argument1 is ExpressionCompare compare1)
+                arg1 = compare1.ToStringWithParen(context);
             string arg2 = Argument2.ToString(context);
+            if (Argument2 is ExpressionCompare compare2)
+                arg2 = compare2.ToStringWithParen(context);
+
             return String.Format("{0} {1} {2}", arg1, OperationToPrintableString(Opcode), arg2);
         }
 


### PR DESCRIPTION
## Description
Minor fix for a bug reported on Discord where the code `x -= ((1 + statetime) < (2 + statetime)) < 4` would decompile as `x -= (1 + statetime) < (2 + statetime) < 4`.

### Caveats
Only the possible exceptions where parentheses might be helpful to other, yet rarer, expressions, which would have already been decompiling incorrectly.

### Notes
N/A