### PR TITLE
Add (most) save/load support for GameMaker 2024.6

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -2069,7 +2069,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                     if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         ParticleSystems = reader.ReadUndertaleObjectPointer<UndertalePointerList<ParticleSystemInstance>>();
                     if (firstPointerTarget > reader.AbsPosition && !reader.undertaleData.IsVersionAtLeast(2024, 6))
-                        reader.undertaleData.SetGMS2Version(2024, 6); // there's more data before legacy tiles, so must be 2024.6+
+                        reader.undertaleData.SetGMS2Version(2024, 6); // There's more data before legacy tiles, so must be 2024.6+
                     if (reader.undertaleData.IsVersionAtLeast(2024, 6))
                         TextItems = reader.ReadUndertaleObjectPointer<UndertalePointerList<TextItemInstance>>();
                 }
@@ -2106,7 +2106,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                     if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         partSystemsPtr = reader.ReadUInt32();
                     if (legacyTilesPtr > reader.AbsPosition && !reader.undertaleData.IsVersionAtLeast(2024, 6))
-                        reader.undertaleData.SetGMS2Version(2024, 6); // there's more data before legacy tiles, so must be 2024.6+
+                        reader.undertaleData.SetGMS2Version(2024, 6); // There's more data before legacy tiles, so must be 2024.6+
                     if (reader.undertaleData.IsVersionAtLeast(2024, 6))
                         textItemsPtr = reader.ReadUInt32();
                 }
@@ -2388,6 +2388,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             Rotation = reader.ReadSingle();
         }
 
+        /// <summary>
+        /// Generates a random name for this instance, as a utility for room editing.
+        /// </summary>
         //TODO: rework this method slightly.
         public static UndertaleString GenerateRandomName(UndertaleData data)
         {
@@ -2550,6 +2553,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             Rotation = reader.ReadSingle();
         }
 
+        /// <summary>
+        /// Generates a random name for this instance, as a utility for room editing.
+        /// </summary>
         public static UndertaleString GenerateRandomName(UndertaleData data)
         {
             return data.Strings.MakeString("particle_" + ((uint)Random.Shared.Next(-Int32.MaxValue, Int32.MaxValue)).ToString("X8"));
@@ -2587,6 +2593,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         private UndertaleResourceById<UndertaleFont, UndertaleChunkFONT> _font = new();
 
+        // TODO: document these fields; some are self-explanatory but unsure on the behavior of all of them
         public UndertaleString Name { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
@@ -2657,6 +2664,9 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             Wrap = reader.ReadBoolean();
         }
 
+        /// <summary>
+        /// Generates a random name for this instance, as a utility for room editing.
+        /// </summary>
         public static UndertaleString GenerateRandomName(UndertaleData data)
         {
             return data.Strings.MakeString("textitem_" + ((uint)Random.Shared.Next(-Int32.MaxValue, Int32.MaxValue)).ToString("X8"));
@@ -2665,7 +2675,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <inheritdoc />
         public override string ToString()
         {
-            return "Text item " + Name?.Content + " with text \"" + (Text?.Content ?? "?") + "\"";
+            return $"Text item {Name?.Content} with text \"{Text?.Content ?? "?"}\"";
         }
 
         /// <inheritdoc/>

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -2021,6 +2021,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             public UndertalePointerList<SequenceInstance> Sequences { get; set; }
             public UndertalePointerList<SpriteInstance> NineSlices { get; set; } // Removed in 2.3.2, before never used
             public UndertalePointerList<ParticleSystemInstance> ParticleSystems { get; set; }
+            public UndertalePointerList<TextItemInstance> TextItems { get; set; }
 
             /// <inheritdoc />
             public void Serialize(UndertaleWriter writer)
@@ -2034,6 +2035,8 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                         writer.WriteUndertaleObjectPointer(NineSlices);
                     if (writer.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         writer.WriteUndertaleObjectPointer(ParticleSystems);
+                    if (writer.undertaleData.IsVersionAtLeast(2024, 6))
+                        writer.WriteUndertaleObjectPointer(TextItems);
                 }
                 writer.WriteUndertaleObject(LegacyTiles);
                 writer.WriteUndertaleObject(Sprites);
@@ -2044,12 +2047,18 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                         writer.WriteUndertaleObject(NineSlices);
                     if (writer.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         writer.WriteUndertaleObject(ParticleSystems);
+                    if (writer.undertaleData.IsVersionAtLeast(2024, 6))
+                        writer.WriteUndertaleObject(TextItems);
                 }
             }
 
             /// <inheritdoc />
             public void Unserialize(UndertaleReader reader)
             {
+                // Track first pointer target to detect additional data
+                long firstPointerTarget = reader.ReadUInt32();
+                reader.Position -= 4;
+
                 LegacyTiles = reader.ReadUndertaleObjectPointer<UndertalePointerList<Tile>>();
                 Sprites = reader.ReadUndertaleObjectPointer<UndertalePointerList<SpriteInstance>>();
                 if (reader.undertaleData.IsVersionAtLeast(2, 3))
@@ -2059,6 +2068,10 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                         NineSlices = reader.ReadUndertaleObjectPointer<UndertalePointerList<SpriteInstance>>();
                     if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         ParticleSystems = reader.ReadUndertaleObjectPointer<UndertalePointerList<ParticleSystemInstance>>();
+                    if (firstPointerTarget > reader.AbsPosition && !reader.undertaleData.IsVersionAtLeast(2024, 6))
+                        reader.undertaleData.SetGMS2Version(2024, 6); // there's more data before legacy tiles, so must be 2024.6+
+                    if (reader.undertaleData.IsVersionAtLeast(2024, 6))
+                        TextItems = reader.ReadUndertaleObjectPointer<UndertalePointerList<TextItemInstance>>();
                 }
                 reader.ReadUndertaleObject(LegacyTiles);
                 reader.ReadUndertaleObject(Sprites);
@@ -2069,6 +2082,8 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                         reader.ReadUndertaleObject(NineSlices);
                     if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         reader.ReadUndertaleObject(ParticleSystems);
+                    if (reader.undertaleData.IsVersionAtLeast(2024, 6))
+                        reader.ReadUndertaleObject(TextItems);
                 }
             }
 
@@ -2082,6 +2097,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 uint sequencesPtr = 0;
                 uint nineSlicesPtr = 0;
                 uint partSystemsPtr = 0;
+                uint textItemsPtr = 0;
                 if (reader.undertaleData.IsVersionAtLeast(2, 3))
                 {
                     sequencesPtr = reader.ReadUInt32();
@@ -2089,6 +2105,10 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                         nineSlicesPtr = reader.ReadUInt32();
                     if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
                         partSystemsPtr = reader.ReadUInt32();
+                    if (legacyTilesPtr > reader.AbsPosition && !reader.undertaleData.IsVersionAtLeast(2024, 6))
+                        reader.undertaleData.SetGMS2Version(2024, 6); // there's more data before legacy tiles, so must be 2024.6+
+                    if (reader.undertaleData.IsVersionAtLeast(2024, 6))
+                        textItemsPtr = reader.ReadUInt32();
                 }
 
                 reader.AbsPosition = legacyTilesPtr;
@@ -2108,6 +2128,11 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                     {
                         reader.AbsPosition = partSystemsPtr;
                         count += 1 + UndertalePointerList<ParticleSystemInstance>.UnserializeChildObjectCount(reader);
+                    }
+                    if (reader.undertaleData.IsVersionAtLeast(2024, 6))
+                    {
+                        reader.AbsPosition = textItemsPtr;
+                        count += 1 + UndertalePointerList<TextItemInstance>.UnserializeChildObjectCount(reader);
                     }
                 }
 
@@ -2543,6 +2568,114 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
             _particleSys.Dispose();
             Name = null;
+        }
+    }
+
+    public class TextItemInstance : UndertaleObject, INotifyPropertyChanged, IStaticChildObjCount, IStaticChildObjectsSize, IDisposable
+    {
+        /// <inheritdoc cref="IStaticChildObjCount.ChildObjectCount" />
+        public static readonly uint ChildObjectCount = 1;
+
+        /// <inheritdoc cref="IStaticChildObjectsSize.ChildObjectsSize" />
+        public static readonly uint ChildObjectsSize = 68;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected void OnPropertyChanged([CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        private UndertaleResourceById<UndertaleFont, UndertaleChunkFONT> _font = new();
+
+        public UndertaleString Name { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
+        public UndertaleFont Font
+        {
+            get => _font.Resource;
+            set
+            {
+                _font.Resource = value;
+                OnPropertyChanged();
+            }
+        }
+        public float ScaleX { get; set; }
+        public float ScaleY { get; set; }
+        public float Rotation { get; set; }
+        public uint Color { get; set; }
+        public float OriginX { get; set; }
+        public float OriginY { get; set; }
+        public UndertaleString Text { get; set; }
+        public int Alignment { get; set; }
+        public float CharSpacing { get; set; }
+        public float LineSpacing { get; set; }
+        public float FrameWidth { get; set; }
+        public float FrameHeight { get; set; }
+        public bool Wrap { get; set; }
+
+        /// <inheritdoc />
+        public void Serialize(UndertaleWriter writer)
+        {
+            writer.WriteUndertaleString(Name);
+            writer.Write(X);
+            writer.Write(Y);
+            writer.WriteUndertaleObject(_font);
+            writer.Write(ScaleX);
+            writer.Write(ScaleY);
+            writer.Write(Rotation);
+            writer.Write(Color);
+            writer.Write(OriginX);
+            writer.Write(OriginY);
+            writer.WriteUndertaleString(Text);
+            writer.Write(Alignment);
+            writer.Write(CharSpacing);
+            writer.Write(LineSpacing);
+            writer.Write(FrameWidth);
+            writer.Write(FrameHeight);
+            writer.Write(Wrap);
+        }
+
+        /// <inheritdoc />
+        public void Unserialize(UndertaleReader reader)
+        {
+            Name = reader.ReadUndertaleString();
+            X = reader.ReadInt32();
+            Y = reader.ReadInt32();
+            _font = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleFont, UndertaleChunkFONT>>();
+            ScaleX = reader.ReadSingle();
+            ScaleY = reader.ReadSingle();
+            Rotation = reader.ReadSingle();
+            Color = reader.ReadUInt32();
+            OriginX = reader.ReadSingle();
+            OriginY = reader.ReadSingle();
+            Text = reader.ReadUndertaleString();
+            Alignment = reader.ReadInt32();
+            CharSpacing = reader.ReadSingle();
+            LineSpacing = reader.ReadSingle();
+            FrameWidth = reader.ReadSingle();
+            FrameHeight = reader.ReadSingle();
+            Wrap = reader.ReadBoolean();
+        }
+
+        public static UndertaleString GenerateRandomName(UndertaleData data)
+        {
+            return data.Strings.MakeString("textitem_" + ((uint)Random.Shared.Next(-Int32.MaxValue, Int32.MaxValue)).ToString("X8"));
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return "Text item " + Name?.Content + " with text \"" + (Text?.Content ?? "?") + "\"";
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            _font.Dispose();
+            Name = null;
+            Text = null;
         }
     }
 }

--- a/UndertaleModLib/Models/UndertaleSound.cs
+++ b/UndertaleModLib/Models/UndertaleSound.cs
@@ -144,6 +144,12 @@ public class UndertaleSound : UndertaleNamedResource, INotifyPropertyChanged, ID
     /// </summary>
     public int GroupID { get => _audioGroup.CachedId; set { _audioGroup.CachedId = value; OnPropertyChanged(); } }
 
+    /// <summary>
+    /// The precomputed length of the sound's audio data.
+    /// </summary>
+    /// <remarks>Introduced in GameMaker 2024.6.</remarks>
+    public float AudioLength { get; set; }
+
     /// <inheritdoc />
     public event PropertyChangedEventHandler PropertyChanged;
     
@@ -174,6 +180,9 @@ public class UndertaleSound : UndertaleNamedResource, INotifyPropertyChanged, ID
             writer.WriteUndertaleObject(_audioFile);
         else
             writer.Write(_audioFile.CachedId);
+
+        if (writer.undertaleData.IsVersionAtLeast(2024, 6))
+            writer.Write(AudioLength);
     }
 
     /// <inheritdoc />
@@ -207,6 +216,9 @@ public class UndertaleSound : UndertaleNamedResource, INotifyPropertyChanged, ID
         {
             _audioFile.CachedId = reader.ReadInt32();
         }
+
+        if (reader.undertaleData.IsVersionAtLeast(2024, 6))
+            AudioLength = reader.ReadSingle();
     }
 
     /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -806,6 +806,9 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
         return count;
     }
 
+    /// <summary>
+    /// Returns the width and height of the collision mask for this sprite, which changes depending on GameMaker version.
+    /// </summary>
     public (uint Width, uint Height) CalculateMaskDimensions(UndertaleData data)
     {
         if (data.IsVersionAtLeast(2024, 6))
@@ -815,11 +818,22 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
         return CalculateFullMaskDimensions(Width, Height);
     }
 
+    /// <summary>
+    /// Calculates the width and height of a collision mask from the given margin/bounding box.
+    /// This method is used to calculate collision mask dimensions in GameMaker 2024.6 and above.
+    /// </summary>
     public static (uint Width, uint Height) CalculateBboxMaskDimensions(int marginRight, int marginLeft, int marginBottom, int marginTop)
     {
         return ((uint)(marginRight - marginLeft + 1), (uint)(marginBottom - marginTop + 1));
     }
 
+    /// <summary>
+    /// Calculates the width and height of a collision mask from a given sprite's full width and height.
+    /// This method is used to calculate collision mask dimensions prior to GameMaker 2024.6.
+    /// </summary>
+    /// <remarks>
+    /// This simply returns the width and height supplied, but is intended for clarity in the code.
+    /// </remarks>
     public static (uint Width, uint Height) CalculateFullMaskDimensions(uint width, uint height)
     {
         return (width, height);

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -359,6 +359,67 @@ namespace UndertaleModLib
     public class UndertaleChunkSOND : UndertaleListChunk<UndertaleSound>
     {
         public override string Name => "SOND";
+
+        private static bool checkedFor2024_6;
+        private void CheckForGM2024_6(UndertaleReader reader)
+        {
+            if (!reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2) || reader.undertaleData.IsVersionAtLeast(2024, 6))
+            {
+                checkedFor2024_6 = true;
+                return;
+            }
+
+            long returnTo = reader.Position;
+
+            uint soundCount = reader.ReadUInt32();
+            if (soundCount >= 2)
+            {
+                // If first sound's theoretical (old) end offset is below the start offset of
+                // the next sound by exactly 4 bytes, then this is 2024.6.
+                uint firstSoundPtr = reader.ReadUInt32();
+                uint secondSoundPtr = reader.ReadUInt32();
+                if ((firstSoundPtr + (4 * 9)) == (secondSoundPtr - 4))
+                {
+                    reader.undertaleData.SetGMS2Version(2024, 6);
+                }
+            }
+            else if (soundCount == 1)
+            {
+                // If there's a nonzero value where padding should be at the
+                // end of the sound, then this is 2024.6.
+                uint firstSoundPtr = reader.ReadUInt32();
+                reader.AbsPosition = firstSoundPtr + (4 * 9);
+                if ((reader.AbsPosition % 16) != 4)
+                {
+                    // If this occurs, then something weird has happened at the start of the chunk?
+                    throw new IOException("Expected to be on specific alignment at this point");
+                }
+                if (reader.ReadUInt32() != 0)
+                {
+                    reader.undertaleData.SetGMS2Version(2024, 6);
+                }
+            }
+
+            reader.Position = returnTo;
+            checkedFor2024_6 = true;
+        }
+
+        internal override void UnserializeChunk(UndertaleReader reader)
+        {
+            if (!checkedFor2024_6)
+                CheckForGM2024_6(reader);
+
+            base.UnserializeChunk(reader);
+        }
+
+        internal override uint UnserializeObjectCount(UndertaleReader reader)
+        {
+            checkedFor2024_6 = false;
+
+            CheckForGM2024_6(reader);
+
+            return base.UnserializeObjectCount(reader);
+        }
     }
 
     public class UndertaleChunkAGRP : UndertaleListChunk<UndertaleAudioGroup>
@@ -369,6 +430,170 @@ namespace UndertaleModLib
     public class UndertaleChunkSPRT : UndertaleListChunk<UndertaleSprite>
     {
         public override string Name => "SPRT";
+
+        private static bool checkedFor2024_6;
+        private void CheckForGM2024_6(UndertaleReader reader)
+        {
+            if (!reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2) || reader.undertaleData.IsVersionAtLeast(2024, 6))
+            {
+                checkedFor2024_6 = true;
+                return;
+            }
+
+            long returnTo = reader.Position;
+            long chunkStartPos = reader.AbsPosition;
+
+            // Calculate the expected end position of the first sprite where the bbox size differs from width/height
+            uint spriteCount = reader.ReadUInt32();
+            for (int i = 0; i < spriteCount; i++)
+            {
+                // Go to sprite's start position
+                reader.Position = returnTo + 4 + (4 * i);
+                uint spritePtr = reader.ReadUInt32();
+                uint nextSpritePtr = 0;
+                if ((i + 1) < spriteCount)
+                    nextSpritePtr = reader.ReadUInt32();
+                reader.AbsPosition = spritePtr + 4 /* skip name */;
+
+                // Check if bbox size differs from width/height
+                uint width = reader.ReadUInt32();
+                uint height = reader.ReadUInt32();
+                int marginLeft = reader.ReadInt32();
+                int marginRight = reader.ReadInt32();
+                int marginBottom = reader.ReadInt32();
+                int marginTop = reader.ReadInt32();
+                (uint bboxWidth, uint bboxHeight) = UndertaleSprite.CalculateBboxMaskDimensions(marginRight, marginLeft, marginBottom, marginTop);
+                (uint normalWidth, uint normalHeight) = UndertaleSprite.CalculateFullMaskDimensions(width, height);
+                if (bboxWidth == normalWidth && bboxHeight == normalHeight)
+                {
+                    // We can't determine anything from this sprite
+                    continue;
+                }
+                
+                reader.Position += 28;
+
+                if (reader.ReadInt32() == -1)
+                {
+                    uint sVersion = reader.ReadUInt32();
+                    UndertaleSprite.SpriteType sSpriteType = (UndertaleSprite.SpriteType)reader.ReadUInt32();
+
+                    if (sSpriteType != UndertaleSprite.SpriteType.Normal)
+                    {
+                        // We can't determine anything from this sprite
+                        continue;
+                    }
+
+                    reader.Position += 8; // playback speed values
+
+                    if (sVersion != 3)
+                    {
+                        throw new IOException("Expected sprite version 3");
+                    }
+                    uint sequenceOffset = reader.ReadUInt32();
+                    uint nineSliceOffset = reader.ReadUInt32();
+
+                    // Skip past texture pointers
+                    uint textureCount = reader.ReadUInt32();
+                    reader.Position += textureCount * 4;
+
+                    // Calculate how much space the "full" and "bbox" mask data take up
+                    uint maskCount = reader.ReadUInt32();
+                    if (maskCount == 0)
+                    {
+                        // We can't determine anything from this sprite
+                        continue;
+                    }
+                    uint fullLength = (normalWidth + 7) / 8 * normalHeight;
+                    fullLength *= maskCount;
+                    if ((fullLength % 4) != 0)
+                        fullLength += (4 - (fullLength % 4));
+                    uint bboxLength = (bboxWidth + 7) / 8 * bboxHeight;
+                    bboxLength *= maskCount;
+                    if ((bboxLength % 4) != 0)
+                        bboxLength += (4 - (bboxLength % 4));
+
+                    // Calculate expected end offset
+                    long expectedEndOffset;
+                    bool endOffsetLenient = false;
+                    if (sequenceOffset != 0)
+                    {
+                        expectedEndOffset = sequenceOffset;
+                    }
+                    else if (nineSliceOffset != 0)
+                    {
+                        expectedEndOffset = nineSliceOffset;
+                    }
+                    else if (nextSpritePtr != 0)
+                    {
+                        expectedEndOffset = nextSpritePtr;
+                    }
+                    else
+                    {
+                        // Use chunk length, and be lenient with it (due to chunk padding)
+                        endOffsetLenient = true;
+                        expectedEndOffset = chunkStartPos + Length;
+                    }
+
+                    // If the "full" mask data runs past the expected end offset, and the "bbox" mask data does not, then this is 2024.6.
+                    // Otherwise, stop processing and assume this is not 2024.6.
+                    long fullEndPos = (reader.AbsPosition + fullLength);
+                    if (fullEndPos != expectedEndOffset)
+                    {
+                        if (endOffsetLenient && (fullEndPos % 16) != 0 && fullEndPos + (16 - (fullEndPos % 16)) == expectedEndOffset)
+                        {
+                            // "Full" mask data doesn't exactly line up, but works if rounded up to the next chunk padding
+                            break;
+                        }
+
+                        long bboxEndPos = (reader.AbsPosition + bboxLength);
+                        if (bboxEndPos == expectedEndOffset)
+                        {
+                            // "Bbox" mask data is valid
+                            reader.undertaleData.SetGMS2Version(2024, 6);
+                        }
+                        else if (endOffsetLenient && (bboxEndPos % 16) != 0 && bboxEndPos + (16 - (bboxEndPos % 16)) == expectedEndOffset)
+                        {
+                            // "Bbox" mask data doesn't exactly line up, but works if rounded up to the next chunk padding
+                            reader.undertaleData.SetGMS2Version(2024, 6);
+                        }
+                        else
+                        {
+                            // Neither option seems to have worked...
+                            throw new IOException("Failed to detect mask type in 2024.6 detection");
+                        }
+                    }
+                    else
+                    {
+                        // "Full" mask data is valid
+                        break;
+                    }
+                }
+                else
+                {
+                    throw new IOException("Expected special sprite type");
+                }
+            }
+
+            reader.Position = returnTo;
+            checkedFor2024_6 = true;
+        }
+
+        internal override void UnserializeChunk(UndertaleReader reader)
+        {
+            if (!checkedFor2024_6)
+                CheckForGM2024_6(reader);
+
+            base.UnserializeChunk(reader);
+        }
+
+        internal override uint UnserializeObjectCount(UndertaleReader reader)
+        {
+            checkedFor2024_6 = false;
+
+            CheckForGM2024_6(reader);
+
+            return base.UnserializeObjectCount(reader);
+        }
     }
 
     public class UndertaleChunkBGND : UndertaleAlignUpdatedListChunk<UndertaleBackground>


### PR DESCRIPTION
## Description
Adds save/load support for new structures introduced in 2024.6, including text items in rooms, an additional field in sound assets, and collision masks in sprites that now depend on bounding box size instead of width/height.

### Caveats
This does not account for some of the variable changes that came in earlier releases, so 2024.6 games may still fail to load until changes are merged from the upcoming Underanalyzer branch.
