### PR TITLE
Restore 2.3.1 version check (part 2)

### DIFF
--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -133,6 +133,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
             Name = reader.ReadUndertaleString();
             Function = (FunctionType)reader.ReadUInt32();
             Iterations = reader.ReadUInt32();
+
             // This check is partly duplicated from UndertaleChunks.cs, but it's necessary to handle embedded curves
             // (for example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
             if (!reader.undertaleData.IsVersionAtLeast(2, 3, 1))
@@ -156,6 +157,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
 
                 reader.AbsPosition = returnPosition;
             }
+
             Points = reader.ReadUndertaleObject<UndertaleSimpleList<Point>>();
         }
 

--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -134,6 +134,14 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
             Function = (FunctionType)reader.ReadUInt32();
             Iterations = reader.ReadUInt32();
 
+            Points = reader.ReadUndertaleObject<UndertaleSimpleList<Point>>();
+        }
+
+        /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
+        public static uint UnserializeChildObjectCount(UndertaleReader reader)
+        {
+            reader.Position += 12;
+
             // This check is partly duplicated from UndertaleChunks.cs, but it's necessary to handle embedded curves
             // (For example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
             if (!reader.undertaleData.IsVersionAtLeast(2, 3, 1))
@@ -157,14 +165,6 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
 
                 reader.AbsPosition = returnPosition;
             }
-
-            Points = reader.ReadUndertaleObject<UndertaleSimpleList<Point>>();
-        }
-
-        /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
-        public static uint UnserializeChildObjectCount(UndertaleReader reader)
-        {
-            reader.Position += 12;
 
             // "Points"
             uint count = reader.ReadUInt32();

--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -142,13 +142,15 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
         {
             reader.Position += 12;
 
+            // Read the number of points in the curve
+            uint pointCount = reader.ReadUInt32();
+
             // This check is partly duplicated from UndertaleChunks.cs, but it's necessary to handle embedded curves
             // (For example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
             if (!reader.undertaleData.IsVersionAtLeast(2, 3, 1))
             {
                 long returnPosition = reader.AbsPosition;
-                uint numPoints = reader.ReadUInt32();
-                if (numPoints > 0)
+                if (pointCount > 0)
                 {
                     reader.AbsPosition += 8;
                     if (reader.ReadUInt32() != 0) // In 2.3 an int with the value of 0 would be set here,
@@ -162,18 +164,16 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
                                                                            // Then BezierY0 equals to 0 as well (the current check)
                     }
                 }
-
                 reader.AbsPosition = returnPosition;
             }
 
             // "Points"
-            uint count = reader.ReadUInt32();
             if (reader.undertaleData.IsVersionAtLeast(2, 3, 1))
-                reader.Position += 24 * count;
+                reader.Position += 24 * pointCount;
             else
-                reader.Position += 12 * count;
+                reader.Position += 12 * pointCount;
 
-            return 1 + count;
+            return 1 + pointCount;
         }
 
         /// <inheritdoc/>

--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -135,7 +135,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
             Iterations = reader.ReadUInt32();
 
             // This check is partly duplicated from UndertaleChunks.cs, but it's necessary to handle embedded curves
-            // (for example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
+            // (For example, those in SEQN in the TS!Underswap v1.0 demo; see issue #1414)
             if (!reader.undertaleData.IsVersionAtLeast(2, 3, 1))
             {
                 long returnPosition = reader.AbsPosition;
@@ -143,7 +143,7 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
                 if (numPoints > 0)
                 {
                     reader.AbsPosition += 8;
-                    if (reader.ReadUInt32() != 0) // in 2.3 a int with the value of 0 would be set here,
+                    if (reader.ReadUInt32() != 0) // In 2.3 a int with the value of 0 would be set here,
                     {                             // it cannot be version 2.3 if this value isn't 0
                         reader.undertaleData.SetGMS2Version(2, 3, 1);
                     }

--- a/UndertaleModLib/Models/UndertaleAnimationCurve.cs
+++ b/UndertaleModLib/Models/UndertaleAnimationCurve.cs
@@ -151,15 +151,15 @@ public class UndertaleAnimationCurve : UndertaleNamedResource, IDisposable
                 if (numPoints > 0)
                 {
                     reader.AbsPosition += 8;
-                    if (reader.ReadUInt32() != 0) // In 2.3 a int with the value of 0 would be set here,
-                    {                             // it cannot be version 2.3 if this value isn't 0
+                    if (reader.ReadUInt32() != 0) // In 2.3 an int with the value of 0 would be set here,
+                    {                             // It cannot be version 2.3 if this value isn't 0
                         reader.undertaleData.SetGMS2Version(2, 3, 1);
                     }
                     else
                     {
                         if (reader.ReadUInt32() == 0)                      // At all points (besides the first one)
-                            reader.undertaleData.SetGMS2Version(2, 3, 1);  // if BezierX0 equals to 0 (the above check)
-                                                                           // then BezierY0 equals to 0 as well (the current check)
+                            reader.undertaleData.SetGMS2Version(2, 3, 1);  // If BezierX0 equals to 0 (the above check)
+                                                                           // Then BezierY0 equals to 0 as well (the current check)
                     }
                 }
 

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1527,8 +1527,8 @@ namespace UndertaleModLib
             reader.AbsPosition = reader.ReadUInt32(); // Go to the first "Point"
             reader.Position += 8;
 
-            if (reader.ReadUInt32() != 0) // In 2.3 a int with the value of 0 would be set here,
-            {                             // it cannot be version 2.3 if this value isn't 0
+            if (reader.ReadUInt32() != 0) // In 2.3 an int with the value of 0 would be set here,
+            {                             // It cannot be version 2.3 if this value isn't 0
                 reader.undertaleData.SetGMS2Version(2, 3, 1);
             }
             else

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1504,6 +1504,8 @@ namespace UndertaleModLib
         public override string Name => "ACRV";
 
         private static bool checkedForGMS2_3_1;
+
+        // See also a similar check in UndertaleAnimationCurve.cs, necessary for embedded animation curves.
         private void CheckForGMS2_3_1(UndertaleReader reader)
         {
             if (reader.undertaleData.IsVersionAtLeast(2, 3, 1))
@@ -1522,10 +1524,10 @@ namespace UndertaleModLib
                 return;
             }
 
-            reader.AbsPosition = reader.ReadUInt32(); // go to the first "Point"
+            reader.AbsPosition = reader.ReadUInt32(); // Go to the first "Point"
             reader.Position += 8;
 
-            if (reader.ReadUInt32() != 0) // in 2.3 a int with the value of 0 would be set here,
+            if (reader.ReadUInt32() != 0) // In 2.3 a int with the value of 0 would be set here,
             {                             // it cannot be version 2.3 if this value isn't 0
                 reader.undertaleData.SetGMS2Version(2, 3, 1);
             }


### PR DESCRIPTION
## Description
See https://github.com/UnderminersTeam/UndertaleModTool/pull/1696; this just moves the check to the object count unserialization stage, preventing the warning that can occur otherwise. Closes https://github.com/UnderminersTeam/UndertaleModTool/issues/1414.

## Notes
I think it's OK that this can potentially yield false positives/negatives, as the original PR says, because newer GM versions bypass this check altogether.