### PR TITLE
Fix external textures being counted in object pool

### DIFF
--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1431,17 +1431,6 @@ namespace UndertaleModLib
 
             CheckFor2022_3And5(reader);
 
-            uint txtrSize = UndertaleEmbeddedTexture.ChildObjectsSize;
-            if (reader.undertaleData.IsVersionAtLeast(2, 0, 6))
-                txtrSize += 4; // "GeneratedMips"
-            if (reader.undertaleData.IsVersionAtLeast(2022, 3))
-                txtrSize += 4; // "TextureBlockSize"
-            if (reader.undertaleData.IsVersionAtLeast(2022, 9))
-                txtrSize += 12;
-
-            if (txtrSize != UndertaleEmbeddedTexture.ChildObjectsSize)
-                reader.SetStaticChildObjectsSize(typeof(UndertaleEmbeddedTexture), txtrSize);
-
             // Texture blobs are already included in the count
             return base.UnserializeObjectCount(reader);
         }


### PR DESCRIPTION
## Description
Fixes https://github.com/UnderminersTeam/UndertaleModTool/issues/1684, fixes https://github.com/UnderminersTeam/UndertaleModTool/issues/1811, and fixes https://github.com/UnderminersTeam/UndertaleModTool/issues/1646, by preventing external textures from having their (nonexistent) texture blob objects counted as part of the object pool.

### Notes
Tested on a variety of GameMaker versions already; should be stable.