### PR TITLE
Alternate right-hand side special parentheses handling

### DIFF
--- a/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionTwo.cs
+++ b/UndertaleModLib/Decompiler/Instructions/Decompiler.ExpressionTwo.cs
@@ -65,6 +65,10 @@ public static partial class Decompiler
                     _ => 0,
                 };
 
+                // The second argument needs parentheses even if the operation level is equal, not just less; e.g. a - (b + c)
+                // Even some cases that match mathematically will recompile differently without right-hand parentheses e.g. a + (b + c)
+                if (isSecond)
+                    argPriorityLevel--;
 
                 // Suppose we have "(arg1a argOp arg1b) opcode argument2", and are wondering whether the depicted parentheses are needed
                 // If the argument's opcode is more highly-prioritized than our own, such as it being multiplication
@@ -76,10 +80,6 @@ public static partial class Decompiler
                 if (outerPriorityLevel == 0)
                     needsParens = true; // Better safe than sorry
                 
-                // Non-commutative operators may still need parentheses, e.g `a - (b - c)`
-                bool nonCommutative = Opcode is UndertaleInstruction.Opcode.Sub or UndertaleInstruction.Opcode.Div;
-                if (isSecond && nonCommutative && Opcode == argumentAsBinaryExpression.Opcode)
-                    needsParens = true;
             }
 
             return (needsParens ? String.Format("({0})", arg) : arg);


### PR DESCRIPTION
## Description
This replaces the ExpressionTwo parentheses special check for right-side parentheses with a simpler one that covers more cases. For example, the previous solution correctly adds parentheses to `a - (b - c)` but not `a - (b + c)` or (technically different though functionally the same) `a + (b + c)`. This shouldn't cause any problems with the left side; we aren't going back to `((a + b) + c) + d`. Closes #1833 (not all examples given there will decompile 1:1 with this change, but those that don't match had redundant parentheses to begin with).

### Caveats
N/A

### Notes
Nobody commented on whether this seemed like a good fix in the Discord. Also, Underanalyzer completely redoes this anyway.