### PR TITLE
Fix 2022.0.2 detection

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -295,7 +295,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             writer.Write(AscenderOffset);
         if (writer.undertaleData.IsVersionAtLeast(2022, 2))
             writer.Write(Ascender);
-        if (writer.undertaleData.IsVersionAtLeast(2023, 2))
+        if (writer.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
             writer.Write(SDFSpread);
         if (writer.undertaleData.IsVersionAtLeast(2023, 6))
             writer.Write(LineHeight);
@@ -335,7 +335,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             AscenderOffset = reader.ReadInt32();
         if (reader.undertaleData.IsVersionAtLeast(2022, 2))
             Ascender = reader.ReadUInt32();
-        if (reader.undertaleData.IsVersionAtLeast(2023, 2))
+        if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
             SDFSpread = reader.ReadUInt32();
         if (reader.undertaleData.IsVersionAtLeast(2023, 6))
             LineHeight = reader.ReadUInt32();
@@ -350,7 +350,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
             skipSize += 4; // AscenderOffset
         if (reader.undertaleData.IsVersionAtLeast(2022, 2))
             skipSize += 4; // Ascender
-        if (reader.undertaleData.IsVersionAtLeast(2023, 2))
+        if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2))
             skipSize += 4; // SDFSpread
         if (reader.undertaleData.IsVersionAtLeast(2023, 6))
             skipSize += 4; // LineHeight

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -754,7 +754,10 @@ namespace UndertaleModLib
             if (reader.ReadUInt32() > 0) // Font count
             {
                 uint firstFontPointer = reader.ReadUInt32();
-                reader.AbsPosition = firstFontPointer + 56; // Two more values: SDFSpread and LineHeight. 48 + 4 + 4 = 56.
+                reader.AbsPosition = firstFontPointer + 52; // Also the LineHeight value. 48 + 4 = 52.
+                if (reader.undertaleData.IsNonLTSVersionAtLeast(2023, 2)) // SDFSpread is present from 2023.2 non-LTS onward
+                    reader.AbsPosition += 4;                              // (detected by PSEM/PSYS chunk existence)
+
                 uint glyphsLength = reader.ReadUInt32();
                 GMS2023_6 = true;
                 if ((glyphsLength * 4) > this.Length)


### PR DESCRIPTION
## Description
This ACTUALLY fixes 2022.0.2 (and presumably 2022.0.3) detection. Our previous test case, the AntonBlast Demo (#1729), was erroneously detecting as "2023.2, but actually LTS 2022.0" instead of "2023.6, but actually LTS 2022.0", which loaded successfully but doesn't extend to other test cases (and loaded the SDFSpread value instead of LineHeight). This error has been present since merging #1737.

### Caveats
N/A

### Notes
A test LTS project which now loads, built by Colinator27, is attached.
[TestLTSProject.zip](https://github.com/user-attachments/files/16397539/TestLTSProject.zip)