### PR TITLE
Dont publish release bulids of bleeding edge

### DIFF
--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        configuration: [Debug, Release]
+        configuration: [Debug]
         bundled: [true]
         singlefile: [true, false]
 
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        configuration: [Debug, Release]
+        configuration: [Debug]
         bundled: [true]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
## Description
Bleeding edge builds are not stable, and are intended to be a preview build to inform us better about bugs
Release builds hinder there, as they contain less debug information.
Also makes CI slightly faster/less spammy

### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

### Notes
<!-- Any notes or closing words -->