### PR TITLE
Fix new mask data dimensions when saving

### DIFF
--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -514,7 +514,9 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
             writer.Write((byte)0);
             total++;
         }
-        Util.DebugUtil.Assert(total == CalculateMaskDataSize(Width, Height, (uint)CollisionMasks.Count), "Invalid mask data for sprite");
+
+        (uint width, uint height) = CalculateMaskDimensions(writer.undertaleData);
+        Util.DebugUtil.Assert(total == CalculateMaskDataSize(width, height, (uint)CollisionMasks.Count), "Invalid mask data for sprite");
     }
 
     private static byte[] DecodeSpineBlob(byte[] blob)


### PR DESCRIPTION
## Description
The PR introducing 2024.6 support forgot to account for mask dimensions when saving, so this corrects that. Fixes https://github.com/UnderminersTeam/UndertaleModTool/issues/1855, although I do not have the game on hand personally. *EDIT: Has now been tested, and this seems to work.*

### Caveats
This won't affect any games prior to GameMaker 2024.4, so there are likely no caveats to existing games we fully support.

### Notes
This should be fine to merge in prior to the next major release, as the risk is very low.
However, I would like to see if this fixes https://github.com/UnderminersTeam/UndertaleModTool/issues/1855 before doing so. *EDIT: Has now been tested, and this seems to work.*