### PR TITLE
Some serialization cleanup, optimization, fixes

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -412,13 +412,13 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
         /// <inheritdoc />
         public void Serialize(UndertaleWriter writer)
         {
-            Serialize(writer, writer.undertaleData.IsVersionAtLeast(2022, 3), writer.undertaleData.IsVersionAtLeast(2022, 5));
+            Serialize(writer, writer.undertaleData.IsVersionAtLeast(2022, 5));
         }
 
         /// <summary>
         /// Serializes the texture to any type of writer (can be any destination file).
         /// </summary>
-        public void Serialize(FileBinaryWriter writer, bool gm2022_3, bool gm2022_5)
+        public void Serialize(FileBinaryWriter writer, bool gm2022_5)
         {
             if (FormatQOI)
             {
@@ -430,7 +430,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
                     using Bitmap bmp = TextureWorker.GetImageFromByteArray(TextureBlob);
                     writer.Write((short)bmp.Width);
                     writer.Write((short)bmp.Height);
-                    byte[] qoiData = QoiConverter.GetArrayFromImage(bmp, gm2022_3 ? 0 : 4);
+                    byte[] qoiData = QoiConverter.GetArrayFromImage(bmp);
                     using MemoryStream input = new MemoryStream(qoiData);
                     if (sharedStream.Length != 0)
                         sharedStream.Seek(0, SeekOrigin.Begin);
@@ -443,7 +443,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
                 {
                     // Encode the PNG data back to QOI
                     using Bitmap bmp = TextureWorker.GetImageFromByteArray(TextureBlob);
-                    writer.Write(QoiConverter.GetSpanFromImage(bmp, gm2022_3 ? 0 : 4));
+                    writer.Write(QoiConverter.GetSpanFromImage(bmp));
                 }
             }
             else

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -313,7 +313,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
         // since the float is always written negated, it has the first bit set.
         if ((readEmSize & (1 << 31)) != 0)
         {
-            float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(EmSize), 0);
+            float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(readEmSize), 0);
             EmSize = fsize;
             EmSizeIsFloat = true;
         }

--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -313,7 +313,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
         // since the float is always written negated, it has the first bit set.
         if ((readEmSize & (1 << 31)) != 0)
         {
-            float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(readEmSize), 0);
+            float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(EmSize), 0);
             EmSize = fsize;
             EmSizeIsFloat = true;
         }

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -764,13 +764,13 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
                     switch (spineVersion)
                     {
                         case 1:
-                            reader.Position += 8 + jsonLength + atlasLength + textures;
+                            reader.Position += 8 + (uint)jsonLength + (uint)atlasLength + (uint)textures;
                             break;
 
                         case 2:
                         case 3:
                         {
-                            reader.Position += jsonLength + atlasLength;
+                            reader.Position += (uint)jsonLength + (uint)atlasLength;
 
                             // TODO: make this return count instead if spine sprite
                             // couldn't have sequence or nine slices data.

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1167,7 +1167,7 @@ namespace UndertaleModLib
 
                     reader.Position += 32;
                     int effectCount = reader.ReadInt32();
-                    reader.Position += effectCount * 12 + 4;
+                    reader.Position += (uint)effectCount * 12 + 4;
 
                     int tileMapWidth = reader.ReadInt32();
                     int tileMapHeight = reader.ReadInt32();

--- a/UndertaleModLib/Util/AdaptiveBinaryReader.cs
+++ b/UndertaleModLib/Util/AdaptiveBinaryReader.cs
@@ -86,10 +86,8 @@ namespace UndertaleModLib.Util
             {
                 if (isUsingBufferReader)
                 {
-#if DEBUG
-                    if (value > Length)
+                    if (value < 0 || value > Length)
                         throw new IOException("Reading out of bounds.");
-#endif
                     bufferBinaryReader.Position = value - bufferBinaryReader.ChunkStartPosition + 8;
                 }
                 else

--- a/UndertaleModLib/Util/BufferBinaryReader.cs
+++ b/UndertaleModLib/Util/BufferBinaryReader.cs
@@ -27,6 +27,11 @@ namespace UndertaleModLib.Util
 
             public int Read(byte[] buffer, int count)
             {
+                if (count < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count));
+                }
+
                 int n = _length - _position;
                 if (n > count)
                     n = count;
@@ -75,6 +80,9 @@ namespace UndertaleModLib.Util
 
             public void Write(byte[] buffer, int count)
             {
+                if (count < 0)
+                    throw new ArgumentOutOfRangeException(nameof(count));
+
                 int i = _position + count;
                 if (i < 0)
                     throw new IOException("Writing out of the chunk buffer bounds.");
@@ -174,6 +182,10 @@ namespace UndertaleModLib.Util
 
         public string ReadChars(int count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             if (chunkBuffer.Position + count > _length)
             {
                 throw new IOException("Reading out of chunk bounds");
@@ -198,6 +210,10 @@ namespace UndertaleModLib.Util
 
         public byte[] ReadBytes(int count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             if (chunkBuffer.Position + count > _length)
             {
                 throw new IOException("Reading out of chunk bounds");
@@ -268,6 +284,8 @@ namespace UndertaleModLib.Util
 
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
 
+            if (length < 0)
+                throw new IOException("Invalid string length");
             if (chunkBuffer.Position + length + 1 >= _length)
                 throw new IOException("Reading out of chunk bounds");
 
@@ -293,9 +311,12 @@ namespace UndertaleModLib.Util
 
             return res;
         }
+
         public void SkipGMString()
         {
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+            if (length < 0)
+                throw new IOException("Invalid string length");
             Position += (uint)length + 1;
         }
 

--- a/UndertaleModLib/Util/FileBinaryReader.cs
+++ b/UndertaleModLib/Util/FileBinaryReader.cs
@@ -21,10 +21,8 @@ namespace UndertaleModLib.Util
             get => Stream.Position;
             set
             {
-#if DEBUG
-                if (value > Length)
+                if (value < 0 || value > Length)
                     throw new IOException("Reading out of bounds.");
-#endif
                 Stream.Position = value;
             }
         }
@@ -49,10 +47,11 @@ namespace UndertaleModLib.Util
 
         public byte ReadByte()
         {
-#if DEBUG
             if (Stream.Position + 1 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return (byte)Stream.ReadByte();
         }
 
@@ -63,10 +62,15 @@ namespace UndertaleModLib.Util
 
         public string ReadChars(int count)
         {
-#if DEBUG
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             if (Stream.Position + count > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             if (count > 1024)
             {
                 byte[] buf = new byte[count];
@@ -85,10 +89,15 @@ namespace UndertaleModLib.Util
 
         public byte[] ReadBytes(int count)
         {
-#if DEBUG
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             if (Stream.Position + count > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             byte[] val = new byte[count];
             Stream.Read(val, 0, count);
             return val;
@@ -96,107 +105,118 @@ namespace UndertaleModLib.Util
 
         public short ReadInt16()
         {
-#if DEBUG
             if (Stream.Position + 2 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BinaryPrimitives.ReadInt16LittleEndian(ReadToBuffer(2));
         }
 
         public ushort ReadUInt16()
         {
-#if DEBUG
             if (Stream.Position + 2 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BinaryPrimitives.ReadUInt16LittleEndian(ReadToBuffer(2));
         }
 
         public int ReadInt24()
         {
-#if DEBUG
             if (Stream.Position + 3 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             ReadToBuffer(3);
             return buffer[0] | buffer[1] << 8 | (sbyte)buffer[2] << 16;
         }
 
         public uint ReadUInt24()
         {
-#if DEBUG
             if (Stream.Position + 3 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             ReadToBuffer(3);
             return (uint)(buffer[0] | buffer[1] << 8 | buffer[2] << 16);
         }
 
         public int ReadInt32()
         {
-#if DEBUG
             if (Stream.Position + 4 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
         }
 
         public uint ReadUInt32()
         {
-#if DEBUG
             if (Stream.Position + 4 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BinaryPrimitives.ReadUInt32LittleEndian(ReadToBuffer(4));
         }
 
         public float ReadSingle()
         {
-#if DEBUG
             if (Stream.Position + 4 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4)));
         }
 
         public double ReadDouble()
         {
-#if DEBUG
             if (Stream.Position + 8 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(ReadToBuffer(8)));
         }
 
         public long ReadInt64()
         {
-#if DEBUG
             if (Stream.Position + 8 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BinaryPrimitives.ReadInt64LittleEndian(ReadToBuffer(8));
         }
 
         public ulong ReadUInt64()
         {
-#if DEBUG
             if (Stream.Position + 8 > _length)
+            {
                 throw new IOException("Reading out of bounds");
-#endif
+            }
+
             return BinaryPrimitives.ReadUInt64LittleEndian(ReadToBuffer(8));
         }
 
         public string ReadGMString()
         {
-#if DEBUG
             if (Stream.Position + 5 > _length)
                 throw new IOException("Reading out of bounds");
-#endif
+
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
-#if DEBUG
+
+            if (length < 0)
+                throw new IOException("Invalid string length");
             if (Stream.Position + length + 1 >= _length)
                 throw new IOException("Reading out of bounds");
-#endif
+
             string res;
             if (length > 1024)
             {
@@ -210,18 +230,20 @@ namespace UndertaleModLib.Util
                 Stream.Read(buf);
                 res = encoding.GetString(buf);
             }
-            
-#if DEBUG
+
             if (Stream.ReadByte() != 0)
+            {
                 throw new IOException("String not null terminated!");
-#else
-            Position++;
-#endif
+            }
+
             return res;
         }
+
         public void SkipGMString()
         {
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+            if (length < 0)
+                throw new IOException("Invalid string length");
             Position += (uint)length + 1;
         }
 

--- a/UndertaleModLib/Util/QoiConverter.cs
+++ b/UndertaleModLib/Util/QoiConverter.cs
@@ -187,19 +187,17 @@ namespace UndertaleModLib.Util
         /// Creates a QOI image as a byte array from a <see cref="Bitmap"/>.
         /// </summary>
         /// <param name="bmp">The <see cref="Bitmap"/> to create the QOI image from.</param>
-        /// <param name="padding">The amount of bytes of padding that should be used.</param>
         /// <returns>A QOI Image as a byte array.</returns>
         /// <exception cref="Exception">If there was an error with stride width.</exception>
-        public static byte[] GetArrayFromImage(Bitmap bmp, int padding = 4) => GetSpanFromImage(bmp, padding).ToArray();
+        public static byte[] GetArrayFromImage(Bitmap bmp) => GetSpanFromImage(bmp).ToArray();
 
         /// <summary>
         /// Creates a QOI image as a <see cref="Span{TKey}"/> from a <see cref="Bitmap"/>.
         /// </summary>
         /// <param name="bmp">The <see cref="Bitmap"/> to create the QOI image from.</param>
-        /// <param name="padding">The amount of bytes of padding that should be used.</param>
         /// <returns>A QOI Image as a byte array.</returns>
         /// <exception cref="Exception">If there was an error with stride width.</exception>
-        public static unsafe Span<byte> GetSpanFromImage(Bitmap bmp, int padding = 4)
+        public static unsafe Span<byte> GetSpanFromImage(Bitmap bmp)
         {
             if (!isBufferEmpty)
                 Array.Clear(sharedBuffer);
@@ -312,9 +310,6 @@ namespace UndertaleModLib.Util
             }
 
             bmp.UnlockBits(data);
-
-            // Add padding
-            resPos += padding;
 
             // Write final length
             int length = resPos - HeaderSize;


### PR DESCRIPTION
## Description
- Removed more cases of `#if DEBUG`, to ensure consistent behavior on Release builds.
- Added more safety checks to binary readers, and to deserialization in general (preventing unintended negative lengths/jumps that could lead to infinite loops).
- ~~Fixed `EmSize` on fonts (when in float form) being accidentally always parsed as 0, due to a typo.~~
- Completely refactored code instruction deserialization, removing many calls and I/O operations.
- Commented and reformatted code instruction deserialization/serialization.
- Fixed QOI padding being added when saving, when none seems to have ever actually existed.

### Caveats
Has potential to break some instruction parsing if I typo'd somewhere, but I did test it on multiple games (including Undertale 1.00, a bytecode 14 game), and it seems to work fine. If it does break, it'll be pretty obvious, as re-saving a data.win file will show differences in the code.

### Notes
Probably too risky to merge into stable, ~~although in the event that we make a minor release, we may want to backport the `EmSize` typo fix, as that is pretty diabolical~~. It affects the Deltarune Chapter 1 & 2 demo, version 1.15 (which I tested this PR on).