### PR TITLE
Fix EmSize being always parsed as 0, if a float

### DIFF
--- a/UndertaleModLib/Models/UndertaleFont.cs
+++ b/UndertaleModLib/Models/UndertaleFont.cs
@@ -313,7 +313,7 @@ public class UndertaleFont : UndertaleNamedResource, IDisposable
         // since the float is always written negated, it has the first bit set.
         if ((readEmSize & (1 << 31)) != 0)
         {
-            float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(EmSize), 0);
+            float fsize = -BitConverter.ToSingle(BitConverter.GetBytes(readEmSize), 0);
             EmSize = fsize;
             EmSizeIsFloat = true;
         }


### PR DESCRIPTION
## Description
Fixes a typo that causes EmSize to always be parsed as 0, if stored as floating point.

### Caveats
N/A

### Notes
Should be good for 0.6.0.1.