### PR TITLE
Mark nightly releases as prereleases

### DIFF
--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -118,7 +118,7 @@ jobs:
       with:
         tag_name: bleeding-edge
         name: Bleeding Edge
-        prerelease: false
+        prerelease: true
         fail_on_unmatched_files: true
         files: |
           */*


### PR DESCRIPTION
## Description
In preparation of upcoming experimental changes to the main branch, we should make sure that bleeding edge/nightly releases are correctly marked as prereleases.

### Caveats
Slightly harder to find the bleeding edge release (as it's no longer the default release), but this is intentional.

### Notes
We may want to also change the name of these releases as well, but this will suffice for now, at least.