### PR TITLE
Add negative length checks during deserialization

### DIFF
--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -764,13 +764,13 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
                     switch (spineVersion)
                     {
                         case 1:
-                            reader.Position += 8 + jsonLength + atlasLength + textures;
+                            reader.Position += 8 + (uint)jsonLength + (uint)atlasLength + (uint)textures;
                             break;
 
                         case 2:
                         case 3:
                         {
-                            reader.Position += jsonLength + atlasLength;
+                            reader.Position += (uint)jsonLength + (uint)atlasLength;
 
                             // TODO: make this return count instead if spine sprite
                             // couldn't have sequence or nine slices data.

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1167,7 +1167,7 @@ namespace UndertaleModLib
 
                     reader.Position += 32;
                     int effectCount = reader.ReadInt32();
-                    reader.Position += effectCount * 12 + 4;
+                    reader.Position += (uint)effectCount * 12 + 4;
 
                     int tileMapWidth = reader.ReadInt32();
                     int tileMapHeight = reader.ReadInt32();

--- a/UndertaleModLib/Util/AdaptiveBinaryReader.cs
+++ b/UndertaleModLib/Util/AdaptiveBinaryReader.cs
@@ -86,7 +86,7 @@ namespace UndertaleModLib.Util
             {
                 if (isUsingBufferReader)
                 {
-                    if (value < 0 || value > Length
+                    if (value < 0 || value > Length)
                         throw new IOException("Reading out of bounds.");
                     bufferBinaryReader.Position = value - bufferBinaryReader.ChunkStartPosition + 8;
                 }

--- a/UndertaleModLib/Util/AdaptiveBinaryReader.cs
+++ b/UndertaleModLib/Util/AdaptiveBinaryReader.cs
@@ -87,7 +87,7 @@ namespace UndertaleModLib.Util
                 if (isUsingBufferReader)
                 {
 #if DEBUG
-                    if (value > Length)
+                    if (value < 0 || value > Length)
                         throw new IOException("Reading out of bounds.");
 #endif
                     bufferBinaryReader.Position = value - bufferBinaryReader.ChunkStartPosition + 8;

--- a/UndertaleModLib/Util/BufferBinaryReader.cs
+++ b/UndertaleModLib/Util/BufferBinaryReader.cs
@@ -27,6 +27,11 @@ namespace UndertaleModLib.Util
 
             public int Read(byte[] buffer, int count)
             {
+                if (count < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count));
+                }
+
                 int n = _length - _position;
                 if (n > count)
                     n = count;
@@ -75,6 +80,9 @@ namespace UndertaleModLib.Util
 
             public void Write(byte[] buffer, int count)
             {
+                if (count < 0)
+                    throw new ArgumentOutOfRangeException(nameof(count));
+
                 int i = _position + count;
                 if (i < 0)
                     throw new IOException("Writing out of the chunk buffer bounds.");
@@ -174,6 +182,10 @@ namespace UndertaleModLib.Util
 
         public string ReadChars(int count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             if (chunkBuffer.Position + count > _length)
             {
                 throw new IOException("Reading out of chunk bounds");
@@ -198,6 +210,10 @@ namespace UndertaleModLib.Util
 
         public byte[] ReadBytes(int count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
             if (chunkBuffer.Position + count > _length)
             {
                 throw new IOException("Reading out of chunk bounds");
@@ -268,6 +284,8 @@ namespace UndertaleModLib.Util
 
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
 
+            if (length < 0)
+                throw new IOException("Invalid string length");
             if (chunkBuffer.Position + length + 1 >= _length)
                 throw new IOException("Reading out of chunk bounds");
 
@@ -293,9 +311,12 @@ namespace UndertaleModLib.Util
 
             return res;
         }
+
         public void SkipGMString()
         {
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+            if (length < 0)
+                throw new IOException("Invalid string length");
             Position += (uint)length + 1;
         }
 

--- a/UndertaleModLib/Util/FileBinaryReader.cs
+++ b/UndertaleModLib/Util/FileBinaryReader.cs
@@ -63,6 +63,10 @@ namespace UndertaleModLib.Util
 
         public string ReadChars(int count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
 #if DEBUG
             if (Stream.Position + count > _length)
                 throw new IOException("Reading out of bounds");
@@ -85,6 +89,10 @@ namespace UndertaleModLib.Util
 
         public byte[] ReadBytes(int count)
         {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
 #if DEBUG
             if (Stream.Position + count > _length)
                 throw new IOException("Reading out of bounds");
@@ -193,6 +201,8 @@ namespace UndertaleModLib.Util
                 throw new IOException("Reading out of bounds");
 #endif
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+            if (length < 0)
+                throw new IOException("Invalid string length");
 #if DEBUG
             if (Stream.Position + length + 1 >= _length)
                 throw new IOException("Reading out of bounds");
@@ -222,6 +232,8 @@ namespace UndertaleModLib.Util
         public void SkipGMString()
         {
             int length = BinaryPrimitives.ReadInt32LittleEndian(ReadToBuffer(4));
+            if (length < 0)
+                throw new IOException("Invalid string length");
             Position += (uint)length + 1;
         }
 


### PR DESCRIPTION
## Description
Added more safety checks to binary readers, and to deserialization in general (preventing unintended negative lengths/jumps that could lead to infinite loops).

### Caveats
None that I can think of, unless new bugs are accidentally introduced.

### Notes
Split up from previous serialization cleanup/optimization PR.