### PR TITLE
Fix string reading bounds checks

### DIFF
--- a/UndertaleModLib/Util/BufferBinaryReader.cs
+++ b/UndertaleModLib/Util/BufferBinaryReader.cs
@@ -286,7 +286,7 @@ namespace UndertaleModLib.Util
 
             if (length < 0)
                 throw new IOException("Invalid string length");
-            if (chunkBuffer.Position + length + 1 >= _length)
+            if (chunkBuffer.Position + length + 1 > _length)
                 throw new IOException("Reading out of chunk bounds");
 
             string res;

--- a/UndertaleModLib/Util/FileBinaryReader.cs
+++ b/UndertaleModLib/Util/FileBinaryReader.cs
@@ -214,7 +214,7 @@ namespace UndertaleModLib.Util
 
             if (length < 0)
                 throw new IOException("Invalid string length");
-            if (Stream.Position + length + 1 >= _length)
+            if (Stream.Position + length + 1 > _length)
                 throw new IOException("Reading out of bounds");
 
             string res;


### PR DESCRIPTION
## Description
Parsing GameMaker null-terminated strings had an off-by-one error in their bounds checks, so if a string appeared directly at the end of a stream, it would throw an exception. This corrects the comparison to no longer be off by one.

### Caveats
None that I am aware of, but if this triggers any actual bugs, it's probably extremely rare.

### Notes
Based on discussion on Discord, brought to our attention by @luizzeroxis.