### PR TITLE
Slightly reword asset ID hover tooltip

### DIFF
--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -141,7 +141,7 @@
             <Grid DockPanel.Dock="Bottom">
                 <local:TextBoxDark x:Name="CommandBox" AcceptsReturn="True" PreviewKeyDown="CommandBox_PreviewKeyDown" Margin="0,0,35,0"/>
                 <Label Content="None" HorizontalAlignment="Right" VerticalAlignment="Top" VerticalContentAlignment="Top" Name="ObjectLabel"
-                       ToolTip="This is an ID (index) of the currently open object. It starts from 0."
+                       ToolTip="This is an ID (index) of the currently open asset, item, or object. It starts from 0."
                        ToolTipService.InitialShowDelay="200"/>
             </Grid>
             <Grid>


### PR DESCRIPTION
## Description
Updated the tooltip you get when hovering over the ID in the bottom-right corner of the GUI. It's now more encompassing than just "object," since it can also be any asset (e.g. a sprite) or item (e.g. a texture page item or string).

### Caveats
Tooltip is now very slightly longer, but it's probably not an issue.
