### PR TITLE
Manually add DEBUG constant to nightly builds

### DIFF
--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -37,7 +37,7 @@ jobs:
         dotnet build UndertaleModTool --no-restore
         dotnet build UndertaleModToolUpdater --no-restore
     - name: Publish ${{ matrix.os }} GUI
-      run: |
+      run: | # FIXME: debug constant should automatically be applied, but for some reason it isn't
         dotnet publish UndertaleModTool -c ${{ matrix.configuration }} -r win-x64 -p:DefineConstants="SHOW_COMMIT_HASH;DEBUG" --self-contained ${{ matrix.bundled }} -p:PublishSingleFile=${{ matrix.singlefile }} --output ${{ matrix.os }}
         dotnet publish UndertaleModToolUpdater -c ${{ matrix.configuration }} -r win-x64 --self-contained ${{ matrix.bundled }} -p:PublishSingleFile=false --output ${{ matrix.os }}/Updater
     - name: Copy external files

--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -38,7 +38,7 @@ jobs:
         dotnet build UndertaleModToolUpdater --no-restore
     - name: Publish ${{ matrix.os }} GUI
       run: |
-        dotnet publish UndertaleModTool -c ${{ matrix.configuration }} -r win-x64 -p:DefineConstants="SHOW_COMMIT_HASH" --self-contained ${{ matrix.bundled }} -p:PublishSingleFile=${{ matrix.singlefile }} --output ${{ matrix.os }}
+        dotnet publish UndertaleModTool -c ${{ matrix.configuration }} -r win-x64 -p:DefineConstants="SHOW_COMMIT_HASH;DEBUG" --self-contained ${{ matrix.bundled }} -p:PublishSingleFile=${{ matrix.singlefile }} --output ${{ matrix.os }}
         dotnet publish UndertaleModToolUpdater -c ${{ matrix.configuration }} -r win-x64 --self-contained ${{ matrix.bundled }} -p:PublishSingleFile=false --output ${{ matrix.os }}/Updater
     - name: Copy external files
       run: |


### PR DESCRIPTION
## Description
It seems that the updater button has completely vanished from nightly/bleeding edge builds, presumably because `DEBUG` isn't being defined correctly. Not sure if we should apply this to other workflows, too.

### Caveats
Not sure if there's some other configuration thing I'm missing, or if this is how the compiler is meant to work.
