### PR TITLE
Issue #1898: Prevent NREs when adding new Texture Page Items or Embedded textures

### DIFF
--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -316,12 +316,12 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
         /// <summary>
         /// The width of the texture.
         /// </summary>
-        public int Width => _image.Width;
+        public int Width => _image?.Width ?? -1;
 
         /// <summary>
         /// The height of the texture.
         /// </summary>
-        public int Height => _image.Height;
+        public int Height => _image?.Height ?? -1;
 
         /// <summary>
         /// Whether this texture uses the QOI format.

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -316,21 +316,33 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
         /// <summary>
         /// The width of the texture.
         /// </summary>
+        /// <remarks>
+        /// In the case of an invalid or missing image, this will always be <c>-1</c>.
+        /// </remarks>
         public int Width => _image?.Width ?? -1;
 
         /// <summary>
         /// The height of the texture.
         /// </summary>
+        /// <remarks>
+        /// In the case of an invalid or missing image, this will always be <c>-1</c>.
+        /// </remarks>
         public int Height => _image?.Height ?? -1;
 
         /// <summary>
         /// Whether this texture uses the QOI format.
         /// </summary>
+        /// <remarks>
+        /// In the case of an invalid or missing image, this will always be <c>false</c>.
+        /// </remarks>
         public bool FormatQOI => _image.Format is GMImage.ImageFormat.Qoi or GMImage.ImageFormat.Bz2Qoi;
 
         /// <summary>
         /// Whether this texture uses the BZ2 format. (Always used in combination with QOI.)
         /// </summary>
+        /// <remarks>
+        /// In the case of an invalid or missing image, this will always be <c>false</c>.
+        /// </remarks>
         public bool FormatBZ2 => _image.Format is GMImage.ImageFormat.Bz2Qoi;
 
         /// <summary>

--- a/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
+++ b/UndertaleModLib/Models/UndertaleEmbeddedTexture.cs
@@ -333,7 +333,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
         /// Whether this texture uses the QOI format.
         /// </summary>
         /// <remarks>
-        /// In the case of an invalid or missing image, this will always be <c>false</c>.
+        /// In the case of an invalid or missing image, this will always be <see langword="false" />.
         /// </remarks>
         public bool FormatQOI => _image.Format is GMImage.ImageFormat.Qoi or GMImage.ImageFormat.Bz2Qoi;
 
@@ -341,7 +341,7 @@ public class UndertaleEmbeddedTexture : UndertaleNamedResource, IDisposable
         /// Whether this texture uses the BZ2 format. (Always used in combination with QOI.)
         /// </summary>
         /// <remarks>
-        /// In the case of an invalid or missing image, this will always be <c>false</c>.
+        /// In the case of an invalid or missing image, this will always be <see langword="false" />.
         /// </remarks>
         public bool FormatBZ2 => _image.Format is GMImage.ImageFormat.Bz2Qoi;
 

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -69,6 +69,9 @@ namespace UndertaleModTool
 
         private void UpdateImage(UndertaleEmbeddedTexture texture)
         {
+            if (texture.TextureData?.Image is null)
+                return;
+            
             GMImage image = texture.TextureData.Image;
             BitmapSource bitmap = mainWindow.GetBitmapSourceForImage(image);
             TexturePageImage.Source = bitmap;
@@ -88,8 +91,13 @@ namespace UndertaleModTool
             {
                 _textureDataContext.PropertyChanged -= ReloadTextureImage;
             }
+            
             _textureDataContext = texture.TextureData;
-            _textureDataContext.PropertyChanged += ReloadTextureImage;
+
+            if (_textureDataContext is not null)
+            {
+                _textureDataContext.PropertyChanged += ReloadTextureImage;
+            }
         }
 
         private void ReloadTextureImage(object sender, PropertyChangedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -70,8 +70,11 @@ namespace UndertaleModTool
         private void UpdateImage(UndertaleEmbeddedTexture texture)
         {
             if (texture.TextureData?.Image is null)
+            {
+                TexturePageImage.Source = null;
                 return;
-            
+            }
+
             GMImage image = texture.TextureData.Image;
             BitmapSource bitmap = mainWindow.GetBitmapSourceForImage(image);
             TexturePageImage.Source = bitmap;

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -40,6 +40,9 @@ namespace UndertaleModTool
 
         private void UpdateImages(UndertaleTexturePageItem item)
         {
+            if (item.TexturePage?.TextureData?.Image is null)
+                return;
+            
             GMImage image = item.TexturePage.TextureData.Image;
             BitmapSource bitmap = mainWindow.GetBitmapSourceForImage(image);
             ItemTextureBGImage.Source = bitmap;
@@ -68,8 +71,12 @@ namespace UndertaleModTool
             {
                 _textureDataContext.PropertyChanged -= ReloadTextureImage;
             }
-            _textureDataContext = item.TexturePage.TextureData;
-            _textureDataContext.PropertyChanged += ReloadTextureImage;
+
+            if (item.TexturePage?.TextureData is not null)
+            {
+                _textureDataContext = item.TexturePage.TextureData;
+                _textureDataContext.PropertyChanged += ReloadTextureImage;
+            }
         }
 
         private void ReloadTexturePage(object sender, PropertyChangedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -41,8 +41,12 @@ namespace UndertaleModTool
         private void UpdateImages(UndertaleTexturePageItem item)
         {
             if (item.TexturePage?.TextureData?.Image is null)
+            {
+                ItemTextureBGImage.Source = null;
+                ItemTextureImage.Source = null;
                 return;
-            
+            }
+
             GMImage image = item.TexturePage.TextureData.Image;
             BitmapSource bitmap = mainWindow.GetBitmapSourceForImage(image);
             ItemTextureBGImage.Source = bitmap;


### PR DESCRIPTION
Prevent NREs when adding new Texture Page Items or Embedded textures by adding more null checks. Closes issue #1898

## Description
As described in issue #1898, attempting to add new Texture Page Items or Embedded Textures results in Null Reference Exceptions being thrown. This MR attempts to mitigate those by adding more null value checks.

### Caveats
I didn't immediately see any tests that covered these areas. If I'm missing tests that I should have added, please let me know

### Notes
I'm not sure if there are any other NRE's that might be lying about. These only seem to fix the ones that I came across personally