### PR TITLE
Add check for updates menu item

### DIFF
--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -56,6 +56,7 @@
       <GitPath Condition="'$(ErrorCode)'=='1'">$(DevEnvDir)\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd\git</GitPath>
     </PropertyGroup>
     <!-- Use GitPath and put the git commit name and branch name into gitversion.txt which is an embedded resource-->
-    <Exec Command="( &quot;$(GitPath)&quot; describe --always --dirty &amp;&amp; &quot;$(GitPath)&quot; rev-parse --abbrev-ref HEAD ) &gt; &quot;$(ProjectDir)/gitversion.txt&quot;" IgnoreExitCode="true" />
+    <Exec ConsoleToMSBuild="true" IgnoreExitCode="true"
+		  Command="( &quot;$(GitPath)&quot; describe --always --dirty &amp;&amp; &quot;$(GitPath)&quot; rev-parse --abbrev-ref HEAD &amp;&amp; &quot;$(GitPath)&quot; show -s --format=%%cI ) &gt; &quot;$(ProjectDir)/gitversion.txt&quot;"/>
   </Target>
 </Project>

--- a/UndertaleModTool/BuildInfo.cs
+++ b/UndertaleModTool/BuildInfo.cs
@@ -1,0 +1,11 @@
+﻿namespace UndertaleModTool
+{
+    internal static class BuildInfo
+    {
+#if BUILD_SINGLEFILE_true
+        public static bool IsSingleFile = true;
+#else
+        public static bool IsSingleFile = false;
+#endif
+    }
+}

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -134,6 +134,7 @@
                               Click="MenuItem_RunBuiltinScript_Item_Click" CommandParameter="Scripts\Builtin Scripts\SearchLimited.csx"/>
                 </local:MenuItemDark>
                 <local:MenuItemDark Header="_Help">
+                    <MenuItem Header="_Check for updates" Click="MenuItem_CheckForUpdates_Click"/>
                     <MenuItem Header="_GitHub" Click="MenuItem_GitHub_Click"/>
                     <MenuItem Header="_About" Click="MenuItem_About_Click"/>
                 </local:MenuItemDark>

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace UndertaleModTool
@@ -53,6 +49,8 @@ namespace UndertaleModTool
 
         public bool EnableDarkMode { get; set; } = false;
         public bool ShowDebuggerOption { get; set; } = false;
+
+        public bool CheckForUpdatesAtStartup { get; set; } = true;
 
         public static Settings Instance;
 

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -20,6 +20,9 @@
         <!-- Suppress all missing XML comment warnings -->
         <NoWarn>1591</NoWarn>
     </PropertyGroup>
+    <PropertyGroup>
+      <DefineConstants>$(DefineConstants);BUILD_SINGLEFILE_$(PublishSingleFile)</DefineConstants>
+    </PropertyGroup>
     <ItemGroup>
       <None Remove="Resources\tabs_left_button.png" />
       <None Remove="Resources\tabs_right_button.png" />

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -39,62 +39,64 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Text="Game Maker: Studio 1.4 path" ToolTip="Required only if you want to use the Studio runner rather than the .exe or run the game under debugger."/>
-            <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3" Grid.ColumnSpan="3" Text="{Binding GameMakerStudioPath}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="3,3,3,3" Text="Game Maker: Studio 1.4 path" ToolTip="Required only if you want to use the Studio runner rather than the .exe or run the game under debugger."/>
+            <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3,3,3,3" Grid.ColumnSpan="3" Text="{Binding GameMakerStudioPath}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Margin="3" Text="Game Maker: Studio 2 runtimes path" ToolTip="Required only if you want to run GMS2 games using the Studio runner rather than the .exe"/>
-            <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Grid.ColumnSpan="3" Text="{Binding GameMakerStudio2RuntimesPath}"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="3,3,3,3" Text="Game Maker: Studio 2 runtimes path" ToolTip="Required only if you want to run GMS2 games using the Studio runner rather than the .exe"/>
+            <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3,3,3,3" Grid.ColumnSpan="3" Text="{Binding GameMakerStudio2RuntimesPath}"/>
 
-            <CheckBox Grid.Row="3" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding AssetOrderSwappingEnabled}"/>
-            <TextBlock Grid.Row="3" Grid.Column="0" Margin="25 2 2 2" Text="Enable asset order swapping" ToolTip="Toggles dragging &amp; dropping assets in the asset tabs to different positions in the list. Disabled by default."/>
-            <CheckBox Grid.Row="3" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding WarnOnClose}"/>
-            <TextBlock Grid.Row="3" Grid.Column="2" Margin="25 2 2 2" Text="Warn about saving before closing" ToolTip="Warn about saving before closing. Enabled by default."/>
+            <CheckBox Grid.Row="3" Grid.Column="0" Margin="3,3,3,3" Content="" IsChecked="{Binding AssetOrderSwappingEnabled}"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="25,2,2,2" Text="Enable asset order swapping" ToolTip="Toggles dragging &amp; dropping assets in the asset tabs to different positions in the list. Disabled by default."/>
+            <CheckBox Grid.Row="3" Grid.Column="2" Margin="3,3,3,3" Content="" IsChecked="{Binding WarnOnClose}"/>
+            <TextBlock Grid.Row="3" Grid.Column="2" Margin="25,2,2,2" Text="Warn about saving before closing" ToolTip="Warn about saving before closing. Enabled by default."/>
 
-            <CheckBox Grid.Row="4" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding AutomaticFileAssociation}"/>
-            <TextBlock Grid.Row="4" Grid.Column="0" Margin="25 2 2 2" Text="Automatically associate .win files" ToolTip="Automatic file association. Enabled by default."/>
-            <CheckBox Grid.Row="4" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding TempRunMessageShow}"/>
-            <TextBlock Grid.Row="4" Grid.Column="2" Margin="25 2 2 2" Text="Warn about temp running" ToolTip="Warn about temp running. Enabled by default."/>
+            <CheckBox Grid.Row="4" Grid.Column="0" Margin="3,3,3,3" Content="" IsChecked="{Binding AutomaticFileAssociation}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Margin="25,2,2,2" Text="Automatically associate .win files" ToolTip="Automatic file association. Enabled by default."/>
+            <CheckBox Grid.Row="4" Grid.Column="2" Margin="3,3,3,3" Content="" IsChecked="{Binding TempRunMessageShow}"/>
+            <TextBlock Grid.Row="4" Grid.Column="2" Margin="25,2,2,2" Text="Warn about temp running" ToolTip="Warn about temp running. Enabled by default."/>
 
-            <CheckBox Grid.Row="5" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding UseGMLCache}"/>
-            <TextBlock Grid.Row="5" Grid.Column="0" Margin="25 2 2 2" Text="Use decompiled code cache (experimental)" ToolTip="Used by some scripts (e.g. &quot;Search.csx&quot;) for acceleration. Disabled by default."/>
-            <CheckBox Grid.Row="5" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding ShowDebuggerOption}"/>
-            <TextBlock Grid.Row="5" Grid.Column="2" Margin="25 2 2 2" Text="Show &quot;Run game under GMS debugger&quot; file option" ToolTip="Whether to show the option in the &quot;File&quot; menu. Disabled by default."/>
+            <CheckBox Grid.Row="5" Grid.Column="0" Margin="3,3,3,3" Content="" IsChecked="{Binding UseGMLCache}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Margin="25,2,2,2" Text="Use decompiled code cache (experimental)" ToolTip="Used by some scripts (e.g. &quot;Search.csx&quot;) for acceleration. Disabled by default."/>
+            <CheckBox Grid.Row="5" Grid.Column="2" Margin="3,3,3,3" Content="" IsChecked="{Binding ShowDebuggerOption}"/>
+            <TextBlock Grid.Row="5" Grid.Column="2" Margin="25,2,2,2" Text="Show &quot;Run game under GMS debugger&quot; file option" ToolTip="Whether to show the option in the &quot;File&quot; menu. Disabled by default."/>
 
-            <Separator Grid.Row="6" Grid.ColumnSpan="4" Margin="10"/>
+            <Separator Grid.Row="6" Grid.ColumnSpan="4" Margin="10,10,10,10"/>
 
-            <CheckBox Grid.Row="7" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding EnableDarkMode}"/>
-            <TextBlock Grid.Row="7" Grid.Column="0" Margin="25 2 2 2" Text="Enable dark mode" ToolTip="Makes the program interface dark. Disabled by default."/>
+            <CheckBox Content="Check for updates at startup" HorizontalAlignment="Left" Margin="3,3,0,0" Grid.Row="7" VerticalAlignment="Top" Grid.RowSpan="1" Height="15" Width="170" IsChecked="{Binding CheckForUpdatesAtStartup}"/>
 
-            <Separator Grid.Row="8" Grid.ColumnSpan="4" Margin="10"/>
+            <CheckBox Grid.Row="8" Grid.Column="0" Margin="3,3,3,3" Content="" IsChecked="{Binding EnableDarkMode}"/>
+            <TextBlock Grid.Row="8" Grid.Column="0" Margin="25,2,2,2" Text="Enable dark mode" ToolTip="Makes the program interface dark. Disabled by default."/>
 
-            <CheckBox Grid.Row="9" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}"/>
-            <TextBlock Grid.Row="9" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room."/>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
+            <Separator Grid.Row="9" Grid.ColumnSpan="4" Margin="10,10,10,10"/>
 
-            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}"/>
-            <TextBlock Grid.Row="10" Grid.Column="0" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room."/>
-            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
+            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3,0,3,0" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}" Height="15"/>
+            <TextBlock Grid.Row="10" Grid.Column="0" Margin="25,0,2,0" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room." Height="16"/>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3,3,3,3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
 
-            <CheckBox Grid.Row="9" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
-            <TextBlock Grid.Row="9" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
+            <CheckBox Grid.Row="11" Grid.Column="0" Margin="3,0,3,0" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}" Height="15"/>
+            <TextBlock Grid.Row="11" Grid.Column="0" Margin="25,0,2,0"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room." Height="16"/>
+            <local:TextBoxDark Grid.Row="11" Grid.Column="1" Margin="3,3,3,3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
 
-            <Separator Grid.Row="13" Grid.ColumnSpan="4" Margin="10"/>
+            <CheckBox Grid.Row="10" Grid.Column="2" Margin="3,0,3,0" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}" Height="15"/>
+            <TextBlock Grid.Row="10" Grid.Column="2" Margin="25,0,2,0" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness." Height="16"/>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="3" Margin="3,3,3,3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
 
-            <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="4" Margin="3" TextWrapping="Wrap" Foreground="Red" FontWeight="Bold" Text="Warning: the following options are currently experimental, as the profile system is a work in progress. Usage of the system is at your own risk, and though it is relatively stable, it may not be compatible in the future."/>
+            <Separator Grid.Row="12" Grid.ColumnSpan="4" Margin="10,10,10,10" Grid.RowSpan="2"/>
 
-            <CheckBox Grid.Row="15" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileModeEnabled}"/>
-            <TextBlock Grid.Row="15" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Enable profile mode" ToolTip="Toggles the 'decompile once and compile many' profile mode. Enabled by default. May need to be disabled for certain operations."/>
+            <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="4" Margin="3,3,3,3" TextWrapping="Wrap" Foreground="Red" FontWeight="Bold" Text="Warning: the following options are currently experimental, as the profile system is a work in progress. Usage of the system is at your own risk, and though it is relatively stable, it may not be compatible in the future."/>
 
-            <CheckBox Grid.Row="15" Grid.Column="2" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileMessageShown}"/>
-            <TextBlock Grid.Row="15" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Profile mode message shown" ToolTip="On first load, this will show you the profile mode loaded message. If this somehow breaks, you can manually toggle it here."/>
+            <CheckBox Grid.Row="15" Grid.Column="0" Margin="3,0,3,0" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileModeEnabled}" Height="15"/>
+            <TextBlock Grid.Row="15" Grid.Column="0" Margin="25,0,2,0" VerticalAlignment="Center" Text="Enable profile mode" ToolTip="Toggles the 'decompile once and compile many' profile mode. Enabled by default. May need to be disabled for certain operations." Height="16"/>
 
-            <CheckBox Grid.Row="17" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding DeleteOldProfileOnSave}"/>
-            <TextBlock Grid.Row="17" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Delete old profile on saving" ToolTip="Deletes the profile obsoleted on saving. Saves on file space at the expense of losing code information for variants. Enabled by default."/>
+            <CheckBox Grid.Row="15" Grid.Column="2" Margin="3,0,3,0" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileMessageShown}" Height="15"/>
+            <TextBlock Grid.Row="15" Grid.Column="2" Margin="25,0,2,0" VerticalAlignment="Center" Text="Profile mode message shown" ToolTip="On first load, this will show you the profile mode loaded message. If this somehow breaks, you can manually toggle it here." Height="16"/>
 
-            <Separator Grid.Row="18" Grid.ColumnSpan="4" Margin="10"/>
-            <local:ButtonDark Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="1" Margin="5" Click="AppDataButton_Click">Open application data folder</local:ButtonDark>
-            <local:ButtonDark Grid.Row="19" Grid.Column="2" Grid.ColumnSpan="2" Margin="5" Click="UpdateAppButton_Click" x:Name="UpdateAppButton" HorizontalAlignment="Right" Width="223" Visibility="{Binding UpdaterButtonVisibility}">Update app to latest commit</local:ButtonDark>
+            <CheckBox Grid.Row="17" Grid.Column="0" Margin="3,0,3,0" VerticalAlignment="Center" Content="" IsChecked="{Binding DeleteOldProfileOnSave}" Height="15"/>
+            <TextBlock Grid.Row="17" Grid.Column="0" Margin="25,0,2,0" VerticalAlignment="Center" Text="Delete old profile on saving" ToolTip="Deletes the profile obsoleted on saving. Saves on file space at the expense of losing code information for variants. Enabled by default." Height="16"/>
+
+            <Separator Grid.Row="18" Grid.ColumnSpan="4" Margin="10,10,10,10"/>
+            <local:ButtonDark Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="1" Margin="5,5,5,5" Click="AppDataButton_Click">Open application data folder</local:ButtonDark>
+            <local:ButtonDark Grid.Row="19" Grid.Column="2" Grid.ColumnSpan="2" Margin="184,5,0,5" Click="UpdateAppButton_Click" x:Name="UpdateAppButton" HorizontalAlignment="Left" Width="223" Visibility="{Binding UpdaterButtonVisibility}">Update app to latest commit</local:ButtonDark>
         </Grid>
     </ScrollViewer>
 </Window>

--- a/UndertaleModTool/Windows/SettingsWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml.cs
@@ -1,18 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace UndertaleModTool
 {
@@ -206,6 +192,16 @@ namespace UndertaleModTool
                 Settings.Save();
 
                 mainWindow.RunGMSDebuggerItem.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+            }
+        }
+
+        public static bool CheckForUpdatesAtStartup
+        {
+            get => Settings.Instance.CheckForUpdatesAtStartup;
+            set
+            {
+                Settings.Instance.CheckForUpdatesAtStartup = value;
+                Settings.Save();
             }
         }
 


### PR DESCRIPTION
## Description
A simple option to check for updates that just leads the user to the release page for that update.

### Caveats
It's based on the program's version number and the GitHub release's tag name. If any of these become inconsistent or change, it would cause problems. Also this doesn't work on bleeding edge or locally built builds.

### Notes
Right now, can't use the actual date of the release the user has because this information is not saved. If there's some way of doing this, then this would even work for bleeding edge builds that don't have version numbers, only commit hashes.