### PR TITLE
Remove struct keyword

### DIFF
--- a/UndertaleModLib/Compiler/Lexer.cs
+++ b/UndertaleModLib/Compiler/Lexer.cs
@@ -521,7 +521,6 @@ namespace UndertaleModLib.Compiler
                     "globalvar" => new Token(Token.TokenKind.KeywordGlobalVar, cr.GetPositionInfo(index)),
                     "return" => new Token(Token.TokenKind.KeywordReturn, cr.GetPositionInfo(index)),
                     "default" => new Token(Token.TokenKind.KeywordDefault, cr.GetPositionInfo(index)),
-                    "struct" => new Token(Token.TokenKind.KeywordStruct, cr.GetPositionInfo(index)),
                     "function" when CompileContext.GMS2_3 => new Token(Token.TokenKind.KeywordFunction, cr.GetPositionInfo(index)),
                     "throw" when CompileContext.GMS2_3 => new Token(Token.TokenKind.KeywordThrow, cr.GetPositionInfo(index)),
                     "constructor" when CompileContext.GMS2_3 => new Token(Token.TokenKind.KeywordConstructor, cr.GetPositionInfo(index)),
@@ -844,7 +843,6 @@ namespace UndertaleModLib.Compiler
                     KeywordExit,
                     KeywordBreak,
                     KeywordContinue,
-                    KeywordStruct, // Apparently this exists
                     KeywordFunction,
                     KeywordThrow,
                     KeywordConstructor,

--- a/UndertaleModLib/Compiler/Parser.cs
+++ b/UndertaleModLib/Compiler/Parser.cs
@@ -3130,7 +3130,6 @@ namespace UndertaleModLib.Compiler
                     TokenKind.KeywordIf,
                     TokenKind.KeywordRepeat,
                     TokenKind.KeywordReturn,
-                    TokenKind.KeywordStruct,
                     TokenKind.KeywordSwitch,
                     TokenKind.KeywordThen,
                     TokenKind.KeywordUntil,


### PR DESCRIPTION
## Description
Removed the `struct` keyword from the UML compiler.

### Caveats
As far as I can tell there is no `struct` keyword in latest GMS2 IDE that the compiler would need to recognize, though it may exist in earlier versions that UTMT maintains backwards compatibility with.

### Notes
Fixes #1916