### PR TITLE
Hide children

### DIFF
--- a/UndertaleModTool/Converters/CodeViewConverter.cs
+++ b/UndertaleModTool/Converters/CodeViewConverter.cs
@@ -13,7 +13,9 @@ namespace UndertaleModTool
             Predicate<object> baseFilter = base.CreateFilter();
             return (obj) =>
             {
-                if (obj is UndertaleCode code && code.ParentEntry != null)
+                if (obj is UndertaleCode code &&
+                    code.ParentEntry != null &&
+                    Settings.Instance.HideChildCodeEntries)
                     return false;
                 return baseFilter(obj);
             };

--- a/UndertaleModTool/Converters/CodeViewConverter.cs
+++ b/UndertaleModTool/Converters/CodeViewConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Data;
+using UndertaleModLib.Models;
+
+namespace UndertaleModTool
+{
+    [ValueConversion(typeof(object), typeof(ICollectionView))]
+    public class CodeViewConverter : FilteredViewConverter
+    {
+        public override Predicate<object> CreateFilter()
+        {
+            Predicate<object> baseFilter = base.CreateFilter();
+            return (obj) =>
+            {
+                if (obj is UndertaleCode code && code.ParentEntry != null)
+                    return false;
+                return baseFilter(obj);
+            };
+        }
+    }
+}

--- a/UndertaleModTool/Converters/CodeViewConverter.cs
+++ b/UndertaleModTool/Converters/CodeViewConverter.cs
@@ -8,7 +8,7 @@ namespace UndertaleModTool
     [ValueConversion(typeof(object), typeof(ICollectionView))]
     public class CodeViewConverter : FilteredViewConverter
     {
-        public override Predicate<object> CreateFilter()
+        protected override Predicate<object> CreateFilter()
         {
             Predicate<object> baseFilter = base.CreateFilter();
             return (obj) =>

--- a/UndertaleModTool/Converters/FilteredViewConverter.cs
+++ b/UndertaleModTool/Converters/FilteredViewConverter.cs
@@ -26,12 +26,9 @@ namespace UndertaleModTool
             set { SetValue(FilterProperty, value); }
         }
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public virtual Predicate<object> CreateFilter()
         {
-            if (value == null)
-                return null;
-            ICollectionView filteredView = CollectionViewSource.GetDefaultView(value);
-            filteredView.Filter = (obj) =>
+            return (obj) =>
             {
                 if (String.IsNullOrEmpty(Filter))
                     return true;
@@ -44,6 +41,14 @@ namespace UndertaleModTool
                                 .Any(x => (x?.IndexOf(Filter, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0);
                 return true;
             };
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return null;
+            ICollectionView filteredView = CollectionViewSource.GetDefaultView(value);
+            filteredView.Filter = CreateFilter();
             return filteredView;
         }
 

--- a/UndertaleModTool/Converters/FilteredViewConverter.cs
+++ b/UndertaleModTool/Converters/FilteredViewConverter.cs
@@ -26,7 +26,7 @@ namespace UndertaleModTool
             set { SetValue(FilterProperty, value); }
         }
 
-        public virtual Predicate<object> CreateFilter()
+        protected virtual Predicate<object> CreateFilter()
         {
             return (obj) =>
             {

--- a/UndertaleModTool/MainWindow.xaml
+++ b/UndertaleModTool/MainWindow.xaml
@@ -23,6 +23,7 @@
     <Window.Resources>
         <local:ImplementsInterfaceConverter x:Key="ImplementsInterfaceConverter"/>
         <local:FilteredViewConverter x:Key="FilteredViewConverter" Filter="{Binding Text, Source={x:Reference SearchBox}, UpdateSourceTrigger=PropertyChanged}"/>
+        <local:CodeViewConverter x:Key="CodeViewConverter" Filter="{Binding Text, Source={x:Reference SearchBox}, UpdateSourceTrigger=PropertyChanged}"/>
         <local:NullToVisibilityConverter x:Key="VisibleIfNotNull"  nullValue="Collapsed" notNullValue="Visible"/>
         <local:CompareNumbersConverter x:Key="CompareNumbersConverter"/>
         <BooleanToVisibilityConverter x:Key="BoolToVisConverter"/> <!-- (built-in converter) -->
@@ -388,7 +389,7 @@
                                 </HierarchicalDataTemplate>
                             </TreeViewItem.ItemTemplate>
                         </TreeViewItem>
-                        <TreeViewItem Name="CodeItemsList" Header="Code" ItemsSource="{Binding Code, Converter={StaticResource FilteredViewConverter}}" Visibility="{Binding Code, Converter={StaticResource VisibleIfNotNull}}">
+                        <TreeViewItem Name="CodeItemsList" Header="Code" ItemsSource="{Binding Code, Converter={StaticResource CodeViewConverter}}" Visibility="{Binding Code, Converter={StaticResource VisibleIfNotNull}}">
                             <TreeViewItem.ItemContainerStyle>
                                 <Style TargetType="{x:Type TreeViewItem}">
                                     <Setter Property="ContextMenu" Value="{StaticResource UndertaleResourceMenu}"/>

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -317,7 +317,7 @@ namespace UndertaleModTool
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
-        private void UpdateTree()
+        public void UpdateTree()
         {
             foreach (var child in (MainTree.Items[0] as TreeViewItem).Items)
                 ((child as TreeViewItem).ItemsSource as ICollectionView)?.Refresh();

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -40,6 +40,7 @@ namespace UndertaleModTool
 
         public bool DeleteOldProfileOnSave { get; set; } = false;
         public bool WarnOnClose { get; set; } = true;
+        public bool HideChildCodeEntries { get; set; } = false;
 
         private double _globalGridWidth = 20;
         private double _globalGridHeight = 20;

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -37,6 +37,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Margin="3" Text="Game Maker: Studio 1.4 path" ToolTip="Required only if you want to use the Studio runner rather than the .exe or run the game under debugger."/>
@@ -60,41 +61,44 @@
             <CheckBox Grid.Row="5" Grid.Column="2" Margin="3" Content="" IsChecked="{Binding ShowDebuggerOption}"/>
             <TextBlock Grid.Row="5" Grid.Column="2" Margin="25 2 2 2" Text="Show &quot;Run game under GMS debugger&quot; file option" ToolTip="Whether to show the option in the &quot;File&quot; menu. Disabled by default."/>
 
-            <Separator Grid.Row="6" Grid.ColumnSpan="4" Margin="10"/>
+            <CheckBox Grid.Row="6" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding HideChildCodeEntries}"/>
+            <TextBlock Grid.Row="6" Grid.Column="0" Margin="25 2 2 2" Text="Hide child code entries" ToolTip="tooltip TBA"/>
 
-            <CheckBox Grid.Row="7" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding EnableDarkMode}"/>
-            <TextBlock Grid.Row="7" Grid.Column="0" Margin="25 2 2 2" Text="Enable dark mode" ToolTip="Makes the program interface dark. Disabled by default."/>
+            <Separator Grid.Row="7" Grid.ColumnSpan="4" Margin="10"/>
 
-            <Separator Grid.Row="8" Grid.ColumnSpan="4" Margin="10"/>
+            <CheckBox Grid.Row="8" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding EnableDarkMode}"/>
+            <TextBlock Grid.Row="8" Grid.Column="0" Margin="25 2 2 2" Text="Enable dark mode" ToolTip="Makes the program interface dark. Disabled by default."/>
 
-            <CheckBox Grid.Row="9" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}"/>
-            <TextBlock Grid.Row="9" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room."/>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
+            <Separator Grid.Row="9" Grid.ColumnSpan="4" Margin="10"/>
 
-            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}"/>
-            <TextBlock Grid.Row="10" Grid.Column="0" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room."/>
-            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
+            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}"/>
+            <TextBlock Grid.Row="10" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room."/>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
 
-            <CheckBox Grid.Row="9" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
-            <TextBlock Grid.Row="9" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
+            <CheckBox Grid.Row="11" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}"/>
+            <TextBlock Grid.Row="11" Grid.Column="0" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room."/>
+            <local:TextBoxDark Grid.Row="11" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
 
-            <Separator Grid.Row="13" Grid.ColumnSpan="4" Margin="10"/>
+            <CheckBox Grid.Row="10" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
+            <TextBlock Grid.Row="10" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
 
-            <TextBlock Grid.Row="14" Grid.Column="0" Grid.ColumnSpan="4" Margin="3" TextWrapping="Wrap" Foreground="Red" FontWeight="Bold" Text="Warning: the following options are currently experimental, as the profile system is a work in progress. Usage of the system is at your own risk, and though it is relatively stable, it may not be compatible in the future."/>
+            <Separator Grid.Row="14" Grid.ColumnSpan="4" Margin="10"/>
 
-            <CheckBox Grid.Row="15" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileModeEnabled}"/>
-            <TextBlock Grid.Row="15" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Enable profile mode" ToolTip="Toggles the 'decompile once and compile many' profile mode. Enabled by default. May need to be disabled for certain operations."/>
+            <TextBlock Grid.Row="15" Grid.Column="0" Grid.ColumnSpan="4" Margin="3" TextWrapping="Wrap" Foreground="Red" FontWeight="Bold" Text="Warning: the following options are currently experimental, as the profile system is a work in progress. Usage of the system is at your own risk, and though it is relatively stable, it may not be compatible in the future."/>
 
-            <CheckBox Grid.Row="15" Grid.Column="2" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileMessageShown}"/>
-            <TextBlock Grid.Row="15" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Profile mode message shown" ToolTip="On first load, this will show you the profile mode loaded message. If this somehow breaks, you can manually toggle it here."/>
+            <CheckBox Grid.Row="16" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileModeEnabled}"/>
+            <TextBlock Grid.Row="16" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Enable profile mode" ToolTip="Toggles the 'decompile once and compile many' profile mode. Enabled by default. May need to be disabled for certain operations."/>
 
-            <CheckBox Grid.Row="17" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding DeleteOldProfileOnSave}"/>
-            <TextBlock Grid.Row="17" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Delete old profile on saving" ToolTip="Deletes the profile obsoleted on saving. Saves on file space at the expense of losing code information for variants. Enabled by default."/>
+            <CheckBox Grid.Row="16" Grid.Column="2" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding ProfileMessageShown}"/>
+            <TextBlock Grid.Row="16" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Profile mode message shown" ToolTip="On first load, this will show you the profile mode loaded message. If this somehow breaks, you can manually toggle it here."/>
 
-            <Separator Grid.Row="18" Grid.ColumnSpan="4" Margin="10"/>
-            <local:ButtonDark Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="1" Margin="5" Click="AppDataButton_Click">Open application data folder</local:ButtonDark>
-            <local:ButtonDark Grid.Row="19" Grid.Column="2" Grid.ColumnSpan="2" Margin="5" Click="UpdateAppButton_Click" x:Name="UpdateAppButton" HorizontalAlignment="Right" Width="223" Visibility="{Binding UpdaterButtonVisibility}">Update app to latest commit</local:ButtonDark>
+            <CheckBox Grid.Row="18" Grid.Column="0" Margin="3" VerticalAlignment="Center" Content="" IsChecked="{Binding DeleteOldProfileOnSave}"/>
+            <TextBlock Grid.Row="18" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Delete old profile on saving" ToolTip="Deletes the profile obsoleted on saving. Saves on file space at the expense of losing code information for variants. Enabled by default."/>
+
+            <Separator Grid.Row="19" Grid.ColumnSpan="4" Margin="10"/>
+            <local:ButtonDark Grid.Row="20" Grid.Column="0" Grid.ColumnSpan="1" Margin="5" Click="AppDataButton_Click">Open application data folder</local:ButtonDark>
+            <local:ButtonDark Grid.Row="20" Grid.Column="2" Grid.ColumnSpan="2" Margin="5" Click="UpdateAppButton_Click" x:Name="UpdateAppButton" HorizontalAlignment="Right" Width="223" Visibility="{Binding UpdaterButtonVisibility}">Update app to latest commit</local:ButtonDark>
         </Grid>
     </ScrollViewer>
 </Window>

--- a/UndertaleModTool/Windows/SettingsWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml.cs
@@ -127,6 +127,9 @@ namespace UndertaleModTool
             {
                 Settings.Instance.HideChildCodeEntries = value;
                 Settings.Save();
+
+                // Refresh the tree to make the changes take effect.
+                mainWindow.UpdateTree();
             }
         }
 

--- a/UndertaleModTool/Windows/SettingsWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml.cs
@@ -120,6 +120,15 @@ namespace UndertaleModTool
                 Settings.Save();
             }
         }
+        public static bool HideChildCodeEntries
+        {
+            get => Settings.Instance.HideChildCodeEntries;
+            set
+            {
+                Settings.Instance.HideChildCodeEntries = value;
+                Settings.Save();
+            }
+        }
 
         public static double GlobalGridWidth
         {


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->
Implements #1609. Adds a setting to the settings menu to control whether the child code entries (entries which have ParentEntry set) are hidden or shown in the main tree.
### Caveats
<!-- Any caveats, side effects or regressions of this PR -->
The are 2 tiny things that need to be adressed before this can be merged:
1. **The setting is missing a tooltip** - I don't know enough about the data structure to properly describe what the setting does. @VladiStep can you please write it?
2. **Default behavior** - Currently the setting is off by default, but maybe it should be on by default. I couldn't decide what to choose.
### Notes
<!-- Any notes or closing words -->
Resolves #1609.