### PR TITLE
Add support for games that use DDS textures

### DIFF
--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -1,28 +1,20 @@
-﻿using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.Drawing;
-using UndertaleModLib.Models;
-using UndertaleModLib.Util;
-using System.Globalization;
-using UndertaleModLib;
-using UndertaleModTool.Windows;
 using System.Windows.Threading;
 using ImageMagick;
-using System.ComponentModel;
+using Microsoft.Win32;
+using UndertaleModLib.Models;
+using UndertaleModLib.Util;
+using UndertaleModTool.Windows;
 
 namespace UndertaleModTool
 {
@@ -252,8 +244,18 @@ namespace UndertaleModTool
                         mainWindow.ShowWarning("WARNING: Texture page dimensions are not powers of 2. Sprite blurring is very likely in-game.", "Unexpected texture dimensions");
                     }
 
+                    var previousFormat = target.TextureData.Image.Format;
+
                     // Import image
                     target.TextureData.Image = image;
+
+                    var currentFormat = target.TextureData.Image.Format;
+
+                    // If texture was DDS, warn user that texture has been converted to PNG
+                    if (previousFormat == GMImage.ImageFormat.Dds && currentFormat == GMImage.ImageFormat.Png)
+                    {
+                        mainWindow.ShowMessage($"{target} was converted into PNG format since we don't support converting images into DDS format. This might have performance issues in the game.");
+                    }
 
                     // Update width/height properties in the UI
                     TexWidth.GetBindingExpression(TextBox.TextProperty)?.UpdateTarget();

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.Win32;
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using ImageMagick;
+using Microsoft.Win32;
 using UndertaleModLib.Models;
 using UndertaleModLib.Util;
-using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Data;
 using UndertaleModTool.Windows;
-using ImageMagick;
-using System.Windows.Media.Imaging;
-using System.ComponentModel;
 
 namespace UndertaleModTool
 {
@@ -150,7 +150,18 @@ namespace UndertaleModTool
             {
                 using MagickImage image = TextureWorker.ReadBGRAImageFromFile(dlg.FileName);
                 UndertaleTexturePageItem item = DataContext as UndertaleTexturePageItem;
+
+                var previousFormat = item.TexturePage.TextureData.Image.Format;
+
                 item.ReplaceTexture(image);
+
+                var currentFormat = item.TexturePage.TextureData.Image.Format;
+
+                // If texture was DDS, warn user that texture has been converted to PNG
+                if (previousFormat == GMImage.ImageFormat.Dds && currentFormat == GMImage.ImageFormat.Png)
+                {
+                    mainWindow.ShowMessage($"{item.TexturePage} was converted into PNG format since we don't support converting images into DDS format. This might have performance issues in the game.");
+                }
 
                 // Refresh the image of "ItemDisplay"
                 if (ItemDisplay.FindName("RenderAreaBorder") is not Border border)


### PR DESCRIPTION
## Description
Fix #1907

Some games use the official GM-GPUTextureCompression extension to use GPU compressed textures. One of the formats supported is BCN compression, which uses the DDS format, at least on Windows. This PR aims to allow games using that to be modded.

### Caveats
Although you can load it, there's no support for saving these textures in their original format, so it just saves in PNG format and gives a warning to the user. This works, but obviously will have a performance impact. This compression format is lossy anyway.

### Notes
There's other formats supported by this extension, and in other operating systems, hopefully this can be addressed in future PRs.