### PR TITLE
UA: Add rough check for CodeLocals' removal from FUNC in 2024.8

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -449,7 +449,7 @@ public partial class Program : IScriptInterface
 
         try
         {
-            return code != null ? code.Disassemble(Data.Variables, Data.CodeLocals.For(code)) : "";
+            return code != null ? code.Disassemble(Data.Variables, Data.CodeLocals?.For(code)) : "";
         }
         catch (Exception e)
         {
@@ -752,7 +752,7 @@ public partial class Program : IScriptInterface
         else if (code.ParentEntry is not null)
             return;
 
-        if (Data?.GeneralInfo.BytecodeVersion > 14 && Data.CodeLocals.ByName(codeName) == null)
+        if (Data.CodeLocals is not null && Data.CodeLocals.ByName(codeName) is null)
         {
             UndertaleCodeLocals locals = new UndertaleCodeLocals();
             locals.Name = code.Name;

--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -585,7 +585,8 @@ public partial class Program : IScriptInterface
         if (!Data.IsYYC())
         {
             Console.WriteLine($"{Data.Code.Count} Code Entries, {Data.Variables.Count} Variables, {Data.Functions.Count} Functions");
-            Console.WriteLine($"{Data.CodeLocals.Count} Code locals, {Data.Strings.Count} Strings, {Data.EmbeddedTextures.Count} Embedded Textures");
+            var codeLocalsInfo = Data.CodeLocals is not null ? $"{Data.CodeLocals.Count} Code locals, " : "";
+            Console.WriteLine($"{codeLocalsInfo}{Data.Strings.Count} Strings, {Data.EmbeddedTextures.Count} Embedded Textures");
         }
         else
         {

--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -107,7 +107,7 @@ namespace UndertaleModLib.Compiler
                     bool defineArguments = true;
                     if (compileContext.OriginalCode != null)
                     {
-                        UndertaleCodeLocals locals = compileContext.Data?.CodeLocals.For(compileContext.OriginalCode);
+                        UndertaleCodeLocals locals = compileContext.Data?.CodeLocals?.For(compileContext.OriginalCode);
                         if (locals != null)
                         {
                             // Update the code locals of the UndertaleCode

--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -341,8 +341,6 @@ namespace UndertaleModLib.Decompiler
                     string[] aaa = line.Split(' ');
                     if (aaa[0] == ".localvar")
                     {
-                        if (localvars is null)
-                            throw new Exception("Local variable directive is not supported in this bytecode version");
                         if (aaa.Length >= 4)
                         {
                             var varii = vars[Int32.Parse(aaa[3])];

--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -341,6 +341,8 @@ namespace UndertaleModLib.Decompiler
                     string[] aaa = line.Split(' ');
                     if (aaa[0] == ".localvar")
                     {
+                        if (localvars is null)
+                            throw new Exception("Local variable directive is not supported in this bytecode version");
                         if (aaa.Length >= 4)
                         {
                             var varii = vars[Int32.Parse(aaa[3])];
@@ -526,7 +528,7 @@ namespace UndertaleModLib.Decompiler
             // Locate variable from either local variables, or VARI chunk
             UndertaleVariable locatedVariable;
             string variableName = str[strPosition..].ToString();
-            if (variInstanceType == UndertaleInstruction.InstanceType.Local)
+            if (variInstanceType == UndertaleInstruction.InstanceType.Local && data?.CodeLocals is not null)
             {
                 locatedVariable = localvars.ContainsKey(variableName) ? localvars[variableName] : null;
             }

--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -302,16 +302,19 @@ public class UndertaleGameObject : UndertaleNamedResource, INotifyPropertyChange
             action.CodeId = code;
             data.Code.Add(code);
 
-            UndertaleCodeLocals.LocalVar argsLocal = new UndertaleCodeLocals.LocalVar();
-            argsLocal.Name = data.Strings.MakeString("arguments");
-            argsLocal.Index = 0;
-
-            var locals = new UndertaleCodeLocals()
+            if (data.CodeLocals is not null)
             {
-                Name = name
-            };
-            locals.Locals.Add(argsLocal);
-            data.CodeLocals.Add(locals);
+                UndertaleCodeLocals.LocalVar argsLocal = new UndertaleCodeLocals.LocalVar();
+                argsLocal.Name = data.Strings.MakeString("arguments");
+                argsLocal.Index = 0;
+
+                var locals = new UndertaleCodeLocals()
+                {
+                    Name = name
+                };
+                locals.Locals.Add(argsLocal);
+                data.CodeLocals.Add(locals);
+            }
         }
         return code;
     }

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1395,7 +1395,7 @@ namespace UndertaleModLib
 
         internal override void SerializeChunk(UndertaleWriter writer)
         {
-            if (Functions is null && (writer.undertaleData.IsVersionAtLeast(2024, 8) || CodeLocals is null))
+            if (Functions is null && CodeLocals is null)
                 return;
 
             UndertaleInstruction.Reference<UndertaleFunction>.SerializeReferenceChain(writer, writer.undertaleData.Code, Functions);

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1434,6 +1434,7 @@ namespace UndertaleModLib
                 Functions.SetCapacity(Length / 12);
                 while (reader.Position + 12 <= startPosition + Length)
                     Functions.Add(reader.ReadUndertaleObject<UndertaleFunction>());
+                CodeLocals = null;
             }
             else
             {

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -2237,7 +2237,8 @@ namespace UndertaleModLib
                 // Fortunately, consistent padding means we need no parsing here
                 if (Length == 0xF8)
                 {
-                    reader.undertaleData.SetGMS2Version(2023, 8);
+                    if (!reader.undertaleData.IsVersionAtLeast(2023, 8))
+                        reader.undertaleData.SetGMS2Version(2023, 8);
                 }
                 else if (Length == 0xD8)
                 {
@@ -2267,7 +2268,8 @@ namespace UndertaleModLib
             uint secondPtr = reader.ReadUInt32();
             if (secondPtr - firstPtr == 0xEC)
             {
-                reader.undertaleData.SetGMS2Version(2023, 8);
+                if (!reader.undertaleData.IsVersionAtLeast(2023, 8))
+                    reader.undertaleData.SetGMS2Version(2023, 8);
             }
             else if (secondPtr - firstPtr == 0xC0)
             {

--- a/UndertaleModLib/UndertaleDataExtensionMethods.cs
+++ b/UndertaleModLib/UndertaleDataExtensionMethods.cs
@@ -174,10 +174,12 @@ public static class UndertaleDataExtensionMethods
 
 	public static UndertaleVariable DefineLocal(this IList<UndertaleVariable> list, IList<UndertaleVariable> originalReferencedLocalVars, int localId, string name, IList<UndertaleString> strg, UndertaleData data)
 	{
-		bool bytecode14 = (data?.GeneralInfo?.BytecodeVersion <= 14);
-		if (bytecode14)
+		bool bytecode14 = data?.GeneralInfo?.BytecodeVersion <= 14;
+		if (bytecode14 || data?.CodeLocals is null)
 		{
-			UndertaleVariable search = list.Where((x) => x.Name.Content == name).FirstOrDefault();
+			UndertaleVariable search = list.Where((x) =>
+				x.Name.Content == name && (bytecode14 || x.InstanceType == UndertaleInstruction.InstanceType.Local)
+				).FirstOrDefault();
 			if (search != null)
 				return search;
 		}

--- a/UndertaleModTests/GameLoadingTests.cs
+++ b/UndertaleModTests/GameLoadingTests.cs
@@ -75,7 +75,7 @@ namespace UndertaleModTests
                 string disasm;
                 try
                 {
-                    disasm = code.Disassemble(data.Variables, data.CodeLocals.For(code));
+                    disasm = code.Disassemble(data.Variables, data.CodeLocals?.For(code));
                 }
                 catch (Exception e)
                 {

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -529,7 +529,7 @@ namespace UndertaleModTool
                 try
                 {
                     var data = mainWindow.Data;
-                    text = code.Disassemble(data.Variables, data.CodeLocals.For(code));
+                    text = code.Disassemble(data.Variables, data.CodeLocals?.For(code));
 
                     CurrentLocals.Clear();
                 }
@@ -877,7 +877,7 @@ namespace UndertaleModTool
             CurrentLocals.Clear();
 
             // Look up locals for given code entry's name, for syntax highlighting
-            var locals = data.CodeLocals.ByName(code.Name.Content);
+            var locals = data.CodeLocals?.ByName(code.Name.Content);
             if (locals != null)
             {
                 foreach (var local in locals.Locals)

--- a/UndertaleModTool/ImportCodeSystem.cs
+++ b/UndertaleModTool/ImportCodeSystem.cs
@@ -225,7 +225,7 @@ namespace UndertaleModTool
             else if (code.ParentEntry is not null)
                 return;
 
-            if (Data?.GeneralInfo.BytecodeVersion > 14 && Data.CodeLocals.ByName(codeName) == null)
+            if (Data.CodeLocals is not null && Data.CodeLocals.ByName(codeName) is null)
             {
                 UndertaleCodeLocals locals = new UndertaleCodeLocals();
                 locals.Name = code.Name;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2136,7 +2136,7 @@ namespace UndertaleModTool
                         string prefix = Data.IsVersionAtLeast(2, 3) ? "gml_GlobalScript_" : "gml_Script_";
                         code.Name = Data.Strings.MakeString(prefix + newName);
                         Data.Code.Add(code);
-                        if (Data?.GeneralInfo.BytecodeVersion > 14)
+                        if (Data.CodeLocals is not null)
                         {
                             UndertaleCodeLocals locals = new UndertaleCodeLocals();
                             locals.Name = code.Name;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2149,7 +2149,7 @@ namespace UndertaleModTool
                         }
                         (obj as UndertaleScript).Code = code;
                     }
-                    if ((obj is UndertaleCode) && (Data.GeneralInfo.BytecodeVersion > 14))
+                    if (obj is UndertaleCode && Data.CodeLocals is not null)
                     {
                         UndertaleCodeLocals locals = new UndertaleCodeLocals();
                         locals.Name = (obj as UndertaleCode).Name;

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -1210,12 +1210,16 @@ namespace UndertaleModTool
                         {
                             debugData.SourceCode.Add(new UndertaleScriptSource() { SourceCode = debugData.Strings.MakeString(outputs[i]) });
                             debugData.DebugInfo.Add(outputsOffsets[i]);
-                            debugData.LocalVars.Add(Data.CodeLocals[i]);
-                            if (debugData.Strings.IndexOf(Data.CodeLocals[i].Name) < 0)
-                                debugData.Strings.Add(Data.CodeLocals[i].Name);
-                            foreach (var local in Data.CodeLocals[i].Locals)
-                                if (debugData.Strings.IndexOf(local.Name) < 0)
-                                    debugData.Strings.Add(local.Name);
+                            // FIXME: Probably should write something regardless.
+                            if (Data.CodeLocals is not null)
+                            {
+                                debugData.LocalVars.Add(Data.CodeLocals[i]);
+                                if (debugData.Strings.IndexOf(Data.CodeLocals[i].Name) < 0)
+                                    debugData.Strings.Add(Data.CodeLocals[i].Name);
+                                foreach (var local in Data.CodeLocals[i].Locals)
+                                    if (debugData.Strings.IndexOf(local.Name) < 0)
+                                        debugData.Strings.Add(local.Name);
+                            }
                         }
 
                         using (UndertaleWriter writer = new UndertaleWriter(new FileStream(Path.ChangeExtension(FilePath, ".yydebug"), FileMode.Create, FileAccess.Write)))

--- a/UndertaleModTool/ProfileSystem.cs
+++ b/UndertaleModTool/ProfileSystem.cs
@@ -47,7 +47,7 @@ namespace UndertaleModTool
 
             try
             {
-                return code != null ? code.Disassemble(Data.Variables, Data.CodeLocals.For(code)) : "";
+                return code != null ? code.Disassemble(Data.Variables, Data.CodeLocals?.For(code)) : "";
             }
             catch (Exception e)
             {

--- a/UndertaleModTool/Scripts/Builtin Scripts/HeCanBeEverywhere.csx
+++ b/UndertaleModTool/Scripts/Builtin Scripts/HeCanBeEverywhere.csx
@@ -260,7 +260,7 @@ for (int i = 0; i < obj_shop1_Draw.Instructions.Count; i++)
     }
 }
 obj_shop1_Draw.UpdateAddresses();
-obj_shop1_Draw.Replace(Assembler.Assemble(obj_shop1_Draw.Disassemble(Data.Variables, Data.CodeLocals.For(obj_shop1_Draw)), Data)); // TODO: no idea why this is needed
+obj_shop1_Draw.Replace(Assembler.Assemble(obj_shop1_Draw.Disassemble(Data.Variables, Data.CodeLocals?.For(obj_shop1_Draw)), Data)); // TODO: no idea why this is needed
 
 Data.GameObjects.ByName("obj_time").EventHandlerFor(EventType.KeyPress, EventSubtypeKey.vk_f6, Data).ReplaceGML(@"
 if (global.debug == 1)

--- a/UndertaleModTool/Scripts/Builtin Scripts/SearchASM.csx
+++ b/UndertaleModTool/Scripts/Builtin Scripts/SearchASM.csx
@@ -81,7 +81,7 @@ void DumpCode(UndertaleCode code)
         try
         {
             var lineNumber = 1;
-            StringReader assemblyText = new(code != null ? code.Disassemble(Data.Variables, Data.CodeLocals.For(code)) : "");
+            StringReader assemblyText = new(code != null ? code.Disassemble(Data.Variables, Data.CodeLocals?.For(code)) : "");
             bool nameWritten = false;
             string lineInt;
             while ((lineInt = assemblyText.ReadLine()) is not null)

--- a/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopy.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopy.csx
@@ -161,7 +161,7 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                 nativeACT.CodeId.ArgumentsCount = donorACT.CodeId.ArgumentsCount;
                                 nativeACT.CodeId.Offset = donorACT.CodeId.Offset;
                                 nativeACT.CodeId.WeirdLocalFlag = donorACT.CodeId.WeirdLocalFlag;
-                                if (Data?.GeneralInfo.BytecodeVersion > 14)
+                                if (Data.CodeLocals is not null)
                                 {
                                     UndertaleCodeLocals nativelocals = Data.CodeLocals.ByName(donorACT.CodeId?.Name?.Content);
                                     UndertaleCodeLocals donorlocals = DonorData.CodeLocals.ByName(donorACT.CodeId?.Name?.Content);

--- a/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopyInternal.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopyInternal.csx
@@ -114,7 +114,7 @@ for (var j = 0; j < splitStringsList.Count; j++)
                                 nativeACT.CodeId.ArgumentsCount = donorACT.CodeId.ArgumentsCount;
                                 nativeACT.CodeId.Offset = donorACT.CodeId.Offset;
                                 nativeACT.CodeId.WeirdLocalFlag = donorACT.CodeId.WeirdLocalFlag;
-                                if (Data?.GeneralInfo.BytecodeVersion > 14)
+                                if (Data.CodeLocals is not null)
                                 {
                                     UndertaleCodeLocals donorlocals = Data.CodeLocals.ByName(donorACT.CodeId?.Name?.Content);
                                     UndertaleCodeLocals nativelocals = new UndertaleCodeLocals();

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportASM_2_3.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportASM_2_3.csx
@@ -117,7 +117,7 @@ await Task.Run(() => {
             code.Name = Data.Strings.MakeString(codeName);
             Data.Code.Add(code);
         }
-        if ((Data?.GeneralInfo.BytecodeVersion > 14) && (Data.CodeLocals.ByName(codeName) == null))
+        if (Data.CodeLocals is not null && Data.CodeLocals.ByName(codeName) is null)
         {
             UndertaleCodeLocals locals = new UndertaleCodeLocals();
             locals.Name = code.Name;

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGML_2_3.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGML_2_3.csx
@@ -118,7 +118,7 @@ await Task.Run(() => {
             code.Name = Data.Strings.MakeString(codeName);
             Data.Code.Add(code);
         }
-        if ((Data?.GeneralInfo.BytecodeVersion > 14) && (Data.CodeLocals.ByName(codeName) == null))
+        if (Data.CodeLocals is not null && Data.CodeLocals.ByName(codeName) is null)
         {
             UndertaleCodeLocals locals = new UndertaleCodeLocals();
             locals.Name = code.Name;

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportASM.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportASM.csx
@@ -39,7 +39,7 @@ void DumpCode(UndertaleCode code)
     string path = Path.Combine(codeFolder, code.Name.Content + ".asm");
     try
     {
-        File.WriteAllText(path, (code != null ? code.Disassemble(Data.Variables, Data.CodeLocals.For(code)) : ""));
+        File.WriteAllText(path, (code != null ? code.Disassemble(Data.Variables, Data.CodeLocals?.For(code)) : ""));
     }
     catch (Exception e)
     {

--- a/UndertaleModTool/Scripts/Technical Scripts/ConvertFrom17to16_for_2.3.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/ConvertFrom17to16_for_2.3.csx
@@ -77,6 +77,8 @@ applying any changes to the game.";
         Data.FORM.Chunks.Remove("TAGS");
     if (Data.FORM.Chunks.ContainsKey("EMBI"))
         Data.FORM.Chunks.Remove("EMBI");
+    if (Data.FORM.FUNC.CodeLocals is null)
+        Data.FORM.FUNC.CodeLocals = new UndertaleSimpleList<UndertaleCodeLocals>();
     Data.SetGMS2Version(2);
     //Data.IsTPAG4ByteAligned = false;
     for (int i = 0; i < Data.Code.Count; i++)

--- a/UndertaleModTool/Scripts/Technical Scripts/ExportAndConvert_2_3_ASM.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/ExportAndConvert_2_3_ASM.csx
@@ -52,7 +52,7 @@ void DumpCode()
     foreach (UndertaleCode code_orig in Data.Code)
     {
         code_orig.Offset = 0;
-        if (Data.CodeLocals.ByName(code_orig.Name.Content) == null)
+        if (Data.CodeLocals is not null && Data.CodeLocals.ByName(code_orig.Name.Content) == null)
         {
             UndertaleCodeLocals locals = new UndertaleCodeLocals();
             locals.Name = code_orig.Name;
@@ -90,7 +90,7 @@ void DumpCode()
             string x = "";
             try
             {
-                string disasm_code = code_orig.Disassemble(Data.Variables, Data.CodeLocals.For(code_orig));
+                string disasm_code = code_orig.Disassemble(Data.Variables, Data.CodeLocals?.For(code_orig));
                 //ScriptMessage(code_orig.Name.Content);
                 //ScriptMessage("1 " + disasm_code);
                 int ix = -1;
@@ -120,7 +120,7 @@ void DumpCode()
                 string str_path_to_use = Path.Combine(codeFolder, code_orig.Name.Content + ".asm");
                 string code_output = "";
                 if (code_orig != null)
-                    code_output = code_orig.Disassemble(Data.Variables, Data.CodeLocals.For(code_orig));
+                    code_output = code_orig.Disassemble(Data.Variables, Data.CodeLocals?.For(code_orig));
                 File.WriteAllText(str_path_to_use, code_output);
             }
             catch (Exception e)
@@ -144,7 +144,7 @@ void DumpCode()
                 string str_path_to_use = Path.Combine(codeFolder, "Duplicates", code_orig.Name.Content + ".asm");
                 string code_output = "";
                 if (code_orig != null)
-                    code_output = code_orig.Disassemble(Data.Variables, Data.CodeLocals.For(code_orig));
+                    code_output = code_orig.Disassemble(Data.Variables, Data.CodeLocals?.For(code_orig));
                 File.WriteAllText(str_path_to_use, code_output);
             }
             catch (Exception e)

--- a/UndertaleModTool/Scripts/Technical Scripts/RestoreMissingCodeLocals.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/RestoreMissingCodeLocals.csx
@@ -1,6 +1,7 @@
-if (Data?.GeneralInfo.BytecodeVersion < 15)
+EnsureDataLoaded();
+if (Data.CodeLocals is null)
 {
-    ScriptMessage("Cannot run on this game, bytecode >= 15 required!");
+    ScriptMessage("Cannot run on this game, bytecode >= 15 and GM <= 2024.8 required!");
     return;
 }
 int newCount = 0;

--- a/UndertaleModTool/Scripts/Technical Scripts/TestExportAllCode.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/TestExportAllCode.csx
@@ -170,7 +170,7 @@ if (File.Exists(path_error2))
             string asmPath = Path.Combine(asmFolder, code.Name.Content + ".asm");
             try
             {
-                File.WriteAllText(asmPath, (code != null ? code.Disassemble(Data.Variables, Data.CodeLocals.For(code)) : ""));
+                File.WriteAllText(asmPath, (code != null ? code.Disassemble(Data.Variables, Data.CodeLocals?.For(code)) : ""));
             }
             catch (Exception e)
             {

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -10,6 +10,7 @@ namespace UndertaleModTool.Windows
     public class TypesForVersion
     {
         public (uint Major, uint Minor, uint Release) Version { get; set; }
+        public (uint Major, uint Minor, uint Release) BeforeVersion { get; set; } = (uint.MaxValue, uint.MaxValue, uint.MaxValue);
         public (Type, string)[] Types { get; set; }
     }
 
@@ -172,6 +173,7 @@ namespace UndertaleModTool.Windows
                     {
                         // Bytecode version 15
                         Version = (15, uint.MaxValue, uint.MaxValue),
+                        BeforeVersion = (2024, 8, 0),
                         Types = new[]
                         {
                             (typeof(UndertaleCodeLocals), "Code locals")
@@ -439,7 +441,13 @@ namespace UndertaleModTool.Windows
                 else
                     isAtLeast = typeForVer.Version.CompareTo(version) <= 0;
 
-                if (isAtLeast)
+                bool isAboveMost = false;
+                if (typeForVer.BeforeVersion.Minor == uint.MaxValue)
+                    isAboveMost = typeForVer.BeforeVersion.Major <= bytecodeVersion;
+                else
+                    isAboveMost = typeForVer.BeforeVersion.CompareTo(version) <= 0;
+
+                if (isAtLeast && !isAboveMost)
                     outTypes = typeForVer.Types.UnionBy(outTypes, x => x.Item1);
             }
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -617,7 +617,7 @@ namespace UndertaleModTool.Windows
                             if (objSrc is not UndertaleString obj)
                                 return null;
 
-                            var codeLocals = data.CodeLocals?.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
+                            var codeLocals = data.CodeLocals.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
                             if (codeLocals.Any())
                                 return new() { { "Code locals", checkOne ? codeLocals.ToEmptyArray() : codeLocals.ToArray() } };
                             else

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -615,7 +615,7 @@ namespace UndertaleModTool.Windows
                             if (objSrc is not UndertaleString obj)
                                 return null;
 
-                            var codeLocals = data.CodeLocals.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
+                            var codeLocals = data.CodeLocals?.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
                             if (codeLocals.Any())
                                 return new() { { "Code locals", checkOne ? codeLocals.ToEmptyArray() : codeLocals.ToArray() } };
                             else

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -32,6 +32,7 @@ namespace UndertaleModTool.Windows
     public class PredicateForVersion
     {
         public (uint Major, uint Minor, uint Release) Version { get; set; }
+        public (uint Major, uint Minor, uint Release) BeforeVersion { get; set; } = (uint.MaxValue, uint.MaxValue, uint.MaxValue);
         public Func<object, HashSetTypesOverride, bool, Dictionary<string, object[]>> Predicate { get; set; }
     }
 
@@ -607,6 +608,7 @@ namespace UndertaleModTool.Windows
                     {
                         // Bytecode version 15
                         Version = (15, uint.MaxValue, uint.MaxValue),
+                        BeforeVersion = (2024, 8, 0),
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleCodeLocals)))
@@ -1434,7 +1436,13 @@ namespace UndertaleModTool.Windows
                 else
                     isAtLeast = predicateForVer.Version.CompareTo(ver) <= 0;
 
-                if (isAtLeast)
+                bool isAboveMost = false;
+                if (predicateForVer.BeforeVersion.Minor == uint.MaxValue)
+                    isAboveMost = predicateForVer.BeforeVersion.Major <= data.GeneralInfo.BytecodeVersion;
+                else
+                    isAboveMost = predicateForVer.BeforeVersion.CompareTo(ver) <= 0;
+
+                if (isAtLeast && !isAboveMost)
                 {
                     var result = predicateForVer.Predicate(obj, types, checkOne);
                     if (result is null)


### PR DESCRIPTION
## Description
As @colinator27 [noted](https://discord.com/channels/566861759210586112/568950566122946580/1271280990370664469) around the time of GM 2024.8(00) Beta's release, this GM version removes the CodeLocals list from the FUNC chunk. This PR adds logic to detect this, and makes builtin scripts aware of this.

Might fix #1928.

For contributors: feel free to continue this yourself if it's stuck in limbo or something.

### Caveats
* HEAVILY UNTESTED, the disassembler didn't get touched a lot. I only checked whether (de)serialization works as expected.
* Variable names are no longer highlighted in the code editor.

### Notes
Data.CodeLocals is now null if the bytecode version doesn't support it, it must be created manually if needed.