### PR TITLE
Add ParentEntry to code editor

### DIFF
--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -22,13 +22,15 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <local:TextBoxDark Grid.Column="0" x:Name="ObjectText" IsReadOnly="True" Cursor="Arrow" AllowDrop="True"
-                           ToolTip="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!"
-                           ToolTipService.InitialShowDelay="250"
                            PreviewDragOver="TextBox_DragOver" PreviewDrop="TextBox_Drop" PreviewMouseDoubleClick="TextBox_MouseDoubleClick" PreviewMouseDown="Details_MouseDown"
                            Text="{Binding ObjectReference, ElementName=objectReference}">
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">
                     <Style.Triggers>
+                        <DataTrigger Binding="{Binding CanDragInto, ElementName=objectReference}" Value="True">
+                            <Setter Property="ToolTip" Value="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!" />
+                            <Setter Property="ToolTipService.InitialShowDelay" Value="250" />
+                        </DataTrigger>
                         <DataTrigger Binding="{Binding ObjectReference, ElementName=objectReference}" Value="{x:Null}">
                             <Setter Property="Background">
                                 <Setter.Value>

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml
@@ -27,7 +27,7 @@
             <TextBox.Style>
                 <Style TargetType="{x:Type TextBox}">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding CanDragInto, ElementName=objectReference}" Value="True">
+                        <DataTrigger Binding="{Binding CanChange, ElementName=objectReference}" Value="True">
                             <Setter Property="ToolTip" Value="This is an object reference. Drag and drop an object of matching type from the tree on the left to change it!" />
                             <Setter Property="ToolTipService.InitialShowDelay" Value="250" />
                         </DataTrigger>

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -67,8 +67,8 @@ namespace UndertaleModTool
                 new FrameworkPropertyMetadata(true,
                     FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
 					
-        public static DependencyProperty CanDragIntoProperty =
-            DependencyProperty.Register("CanDragInto", typeof(bool),
+        public static DependencyProperty CanChangeProperty =
+            DependencyProperty.Register("CanChange", typeof(bool),
                 typeof(UndertaleObjectReference),
                 new FrameworkPropertyMetadata(true,
                     FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
@@ -104,10 +104,10 @@ namespace UndertaleModTool
             set { SetValue(CanRemoveProperty, value); }
         }
 
-        public bool CanDragInto
+        public bool CanChange
         {
-            get { return (bool)GetValue(CanDragIntoProperty); }
-            set { SetValue(CanDragIntoProperty, value); }
+            get { return (bool)GetValue(CanChangeProperty); }
+            set { SetValue(CanChangeProperty, value); }
         }
 
         public EventType ObjectEventType
@@ -149,7 +149,7 @@ namespace UndertaleModTool
             if (Array.IndexOf(vowels, typeName[0]) != -1)
                 n = "n";
 
-            if (CanDragInto)
+            if (CanChange)
                 label.Content = $"(drag & drop a{n} {typeName})";
             else
                 label.Content = $"(empty {typeName} reference)";
@@ -259,7 +259,7 @@ namespace UndertaleModTool
         {
             UndertaleObject sourceItem = e.Data.GetData(e.Data.GetFormats()[0]) as UndertaleObject;
 
-            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && CanDragInto && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
+            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && CanChange && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
             e.Handled = true;
         }
 
@@ -267,7 +267,7 @@ namespace UndertaleModTool
         {
             UndertaleObject sourceItem = e.Data.GetData(e.Data.GetFormats()[0]) as UndertaleObject;
 
-            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && CanDragInto && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
+            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && CanChange && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
             if (e.Effects == DragDropEffects.Link)
             {
                 ObjectReference = sourceItem;

--- a/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
+++ b/UndertaleModTool/Controls/UndertaleObjectReference.xaml.cs
@@ -66,7 +66,13 @@ namespace UndertaleModTool
                 typeof(UndertaleObjectReference),
                 new FrameworkPropertyMetadata(true,
                     FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
-
+					
+        public static DependencyProperty CanDragIntoProperty =
+            DependencyProperty.Register("CanDragInto", typeof(bool),
+                typeof(UndertaleObjectReference),
+                new FrameworkPropertyMetadata(true,
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+				
         public static DependencyProperty ObjectEventTypeProperty =
             DependencyProperty.Register("ObjectEventType", typeof(EventType),
                 typeof(UndertaleObjectReference),
@@ -94,8 +100,14 @@ namespace UndertaleModTool
 
         public bool CanRemove
         {
-            get { return (bool)GetValue(ObjectTypeProperty); }
-            set { SetValue(ObjectTypeProperty, value); }
+            get { return (bool)GetValue(CanRemoveProperty); }
+            set { SetValue(CanRemoveProperty, value); }
+        }
+
+        public bool CanDragInto
+        {
+            get { return (bool)GetValue(CanDragIntoProperty); }
+            set { SetValue(CanDragIntoProperty, value); }
         }
 
         public EventType ObjectEventType
@@ -136,8 +148,11 @@ namespace UndertaleModTool
             // If the first letter is a vowel
             if (Array.IndexOf(vowels, typeName[0]) != -1)
                 n = "n";
-                
-            label.Content = $"(drag & drop a{n} {typeName})";
+
+            if (CanDragInto)
+                label.Content = $"(drag & drop a{n} {typeName})";
+            else
+                label.Content = $"(empty {typeName} reference)";
         }
 
         public void ClearRemoveClickHandler()
@@ -244,7 +259,7 @@ namespace UndertaleModTool
         {
             UndertaleObject sourceItem = e.Data.GetData(e.Data.GetFormats()[0]) as UndertaleObject;
 
-            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
+            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && CanDragInto && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
             e.Handled = true;
         }
 
@@ -252,7 +267,7 @@ namespace UndertaleModTool
         {
             UndertaleObject sourceItem = e.Data.GetData(e.Data.GetFormats()[0]) as UndertaleObject;
 
-            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
+            e.Effects = e.AllowedEffects.HasFlag(DragDropEffects.Link) && sourceItem != null && CanDragInto && sourceItem.GetType() == ObjectType ? DragDropEffects.Link : DragDropEffects.None;
             if (e.Effects == DragDropEffects.Link)
             {
                 ObjectReference = sourceItem;

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
@@ -14,12 +14,16 @@
     <UserControl.InputBindings>
         <KeyBinding Modifiers="Control" Key="K" Command="{x:Static local:UndertaleCodeEditor.Compile}"/>
     </UserControl.InputBindings>
+    <UserControl.Resources>
+        <local:NullToVisibilityConverter x:Key="VisibleIfNotNull" nullValue="Collapsed" notNullValue="Visible"/>
+    </UserControl.Resources>
     <Grid MaxHeight="{Binding ElementName=DataEditor, Path=ActualHeight}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
             <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -39,7 +43,10 @@
         <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Offset</TextBlock>
         <local:TextBoxDark Grid.Row="3" Grid.Column="1" Margin="3" Text="{Binding Offset}"/>
 
-        <TabControl x:Name="CodeModeTabs" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" SelectionChanged="TabControl_SelectionChanged">
+        <TextBlock Grid.Row="4" Grid.Column="0" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}">Parent entry</TextBlock>
+        <local:UndertaleObjectReference Grid.Row="4" Grid.Column="1" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}" ObjectReference="{Binding ParentEntry}" ObjectType="{x:Type undertale:UndertaleCode}" CanRemove="False"/>
+
+        <TabControl x:Name="CodeModeTabs" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="Decompiled" Name="DecompiledTab">
                 <Grid>
                     <avalonEdit:TextEditor

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
@@ -44,7 +44,7 @@
         <local:TextBoxDark Grid.Row="3" Grid.Column="1" Margin="3" Text="{Binding Offset}"/>
 
         <TextBlock Grid.Row="4" Grid.Column="0" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}">Parent entry</TextBlock>
-        <local:UndertaleObjectReference Grid.Row="4" Grid.Column="1" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}" ObjectReference="{Binding ParentEntry}" ObjectType="{x:Type undertale:UndertaleCode}" CanRemove="False"/>
+        <local:UndertaleObjectReference Grid.Row="4" Grid.Column="1" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}" ObjectReference="{Binding ParentEntry}" ObjectType="{x:Type undertale:UndertaleCode}" CanRemove="False" CanDragInto="False"/>
 
         <TabControl x:Name="CodeModeTabs" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="Decompiled" Name="DecompiledTab">

--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml
@@ -44,7 +44,7 @@
         <local:TextBoxDark Grid.Row="3" Grid.Column="1" Margin="3" Text="{Binding Offset}"/>
 
         <TextBlock Grid.Row="4" Grid.Column="0" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}">Parent entry</TextBlock>
-        <local:UndertaleObjectReference Grid.Row="4" Grid.Column="1" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}" ObjectReference="{Binding ParentEntry}" ObjectType="{x:Type undertale:UndertaleCode}" CanRemove="False" CanDragInto="False"/>
+        <local:UndertaleObjectReference Grid.Row="4" Grid.Column="1" Margin="3" Visibility="{Binding ParentEntry, Converter={StaticResource VisibleIfNotNull}}" ObjectReference="{Binding ParentEntry}" ObjectType="{x:Type undertale:UndertaleCode}" CanRemove="False" CanChange="False"/>
 
         <TabControl x:Name="CodeModeTabs" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="Decompiled" Name="DecompiledTab">


### PR DESCRIPTION
## Description
This PR makes it so you can see the ParentEntry property in the code editor.
Often when searching for a specific function you'll find the code entry referencing it, but then have to manually search for the parent entry to view/edit its contents. This change would make it easier to go there, you just need to double click it.

The property won't be displayed when null (so it will only show up when relevant), and can't be edited or set to null.

Screenshot from Void Stranger's `gml_Script_scr_steam_achievement_get`:
![image](https://github.com/user-attachments/assets/391266bc-f6f2-4fd3-ae97-53d653b7a58a)

### Caveats

### Notes
