### PR TITLE
fix #1940

### DIFF
--- a/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleCodeEditor.xaml.cs
@@ -519,7 +519,8 @@ namespace UndertaleModTool
             if (code.ParentEntry != null)
             {
                 DisassemblyEditor.IsReadOnly = true;
-                text = "; This code entry is a reference to an anonymous function within " + code.ParentEntry.Name.Content + ", view it there";
+                text = "; This code entry is a reference to an anonymous function within " + code.ParentEntry.Name.Content + ", view it there.";
+                DisassemblyChanged = false;
             }
             else
             {
@@ -645,7 +646,8 @@ namespace UndertaleModTool
 
             if (code.ParentEntry != null)
             {
-                DecompiledEditor.Text = "// This code entry is a reference to an anonymous function within " + code.ParentEntry.Name.Content + ", view it there";
+                DecompiledEditor.Text = "// This code entry is a reference to an anonymous function within " + code.ParentEntry.Name.Content + ", view it there.";
+                DecompiledChanged = false;
                 CurrentDecompiled = code;
                 existingDialog?.TryClose();
             }


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->
Fix DecompiledEditor and DisassemblyEditor erroneously reporting that they have changed when loading a child code entry, resulting in an error when trying to save.

Also added periods to the end of the sentences presented to the user.
### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

### Notes
<!-- Any notes or closing words -->