### PR TITLE
Fix UTMT crash when searching for a lot of unreferenced assets

### DIFF
--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -559,14 +559,20 @@ namespace UndertaleModTool.Windows
                                 if (constantsMatches)
                                     outDict["Game options constants"] = new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) };
                             }
-
-                            if (types.Contains(typeof(UndertaleLanguage)))
+                            try
                             {
-                                bool langsMatches = data.Language.EntryIDs.Contains(obj)
-                                                    || data.Language.Languages.Any(x => x.Name == obj || x.Region == obj
-                                                                                        || x.Entries.Contains(obj));
-                                if (langsMatches)
-                                    outDict["Languages"] = new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) };
+                                if (types.Contains(typeof(UndertaleLanguage)))
+                                {
+                                    bool langsMatches = data.Language.EntryIDs.Contains(obj)
+                                                        || data.Language.Languages.Any(x => x.Name == obj || x.Region == obj
+                                                                                            || x.Entries.Contains(obj));
+                                    if (langsMatches)
+                                        outDict["Languages"] = new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) };
+                                }
+                            }
+                            catch(Exception e)
+                            {
+                                //Do nothing
                             }
 
                             if (types.Contains(typeof(UndertalePath)))


### PR DESCRIPTION
For example, in Undertale, if you tried to find unreferenced assets in all groups UTMT would crash. This fixes that by using just a try catch.

## Description
Old error:
![old error](https://github.com/user-attachments/assets/f44fbdc7-acc2-48ee-b4cd-50f84a51d05a)


### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

### Notes
<!-- Any notes or closing words -->