### PR TITLE
Find references crash fix

### DIFF
--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -22,6 +22,8 @@ namespace UndertaleModTool.Windows
     /// </summary>
     public partial class FindReferencesTypesDialog : Window
     {
+        private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+
         private readonly UndertaleResource sourceObj;
         private readonly UndertaleData data;
         private readonly bool dontShowWindow = false;
@@ -140,9 +142,21 @@ namespace UndertaleModTool.Windows
                     return;
                 }
 
-                var results = UndertaleResourceReferenceMethodsMap.GetReferencesOfObject(sourceObj, data, typesList);
-                FindReferencesResults dialog = new(sourceObj, data, results);
-                dialog.Show();
+                FindReferencesResults dialog = null;
+                try
+                {
+                    var results = UndertaleResourceReferenceMethodsMap.GetReferencesOfObject(sourceObj, data, typesList);
+                    dialog = new(sourceObj, data, results);
+                    dialog.Show();
+                }
+                catch (Exception ex)
+                {
+                    mainWindow.ShowError("An error occured in the object references related window.\n" +
+                                         $"Please report this on GitHub.\n\n{ex}");
+                    dialog?.Close();
+
+                }
+
             }
             else
             {
@@ -173,9 +187,19 @@ namespace UndertaleModTool.Windows
                 }
 
                 Hide();
-                var results = await UndertaleResourceReferenceMethodsMap.GetUnreferencedObjects(data, typesDict);
-                FindReferencesResults dialog = new(data, results);
-                dialog.Show();
+                FindReferencesResults dialog = null;
+                try
+                {
+                    var results = await UndertaleResourceReferenceMethodsMap.GetUnreferencedObjects(data, typesDict);
+                    dialog = new(data, results);
+                    dialog.Show();
+                }
+                catch (Exception ex)
+                {
+                    mainWindow.ShowError("An error occured in the object references related window.\n" +
+                                         $"Please report this on GitHub.\n\n{ex}");
+                    dialog?.Close();
+                }
             }
 
             Close();

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -161,7 +161,6 @@ namespace UndertaleModTool.Windows
                             (typeof(UndertaleGameObject), "Game objects"),
                             (typeof(UndertaleGeneralInfo), "General info"),
                             (typeof(UndertaleOptions.Constant), "Game options constants"),
-                            (typeof(UndertaleLanguage), "Languages"),
                             (typeof(UndertalePath), "Paths"),
                             (typeof(UndertaleRoom), "Rooms"),
                             (typeof(UndertaleScript), "Scripts"),
@@ -176,6 +175,15 @@ namespace UndertaleModTool.Windows
                         Types = new[]
                         {
                             (typeof(UndertaleCodeLocals), "Code locals")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        // Bytecode version 16
+                        Version = (16, uint.MaxValue, uint.MaxValue),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleLanguage), "Languages"),
                         }
                     },
                     new TypesForVersion

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1590,6 +1590,9 @@ namespace UndertaleModTool.Windows
                 funcReferences = null;
                 variReferences = null;
 
+                await mainWindow.StopProgressBarUpdater();
+                mainWindow.HideProgressBar();
+
                 throw;
             }
             mainWindow.IsEnabled = true;

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -560,15 +560,6 @@ namespace UndertaleModTool.Windows
                                     outDict["Game options constants"] = new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) };
                             }
 
-                            if (types.Contains(typeof(UndertaleLanguage)))
-                            {
-                                bool langsMatches = data.Language.EntryIDs.Contains(obj)
-                                                    || data.Language.Languages.Any(x => x.Name == obj || x.Region == obj
-                                                                                        || x.Entries.Contains(obj));
-                                if (langsMatches)
-                                    outDict["Languages"] = new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) };
-                            }
-
                             if (types.Contains(typeof(UndertalePath)))
                             {
                                 var paths = data.Paths.Where(x => x.Name == obj);
@@ -627,6 +618,28 @@ namespace UndertaleModTool.Windows
                             var codeLocals = data.CodeLocals.Where(x => x.Name == obj || x.Locals.Any(l => l.Name == obj));
                             if (codeLocals.Any())
                                 return new() { { "Code locals", checkOne ? codeLocals.ToEmptyArray() : codeLocals.ToArray() } };
+                            else
+                                return null;
+                        }
+                    },
+                    new PredicateForVersion()
+                    {
+                        // Bytecode version 16
+                        Version = (16, uint.MaxValue, uint.MaxValue),
+                        Predicate = (objSrc, types, checkOne) =>
+                        {
+                            if (!types.Contains(typeof(UndertaleLanguage)))
+                                return null;
+
+                            if (objSrc is not UndertaleString obj)
+                                return null;
+
+                            bool langsMatches = data.Language.EntryIDs.Contains(obj)
+                                                || data.Language.Languages.Any(x => x.Name == obj || x.Region == obj
+                                                                                    || x.Entries.Contains(obj));
+
+                            if (langsMatches)
+                                return new() { { "Languages",  new object[] { new GeneralInfoEditor(data.GeneralInfo, data.Options, data.Language) } } };
                             else
                                 return null;
                         }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1579,26 +1579,17 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
-
+            }
+            finally
+            {
                 await mainWindow.StopProgressBarUpdater();
                 mainWindow.HideProgressBar();
-            }
-            catch
-            {
+
                 mainWindow.IsEnabled = true;
                 stringReferences = null;
                 funcReferences = null;
                 variReferences = null;
-
-                await mainWindow.StopProgressBarUpdater();
-                mainWindow.HideProgressBar();
-
-                throw;
             }
-            mainWindow.IsEnabled = true;
-            stringReferences = null;
-            funcReferences = null;
-            variReferences = null;
 
             if (outDict.Count == 0)
                 return null;


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->
Fixes #1946 by only checking language for bytecode 16 and above games.
Based on https://github.com/UnderminersTeam/UndertaleModTool/wiki/Bytecode-version-differences.

Also adds error handling to all functions which use GetReferencesOfObject so if something similar happens again it won't cause the tool to crash.
### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

### Notes
<!-- Any notes or closing words -->
Replaces #1942.
Thanks to @maxiterr1 for bringing this to my attention.