### PR TITLE
Fix 2024.6 masks not showing

### DIFF
--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -347,8 +347,13 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
     {
         public byte[] Data { get; set; }
 
-        // Not in the data file
+        /// <summary>
+        /// Width of this sprite mask. UTMT only.
+        /// </summary>
         public uint Width { get; set; }
+        /// <summary>
+        /// Height of this sprite mask. UTMT only.
+        /// </summary>
         public uint Height { get; set; }
 
         public MaskEntry()

--- a/UndertaleModLib/Models/UndertaleSprite.cs
+++ b/UndertaleModLib/Models/UndertaleSprite.cs
@@ -279,9 +279,8 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
 
     public MaskEntry NewMaskEntry()
     {
-        MaskEntry newEntry = new MaskEntry();
         uint len = (Width + 7) / 8 * Height;
-        newEntry.Data = new byte[len];
+        MaskEntry newEntry = new MaskEntry(new byte[len], Width, Height);
         return newEntry;
     }
 
@@ -348,13 +347,19 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
     {
         public byte[] Data { get; set; }
 
+        // Not in the data file
+        public uint Width { get; set; }
+        public uint Height { get; set; }
+
         public MaskEntry()
         {
         }
 
-        public MaskEntry(byte[] data)
+        public MaskEntry(byte[] data, uint width, uint height)
         {
             this.Data = data;
+            this.Width = width;
+            this.Height = height;
         }
 
         /// <inheritdoc/>
@@ -853,7 +858,7 @@ public class UndertaleSprite : UndertaleNamedResource, PrePaddedObject, INotifyP
         uint total = 0;
         for (uint i = 0; i < maskCount; i++)
         {
-            newMasks.Add(new MaskEntry(reader.ReadBytes((int)len)));
+            newMasks.Add(new MaskEntry(reader.ReadBytes((int)len), width, height));
             total += len;
         }
 

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
@@ -217,8 +217,8 @@
                                             <MultiBinding.Converter>
                                                 <local:MaskImageConverter/>
                                             </MultiBinding.Converter>
-                                            <Binding RelativeSource="{RelativeSource AncestorType=UserControl}" Path="DataContext.Width" Mode="OneWay"/>
-                                            <Binding RelativeSource="{RelativeSource AncestorType=UserControl}" Path="DataContext.Height" Mode="OneWay"/>
+                                            <Binding Path="Width" Mode="OneWay"/>
+                                            <Binding Path="Height" Mode="OneWay"/>
                                             <Binding Path="Data" Mode="OneWay"/>
                                         </MultiBinding>
                                     </Image.Source>

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -155,6 +155,8 @@ namespace UndertaleModTool
                 {
                     (uint maskWidth, uint maskHeight) = sprite.CalculateMaskDimensions(mainWindow.Data);
                     target.Data = TextureWorker.ReadMaskData(dlg.FileName, (int)maskWidth, (int)maskHeight);
+                    target.Width = maskWidth;
+                    target.Height = maskHeight;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Description
In GMS 2024.6, masks have the size of the bounding box instead of the same as the sprite. This caused them to not display in the UI if these sizes were different. This PR makes so the mask size is stored so it's displayed correctly in the UI.

### Caveats
None

### Notes
Here's a data.win that has a mask which would not work without theses changes: [fix-2024-6-masks-test.zip](https://github.com/user-attachments/files/17608442/fix-2024-6-masks-test.zip)