### PR TITLE
Add EnableCopyOnWrite flag

### DIFF
--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -703,7 +703,8 @@ public class UndertaleOptions : UndertaleObject, IDisposable
         UseRearTouch = 0x2000000,
         UseFastCollision = 0x4000000,
         FastCollisionCompatibility = 0x8000000,
-        DisableSandbox = 0x10000000
+        DisableSandbox = 0x10000000,
+        EnableCopyOnWrite = 0x20000000
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Adds `EnableCopyOnWrite` to the list of flags in game options, seen in at least 2022 LTS and probably many other upgraded GameMaker games.

### Caveats
Probably none, unless there's some kind of branch in the flags across LTS and modern GameMaker that I'm not aware of. (But I *did* check and it looks to be the same, so there should be no issues.)

### Notes
This is mostly a quick fix to prevent `Flags` from being displayed as an arbitrary number in the tool, which is difficult to work with.