### PR TITLE
Better compiler accuracy for functions named differently/the same as the containing script name

### DIFF
--- a/UndertaleModLib/Compiler/AssemblyWriter.cs
+++ b/UndertaleModLib/Compiler/AssemblyWriter.cs
@@ -1376,9 +1376,18 @@ namespace UndertaleModLib.Compiler
                             cw.typeStack.Push(DataType.Variable);
                             cw.Emit(Opcode.Dup, DataType.Variable).Extra = 0;
                             if (isStructDef)
+                            {
                                 cw.Emit(Opcode.PushI, DataType.Int16).Value = (short)-16;
+                            }
+                            else if (cw.compileContext.OriginalCode?.Name?.Content == ("gml_GlobalScript_" + funcDefName.Text))
+                            {
+                                // -1 when the function is named the same as the script name
+                                cw.Emit(Opcode.PushI, DataType.Int16).Value = (short)-1;
+                            }
                             else
-                                cw.Emit(Opcode.PushI, DataType.Int16).Value = (short)-1; // todo: -6 sometimes?
+                            {
+                                cw.Emit(Opcode.PushI, DataType.Int16).Value = (short)-6; 
+                            }
                         }
                         break;
                     case Parser.Statement.StatementKind.ExprBinaryOp:


### PR DESCRIPTION
## Description
This is a port of a very tiny compiler assembly accuracy improvement from UTMTCE.

You know that one pushi.e instruction for function definitions that is -1 sometimes and -6 other times? That instructions's value is -1 if the function's name is the same as the script it's in, and -6 if it isn't.
Not sure what effect this has on the runtime (possibly none), but it does make a difference in the assembly.

### Caveats
This is done by comparing to the code entry name, I'm not sure if it should be done like that. (Iterating through all script entries might be cleaner but that would also probably be slower.)