### PR TITLE
Add flags editor

### DIFF
--- a/UndertaleModTool/Controls/FlagsBox.xaml
+++ b/UndertaleModTool/Controls/FlagsBox.xaml
@@ -1,0 +1,38 @@
+﻿<UserControl x:Class="UndertaleModTool.FlagsBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:UndertaleModTool"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800"
+             x:Name="flagsBox">
+    <UserControl.Resources>
+        <local:EnumToValuesConverter x:Key="enumToValuesConverter" />
+    </UserControl.Resources>
+    <StackPanel>
+        <TextBox Text="{Binding Value, ElementName=flagsBox}" />
+        <Expander Header="Flags">
+            <ItemsControl ItemsSource="{Binding Value, ElementName=flagsBox, Converter={StaticResource enumToValuesConverter}}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel>
+                            <CheckBox>
+                                <CheckBox.Resources>
+                                    <local:EnumFlagToBoolConverter x:Key="enumFlagToBoolConverter"/>
+                                </CheckBox.Resources>
+                                <CheckBox.IsChecked>
+                                    <MultiBinding Converter="{StaticResource enumFlagToBoolConverter}">
+                                        <Binding Path="Value" ElementName="flagsBox" />
+                                        <Binding Path="."/>
+                                    </MultiBinding>
+                                </CheckBox.IsChecked>
+                                <Label Content="{Binding}" Padding="0" />
+                            </CheckBox>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </Expander>
+    </StackPanel>
+</UserControl>

--- a/UndertaleModTool/Controls/FlagsBox.xaml.cs
+++ b/UndertaleModTool/Controls/FlagsBox.xaml.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace UndertaleModTool
+{
+    /// <summary>
+    /// Interaction logic for FlagsBox.xaml
+    /// </summary>
+    public partial class FlagsBox : UserControl
+    {
+        public object Value
+        {
+            get { return (object)GetValue(ValueProperty); }
+            set { SetValue(ValueProperty, value); }
+        }
+
+        public static readonly DependencyProperty ValueProperty =
+            DependencyProperty.Register("Value", typeof(object),
+                typeof(FlagsBox),
+                new FrameworkPropertyMetadata(null,
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public FlagsBox()
+        {
+            InitializeComponent();
+        }
+    }
+
+    public class EnumToValuesConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is null)
+            {
+                return Array.Empty<string>();
+            }
+            return Enum.GetValues(value.GetType());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+
+    public class EnumFlagToBoolConverter : IMultiValueConverter
+    {
+        dynamic enumValue;
+        dynamic flag;
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Any(x => x == DependencyProperty.UnsetValue))
+                return DependencyProperty.UnsetValue;
+
+            enumValue = (Enum)values[0];
+            flag = (Enum)values[1];
+
+            return enumValue.HasFlag(flag);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            if ((bool)value)
+            {
+                enumValue |= flag;
+            }
+            else
+            {
+                enumValue &= ~flag;
+            }
+            return new object[] { enumValue, flag };
+        }
+    }
+}

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
@@ -118,7 +118,7 @@
                 </Grid>
 
                 <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Flags</TextBlock>
-                <local:TextBoxDark Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.Info}"/>
+                <local:FlagsBox Grid.Row="12" Grid.Column="1" Margin="3" Value="{Binding GeneralInfo.Info}" />
 
                 <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">License MD5</TextBlock>
                 <local:TextBoxDark Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LicenseMD5, Mode=TwoWay, Converter={StaticResource byteArrayConverter}}"/>
@@ -148,7 +148,7 @@
                 <local:TextBoxDark Grid.Row="17" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.ActiveTargets}"/>
 
                 <TextBlock Grid.Row="18" Grid.Column="0" Margin="3">Function classifications</TextBlock>
-                <local:TextBoxDark Grid.Row="18" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.FunctionClassifications}"/>
+                <local:FlagsBox Grid.Row="18" Grid.Column="1" Margin="3" Value="{Binding GeneralInfo.FunctionClassifications}"/>
 
                 <TextBlock Grid.Row="19" Grid.Column="0" Margin="3">Steam AppID</TextBlock>
                 <local:TextBoxDark Grid.Row="19" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.SteamAppID}"/>
@@ -262,7 +262,7 @@
                 </Grid>
 
                 <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Flags</TextBlock>
-                <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding Options.Info}"/>
+                <local:FlagsBox Grid.Row="1" Grid.Column="1" Margin="3" Value="{Binding Options.Info}" />
 
                 <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Scale</TextBlock>
                 <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Text="{Binding Options.Scale}"/>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -384,7 +384,7 @@
                                 <RowDefinition Height="Auto" SharedSizeGroup="{Binding Flags, Mode=OneTime, Converter={StaticResource GridSizeGroupConverter}}"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="{Binding Flags, Mode=OneTime, Converter={StaticResource GridSizeGroupConverter}}"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
-                                <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
+                                <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
                                 <RowDefinition Height="Auto" SharedSizeGroup="s22"/>
@@ -433,7 +433,7 @@
                             <local:UndertaleObjectReference Grid.Row="7" Grid.Column="2" Margin="3" ObjectReference="{Binding CreationCodeId}" ObjectType="{x:Type undertale:UndertaleCode}"  ObjectEventType="{x:Static undertale:EventType.Create}" ObjectEventSubtype="0"/>
 
                             <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Flags</TextBlock>
-                            <local:TextBoxDark Grid.Row="8" Grid.Column="2" Margin="3" Text="{Binding Flags, Converter={StaticResource IsGMS2Converter}, ConverterParameter=flags}"/>
+                            <local:FlagsBox Grid.Row="8" Grid.Column="2" Margin="3" Value="{Binding Flags, Converter={StaticResource IsGMS2Converter}, ConverterParameter=flags}"/>
 
                             <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">World</TextBlock>
                             <local:TextBoxDark Grid.Row="9" Grid.Column="2" Margin="3" Text="{Binding World}"/>

--- a/UndertaleModTool/Editors/UndertaleSoundEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSoundEditor.xaml
@@ -31,7 +31,7 @@
         <local:UndertaleStringReference Grid.Row="0" Grid.Column="1" Margin="3" ObjectReference="{Binding Name}"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Flags</TextBlock>
-        <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding Flags}"/>
+        <local:FlagsBox Grid.Row="1" Grid.Column="1" Margin="3" Value="{Binding Flags}"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Type</TextBlock>
         <local:UndertaleStringReference Grid.Row="2" Grid.Column="1" Margin="3" ObjectReference="{Binding Type}"/>


### PR DESCRIPTION
## Description
Added a FlagsBox that display all possible flag values of a field as checkboxes. They are hidden in an Expander initially to not create clutter. The TextBox, as it existed before, is still there, so the old method of changing flags still works. If there's unrecognized flags, it'll display the number, and the checkboxes won't override it, simply adding or removing flags normally.

The FlagsBox was added to general info, the sound editor and the room editor.

Example:

![image](https://github.com/user-attachments/assets/4cc4368a-594e-487f-b1f8-58e1722bde93)

### Caveats
Alright, the Expander is a bit a ugly. But what isn't ugly in this, huh? I tried a ComboBox design, but modifying these built in controls is complicated.

### Notes
Fixes #75.