### PR TITLE
Add settings to change transparency colors

### DIFF
--- a/UndertaleModTool/App.xaml
+++ b/UndertaleModTool/App.xaml
@@ -9,7 +9,7 @@
             <MenuItem Command="ApplicationCommands.Copy" />
             <MenuItem Command="ApplicationCommands.Paste" />
         </local:ContextMenuDark>
-        <SolidColorBrush x:Key="TransparencyGridColor1" Color="#ffd3d3d3"/>
-        <SolidColorBrush x:Key="TransparencyGridColor2" Color="#ffffffff"/>
+        <SolidColorBrush x:Key="TransparencyGridColor1" Color="#ff666666"/>
+        <SolidColorBrush x:Key="TransparencyGridColor2" Color="#ff999999"/>
     </Application.Resources>
 </Application>

--- a/UndertaleModTool/App.xaml
+++ b/UndertaleModTool/App.xaml
@@ -9,5 +9,7 @@
             <MenuItem Command="ApplicationCommands.Copy" />
             <MenuItem Command="ApplicationCommands.Paste" />
         </local:ContextMenuDark>
+        <SolidColorBrush x:Key="TransparencyGridColor1" Color="#ffd3d3d3"/>
+        <SolidColorBrush x:Key="TransparencyGridColor2" Color="#ffffffff"/>
     </Application.Resources>
 </Application>

--- a/UndertaleModTool/App.xaml
+++ b/UndertaleModTool/App.xaml
@@ -9,7 +9,7 @@
             <MenuItem Command="ApplicationCommands.Copy" />
             <MenuItem Command="ApplicationCommands.Paste" />
         </local:ContextMenuDark>
-        <SolidColorBrush x:Key="TransparencyGridColor1" Color="#ff666666"/>
-        <SolidColorBrush x:Key="TransparencyGridColor2" Color="#ff999999"/>
+        <SolidColorBrush x:Key="TransparencyGridColor1" Color="#FF666666"/>
+        <SolidColorBrush x:Key="TransparencyGridColor2" Color="#FF999999"/>
     </Application.Resources>
 </Application>

--- a/UndertaleModTool/Controls/TransparencyGridBrush.xaml
+++ b/UndertaleModTool/Controls/TransparencyGridBrush.xaml
@@ -1,21 +1,21 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <DrawingBrush x:Key="TransparencyGridBrushBrush" Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
+    <DrawingBrush x:Key="TransparencyGridBrushBrush" Stretch="None" TileMode="Tile" Viewport="0,0,16,16" ViewportUnits="Absolute">
         <DrawingBrush.Drawing>
             <DrawingGroup>
                 <GeometryDrawing Brush="{DynamicResource TransparencyGridColor1}">
                     <GeometryDrawing.Geometry>
                         <GeometryGroup>
-                            <RectangleGeometry Rect="0,0,10,10"/>
-                            <RectangleGeometry Rect="10,10,10,10"/>
+                            <RectangleGeometry Rect="0,0,8,8"/>
+                            <RectangleGeometry Rect="8,8,8,8"/>
                         </GeometryGroup>
                     </GeometryDrawing.Geometry>
                 </GeometryDrawing>
                 <GeometryDrawing Brush="{DynamicResource TransparencyGridColor2}">
                     <GeometryDrawing.Geometry>
                         <GeometryGroup>
-                            <RectangleGeometry Rect="10,0,10,10"/>
-                            <RectangleGeometry Rect="0,10,10,10"/>
+                            <RectangleGeometry Rect="8,0,8,8"/>
+                            <RectangleGeometry Rect="0,8,8,8"/>
                         </GeometryGroup>
                     </GeometryDrawing.Geometry>
                 </GeometryDrawing>

--- a/UndertaleModTool/Controls/TransparencyGridBrush.xaml
+++ b/UndertaleModTool/Controls/TransparencyGridBrush.xaml
@@ -1,0 +1,25 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DrawingBrush x:Key="TransparencyGridBrushBrush" Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
+        <DrawingBrush.Drawing>
+            <DrawingGroup>
+                <GeometryDrawing Brush="{DynamicResource TransparencyGridColor1}">
+                    <GeometryDrawing.Geometry>
+                        <GeometryGroup>
+                            <RectangleGeometry Rect="0,0,10,10"/>
+                            <RectangleGeometry Rect="10,10,10,10"/>
+                        </GeometryGroup>
+                    </GeometryDrawing.Geometry>
+                </GeometryDrawing>
+                <GeometryDrawing Brush="{DynamicResource TransparencyGridColor2}">
+                    <GeometryDrawing.Geometry>
+                        <GeometryGroup>
+                            <RectangleGeometry Rect="10,0,10,10"/>
+                            <RectangleGeometry Rect="0,10,10,10"/>
+                        </GeometryGroup>
+                    </GeometryDrawing.Geometry>
+                </GeometryDrawing>
+            </DrawingGroup>
+        </DrawingBrush.Drawing>
+    </DrawingBrush>
+</ResourceDictionary>

--- a/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
@@ -7,6 +7,13 @@
              xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleBackground}" DataContextChanged="DataUserControl_DataContextChanged">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
@@ -146,17 +153,7 @@
                         </Style.Triggers>
                     </Style>
                 </Canvas.Style>
-                <Border>
-                    <Border.Background>
-                        <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                            <DrawingBrush.Drawing>
-                                <DrawingGroup>
-                                    <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                    <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                                </DrawingGroup>
-                            </DrawingBrush.Drawing>
-                        </DrawingBrush>
-                    </Border.Background>
+                <Border Background="{DynamicResource TransparencyGridBrushBrush}">
                     <local:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}"/>
                 </Border>
                 <Rectangle Name="TileRectangle" Canvas.Left="0" Canvas.Top="0" Width="{Binding GMS2TileWidth, Mode=OneWay}" Height="{Binding GMS2TileHeight, Mode=OneWay}" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="2" SnapsToDevicePixels="True"

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml
@@ -9,9 +9,14 @@
                        d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleEmbeddedTexture}"
                        DataContextChanged="DataUserControl_DataContextChanged" Loaded="DataUserControl_Loaded" Unloaded="DataUserControl_Unloaded">
     <UserControl.Resources>
-        <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
-        <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>
-        <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
+        <ResourceDictionary>
+            <local:BooleanToVisibilityConverter x:Key="BoolFalseToVisConverter" local:trueValue="Collapsed" local:falseValue="Visible"/>
+            <local:TextureLoadedWrapper x:Key="TextureLoadedWrapper"/>
+            <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -76,18 +81,7 @@
                 </ScrollViewer.Background>
                 <Viewbox Name="TextureViewbox" Stretch="Uniform" StretchDirection="DownOnly"
                          SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor" MouseWheel="TextureViewbox_MouseWheel">
-                    <Border>
-                        <Border.Background>
-                            <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                                <DrawingBrush.Drawing>
-                                    <DrawingGroup>
-                                        <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                        <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                                    </DrawingGroup>
-                                </DrawingBrush.Drawing>
-                            </DrawingBrush>
-                        </Border.Background>
-
+                    <Border Background="{DynamicResource TransparencyGridBrushBrush}">
                         <Grid Cursor="Hand" MouseDown="Grid_MouseDown" MouseMove="Grid_MouseMove" MouseLeave="Grid_MouseLeave">
                             <Image Name="TexturePageImage"/>
                             <Canvas>

--- a/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml
@@ -9,39 +9,44 @@
              mc:Ignorable="d" 
              d:DesignHeight="800" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleGameObject}">
     <UserControl.Resources>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="CollisionShapeFlags">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:CollisionShapeFlags" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeKey">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:EventSubtypeKey" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeStep">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:EventSubtypeStep" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeMouse">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:EventSubtypeMouse" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeOther">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:EventSubtypeOther" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeDraw">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:EventSubtypeDraw" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <local:EventNameConverter x:Key="EventNameConverter"/>
-        <local:GameObjectByIdConverter x:Key="GameObjectByIdConverter"/>
-        <local:IsGMS2Converter x:Key="IsGMS2Converter" />
+        <ResourceDictionary>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="CollisionShapeFlags">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:CollisionShapeFlags" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeKey">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:EventSubtypeKey" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeStep">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:EventSubtypeStep" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeMouse">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:EventSubtypeMouse" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeOther">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:EventSubtypeOther" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EventSubtypeDraw">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:EventSubtypeDraw" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <local:EventNameConverter x:Key="EventNameConverter"/>
+            <local:GameObjectByIdConverter x:Key="GameObjectByIdConverter"/>
+            <local:IsGMS2Converter x:Key="IsGMS2Converter" />
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
 
         <!--
         Leaving this here for now, I might want to add it back for 'advanced' editor
@@ -198,17 +203,7 @@
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Viewbox Stretch="Uniform" StretchDirection="DownOnly">
-                            <Border>
-                                <Border.Background>
-                                    <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                                        <DrawingBrush.Drawing>
-                                            <DrawingGroup>
-                                                <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                                <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                                            </DrawingGroup>
-                                        </DrawingBrush.Drawing>
-                                    </DrawingBrush>
-                                </Border.Background>
+                            <Border Background="{DynamicResource TransparencyGridBrushBrush}">
                                 <local:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}"/>
                             </Border>
                         </Viewbox>

--- a/UndertaleModTool/Editors/UndertaleParticleSystemEmitterEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleParticleSystemEmitterEditor.xaml
@@ -9,32 +9,37 @@
                        mc:Ignorable="d" 
                        d:DesignHeight="4500" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleParticleSystemEmitter}">
     <UserControl.Resources>
-        <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EmitMode">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+EmitMode" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="DistributionEnum">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+DistributionEnum" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EmitterShape">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+EmitterShape" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="TextureEnum">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+TextureEnum" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="TimeUnitEnum">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+TimeUnitEnum" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
+        <ResourceDictionary>
+            <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EmitMode">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+EmitMode" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="DistributionEnum">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+DistributionEnum" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="EmitterShape">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+EmitterShape" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="TextureEnum">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+TextureEnum" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="TimeUnitEnum">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleParticleSystemEmitter+TimeUnitEnum" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid>
@@ -180,17 +185,7 @@
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Viewbox Stretch="Uniform" StretchDirection="DownOnly">
-                        <Border>
-                            <Border.Background>
-                                <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                                    <DrawingBrush.Drawing>
-                                        <DrawingGroup>
-                                            <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                            <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                                        </DrawingGroup>
-                                    </DrawingBrush.Drawing>
-                                </DrawingBrush>
-                            </Border.Background>
+                        <Border Background="{DynamicResource TransparencyGridBrushBrush}">
                             <local:UndertaleTexturePageItemDisplay DataContext="{Binding Texture, Mode=OneWay}"/>
                         </Border>
                     </Viewbox>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor.xaml
@@ -9,43 +9,48 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleRoom}" x:Name="RoomEditor">
     <UserControl.Resources>
-        <local:GridConverter x:Key="GridConverter"/>
-        <local:UndertaleCachedImageLoader x:Key="UndertaleCachedImageLoader"/>
-        <local:ColorConverter x:Key="ColorConverter"/>
-        <local:SimplePointsDisplayConverter x:Key="SimplePointsDisplayConverter"/>
-        <local:LayerItemsSourceConverter x:Key="LayerItemsSourceConverter"/>
-        <local:LayerZIndexConverter x:Key="LayerZIndexConverter"/>
-        <local:IsGMS2Converter x:Key="IsGMS2Converter" />
-        <local:BGColorConverter x:Key="BGColorConverter"/>
-        <local:BGViewportConverter x:Key="BGViewportConverter"/>
-        <local:LayerTypeConverter x:Key="LayerTypeConverter"/>
-        <local:GridSizeGroupConverter x:Key="GridSizeGroupConverter"/>
-        <local:GridColumnSizeConverter x:Key="GridColumnSizeConverter"/>
-        <BooleanToVisibilityConverter x:Key="BoolToVisConverter"/>
-        <local:ColorToOpacityConverter x:Key="ColorToOpacityConverter"/>
-        <local:CachedTileImageLoader x:Key="CachedTileImageLoader"/>
-        <local:CachedTileDataLoader x:Key="CachedTileDataLoader"/>
-        <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
-        <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
-        <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
-        <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
-        <local:NegateNumberConverter x:Key="NegateNumberConverter"/>
-        <local:ParentGridHeightConverter x:Key="ParentGridHeightConverter"/>
-        <local:ParticleSystemRectConverter x:Key="ParticleSystemRectConverter"/>
-        <CompositeCollection x:Key="AllObjectsGMS1">
-            <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Backgrounds}"/>
-            <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Tiles}"/>
-            <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.GameObjects}"/>
-            <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=PreviewPath, Converter={StaticResource SimplePointsDisplayConverter}}"/>
-        </CompositeCollection>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="AnimationSpeedType">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:AnimationSpeedType" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <Style x:Key="Centered" TargetType="FrameworkElement">
-            <Setter Property="VerticalAlignment" Value="Center"/>
-        </Style>
+        <ResourceDictionary>
+            <local:GridConverter x:Key="GridConverter"/>
+            <local:UndertaleCachedImageLoader x:Key="UndertaleCachedImageLoader"/>
+            <local:ColorConverter x:Key="ColorConverter"/>
+            <local:SimplePointsDisplayConverter x:Key="SimplePointsDisplayConverter"/>
+            <local:LayerItemsSourceConverter x:Key="LayerItemsSourceConverter"/>
+            <local:LayerZIndexConverter x:Key="LayerZIndexConverter"/>
+            <local:IsGMS2Converter x:Key="IsGMS2Converter" />
+            <local:BGColorConverter x:Key="BGColorConverter"/>
+            <local:BGViewportConverter x:Key="BGViewportConverter"/>
+            <local:LayerTypeConverter x:Key="LayerTypeConverter"/>
+            <local:GridSizeGroupConverter x:Key="GridSizeGroupConverter"/>
+            <local:GridColumnSizeConverter x:Key="GridColumnSizeConverter"/>
+            <BooleanToVisibilityConverter x:Key="BoolToVisConverter"/>
+            <local:ColorToOpacityConverter x:Key="ColorToOpacityConverter"/>
+            <local:CachedTileImageLoader x:Key="CachedTileImageLoader"/>
+            <local:CachedTileDataLoader x:Key="CachedTileDataLoader"/>
+            <local:TileLayerTemplateSelector x:Key="TileLayerTemplateSelector"/>
+            <local:TileRectanglesConverter x:Key="TileRectanglesConverter"/>
+            <local:CachedImageLoaderWithIndex x:Key="CachedImageLoaderWithIndex"/>
+            <local:IsVersionAtLeastConverter x:Key="IsVersionAtLeastConverter"/>
+            <local:NegateNumberConverter x:Key="NegateNumberConverter"/>
+            <local:ParentGridHeightConverter x:Key="ParentGridHeightConverter"/>
+            <local:ParticleSystemRectConverter x:Key="ParticleSystemRectConverter"/>
+            <CompositeCollection x:Key="AllObjectsGMS1">
+                <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Backgrounds}"/>
+                <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.Tiles}"/>
+                <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=DataContext.GameObjects}"/>
+                <CollectionContainer Collection="{Binding Source={x:Reference RoomEditor}, Path=PreviewPath, Converter={StaticResource SimplePointsDisplayConverter}}"/>
+            </CompositeCollection>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="AnimationSpeedType">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:AnimationSpeedType" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <Style x:Key="Centered" TargetType="FrameworkElement">
+                <Setter Property="VerticalAlignment" Value="Center"/>
+            </Style>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <UserControl.CommandBindings>
@@ -776,17 +781,7 @@
                             </TextBlock>
                             <Viewbox Grid.Row="4" Grid.Column="2" Margin="3" Stretch="Uniform" StretchDirection="DownOnly">
                                 <Canvas Width="{Binding Tpag.BoundingWidth, Mode=OneWay}" Height="{Binding Tpag.BoundingHeight, Mode=OneWay}" SnapsToDevicePixels="True" MouseDown="RectangleTile_MouseDown" MouseMove="RectangleTile_MouseMove">
-                                    <Border>
-                                        <Border.Background>
-                                            <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                                                <DrawingBrush.Drawing>
-                                                    <DrawingGroup>
-                                                        <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                                        <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                                                    </DrawingGroup>
-                                                </DrawingBrush.Drawing>
-                                            </DrawingBrush>
-                                        </Border.Background>
+                                    <Border Background="{DynamicResource TransparencyGridBrushBrush}">
                                         <local:UndertaleTexturePageItemDisplay DataContext="{Binding Tpag, Mode=OneWay}"/>
                                     </Border>
                                     <Rectangle x:Name="TileSelector" Canvas.Left="{Binding SourceX, Mode=OneWay}" Canvas.Top="{Binding SourceY, Mode=OneWay}" Width="{Binding Width, Mode=OneWay}" Height="{Binding Height, Mode=OneWay}" Stroke="#FFB23131" Panel.ZIndex="50" StrokeThickness="2" SnapsToDevicePixels="True">

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
@@ -9,22 +9,27 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleSprite}">
     <UserControl.Resources>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="SpriteType">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleSprite+SpriteType" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="SepMaskType">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:UndertaleSprite+SepMaskType" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="AnimSpeedType">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type TypeName="undertale:AnimSpeedType" />
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <ResourceDictionary>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="SpriteType">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleSprite+SpriteType" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="SepMaskType">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:UndertaleSprite+SepMaskType" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider MethodName="GetValues" ObjectType="{x:Type sys:Enum}" x:Key="AnimSpeedType">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="undertale:AnimSpeedType" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <BooleanToVisibilityConverter x:Key="BoolToVis" />
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -149,17 +154,7 @@
         </local:DataGridDark>
 
         <Viewbox Grid.Row="11" Grid.Column="1" Stretch="Uniform" StretchDirection="DownOnly">
-            <Border>
-                <Border.Background>
-                    <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                        <DrawingBrush.Drawing>
-                            <DrawingGroup>
-                                <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                            </DrawingGroup>
-                        </DrawingBrush.Drawing>
-                    </DrawingBrush>
-                </Border.Background>
+            <Border Background="{StaticResource TransparencyGridBrushBrush}">
                 <local:UndertaleTexturePageItemDisplay DataContext="{Binding SelectedItem.Texture, Mode=OneWay, ElementName=TextureList}" x:Name="TextureDisplay"/>
             </Border>
         </Viewbox>

--- a/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleTexturePageItemEditor.xaml
@@ -7,6 +7,13 @@
              xmlns:undertale="clr-namespace:UndertaleModLib.Models;assembly=UndertaleModLib"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{d:DesignInstance undertale:UndertaleTexturePageItem}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
@@ -68,18 +75,7 @@
                           Click="FindReferencesButton_Click">Find all references to this page item</local:ButtonDark>
 
         <Viewbox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly" Margin="3">
-            <Border>
-                <Border.Background>
-                    <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                        <DrawingBrush.Drawing>
-                            <DrawingGroup>
-                                <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                            </DrawingGroup>
-                        </DrawingBrush.Drawing>
-                    </DrawingBrush>
-                </Border.Background>
-                
+            <Border Background="{StaticResource TransparencyGridBrushBrush}">
                 <local:UndertaleTexturePageItemDisplay x:Name="ItemDisplay"/>
             </Border>
         </Viewbox>
@@ -97,24 +93,13 @@
 
         <Viewbox Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Stretch="Uniform" StretchDirection="DownOnly"
                  SnapsToDevicePixels="True" RenderOptions.BitmapScalingMode="NearestNeighbor">
-            <Grid>
+            <Grid Background="{StaticResource TransparencyGridBrushBrush}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                
-                <Grid.Background>
-                    <DrawingBrush Stretch="None" TileMode="Tile" Viewport="0,0,20,20" ViewportUnits="Absolute">
-                        <DrawingBrush.Drawing>
-                            <DrawingGroup>
-                                <GeometryDrawing Geometry="M0,0 L20,0 20,20, 0,20Z" Brush="White"/>
-                                <GeometryDrawing Geometry="M0,10 L20,10 20,20, 10,20 10,0 0,0Z" Brush="LightGray"/>
-                            </DrawingGroup>
-                        </DrawingBrush.Drawing>
-                    </DrawingBrush>
-                </Grid.Background>
 
                 <Image Grid.Row="0" Grid.Column="1" Name="ItemTextureBGImage" Opacity="0.2"/>
 

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -352,6 +352,12 @@ namespace UndertaleModTool
                 SetDarkMode(true, true);
                 SetDarkTitleBarForWindow(this, true, false);
             }
+
+            try
+            {
+                SetTransparencyGridColors(Settings.Instance.TransparencyGridColor1, Settings.Instance.TransparencyGridColor2);
+            }
+            catch (FormatException) { }
         }
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
@@ -654,6 +660,12 @@ namespace UndertaleModTool
             {
                 Debug.WriteLine($"SetDarkTitleBarForWindow() error for window \"{form}\" - {ex.GetType()}: {ex.Message}");
             }
+        }
+
+        public static void SetTransparencyGridColors(string color1, string color2)
+        {
+            Application.Current.Resources["TransparencyGridColor1"] = new SolidColorBrush((Color)System.Windows.Media.ColorConverter.ConvertFromString(color1));
+            Application.Current.Resources["TransparencyGridColor2"] = new SolidColorBrush((Color)System.Windows.Media.ColorConverter.ConvertFromString(color2));
         }
 
         private async void Command_New(object sender, ExecutedRoutedEventArgs e)

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -51,6 +51,9 @@ namespace UndertaleModTool
         public double GlobalGridThickness { get; set; } = 1;
         public bool GridThicknessEnabled { get; set; } = false;
 
+        public string TransparencyGridColor1 { get; set; } = "#ffd3d3d3";
+        public string TransparencyGridColor2 { get; set; } = "#ffffffff";
+
         public bool EnableDarkMode { get; set; } = false;
         public bool ShowDebuggerOption { get; set; } = false;
 

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -51,8 +51,8 @@ namespace UndertaleModTool
         public double GlobalGridThickness { get; set; } = 1;
         public bool GridThicknessEnabled { get; set; } = false;
 
-        public string TransparencyGridColor1 { get; set; } = "#ff666666";
-        public string TransparencyGridColor2 { get; set; } = "#ff999999";
+        public string TransparencyGridColor1 { get; set; } = "#FF666666";
+        public string TransparencyGridColor2 { get; set; } = "#FF999999";
 
         public bool EnableDarkMode { get; set; } = false;
         public bool ShowDebuggerOption { get; set; } = false;

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -51,8 +51,8 @@ namespace UndertaleModTool
         public double GlobalGridThickness { get; set; } = 1;
         public bool GridThicknessEnabled { get; set; } = false;
 
-        public string TransparencyGridColor1 { get; set; } = "#ffd3d3d3";
-        public string TransparencyGridColor2 { get; set; } = "#ffffffff";
+        public string TransparencyGridColor1 { get; set; } = "#ff666666";
+        public string TransparencyGridColor2 { get; set; } = "#ff999999";
 
         public bool EnableDarkMode { get; set; } = false;
         public bool ShowDebuggerOption { get; set; } = false;

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -6,7 +6,14 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:UndertaleModTool"
         mc:Ignorable="d"
-        Title="Settings" Height="Auto" Width="800" SizeToContent="Height" WindowStartupLocation="CenterOwner">
+        Title="Settings" Height="Auto" Width="800" SizeToContent="Height" WindowStartupLocation="CenterOwner" UseLayoutRounding="False">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Controls/TransparencyGridBrush.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="10">
             <Grid.ColumnDefinitions>
@@ -16,6 +23,7 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -65,19 +73,27 @@
             <CheckBox Grid.Row="7" Grid.Column="0" Margin="3" Content="" IsChecked="{Binding EnableDarkMode}"/>
             <TextBlock Grid.Row="7" Grid.Column="0" Margin="25 2 2 2" Text="Enable dark mode" ToolTip="Makes the program interface dark. Disabled by default."/>
 
-            <Separator Grid.Row="8" Grid.ColumnSpan="4" Margin="10"/>
+            <StackPanel Grid.Row="8" Grid.Column="0" Orientation="Horizontal">
+                <TextBlock Margin="3" Text="Transparency grid colors"/>
+                <local:TextBoxDark Width="80" Margin="3" Text="{Binding TransparencyGridColor1}" />
+                <local:TextBoxDark Width="80" Margin="3" Text="{Binding TransparencyGridColor2}" />
+            </StackPanel>
 
-            <CheckBox Grid.Row="9" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}"/>
-            <TextBlock Grid.Row="9" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room."/>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
+            <Canvas Grid.Row="8" Grid.Column="1" Width="20" Height="20" Background="{DynamicResource TransparencyGridBrushBrush}"></Canvas>
 
-            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}"/>
-            <TextBlock Grid.Row="10" Grid.Column="0" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room."/>
-            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
+            <Separator Grid.Row="9" Grid.ColumnSpan="4" Margin="10"/>
 
-            <CheckBox Grid.Row="9" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
-            <TextBlock Grid.Row="9" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
+            <CheckBox Grid.Row="10" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridWidthCheckbox" Content="" IsChecked="{Binding GridWidthEnabled}"/>
+            <TextBlock Grid.Row="10" Grid.Column="0" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid width" ToolTip="This option globally overrides the automatic assignment of a room's grid width based on the most used tile's width in that room."/>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridWidthCheckbox, Path=IsChecked}" Text="{Binding GlobalGridWidth}"/>
+
+            <CheckBox Grid.Row="11" Grid.Column="0" Margin="3" VerticalAlignment="Center" Name="gridHeightCheckbox" Content="" IsChecked="{Binding GridHeightEnabled}"/>
+            <TextBlock Grid.Row="11" Grid.Column="0" Margin="25 2 2 2"  VerticalAlignment="Center" Text="Global grid height" ToolTip="This option globally overrides the automatic assignment of a room's grid height based on the most used tile's height in that room."/>
+            <local:TextBoxDark Grid.Row="11" Grid.Column="1" Margin="3" IsEnabled="{Binding ElementName=gridHeightCheckbox, Path=IsChecked}" Text="{Binding GlobalGridHeight}"/>
+
+            <CheckBox Grid.Row="10" Grid.Column="2" Margin="3" VerticalAlignment="Center" Name="gridThicknessCheckBox" Content="" IsChecked="{Binding GridThicknessEnabled}"/>
+            <TextBlock Grid.Row="10" Grid.Column="2" Margin="25 2 2 2" VerticalAlignment="Center" Text="Global grid thickness" ToolTip="This option globally overrides the automatic assignment of a room's grid thickness."/>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="3" Margin="3" IsEnabled="{Binding ElementName=gridThicknessCheckBox, Path=IsChecked}" Text="{Binding GlobalGridThickness}"/>
 
             <Separator Grid.Row="13" Grid.ColumnSpan="4" Margin="10"/>
 

--- a/UndertaleModTool/Windows/SettingsWindow.xaml
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml
@@ -79,7 +79,7 @@
                 <local:TextBoxDark Width="80" Margin="3" Text="{Binding TransparencyGridColor2}" />
             </StackPanel>
 
-            <Canvas Grid.Row="8" Grid.Column="1" Width="20" Height="20" Background="{DynamicResource TransparencyGridBrushBrush}"></Canvas>
+            <Canvas Grid.Row="8" Grid.Column="1" Width="16" Height="16" Background="{DynamicResource TransparencyGridBrushBrush}"></Canvas>
 
             <Separator Grid.Row="9" Grid.ColumnSpan="4" Margin="10"/>
 

--- a/UndertaleModTool/Windows/SettingsWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SettingsWindow.xaml.cs
@@ -181,6 +181,38 @@ namespace UndertaleModTool
             }
         }
 
+        public static string TransparencyGridColor1
+        {
+            get => Settings.Instance.TransparencyGridColor1;
+            set
+            {
+                try
+                {
+                    MainWindow.SetTransparencyGridColors(value, TransparencyGridColor2);
+
+                    Settings.Instance.TransparencyGridColor1 = value;
+                    Settings.Save();
+                }
+                catch (FormatException) { }
+            }
+        }
+
+        public static string TransparencyGridColor2
+        {
+            get => Settings.Instance.TransparencyGridColor2;
+            set
+            {
+                try
+                {
+                    MainWindow.SetTransparencyGridColors(TransparencyGridColor1, value);
+
+                    Settings.Instance.TransparencyGridColor2 = value;
+                    Settings.Save();
+                }
+                catch (FormatException) { }
+            }
+        }
+
         public static bool EnableDarkMode
         {
             get => Settings.Instance.EnableDarkMode;


### PR DESCRIPTION
## Description
Add two textboxes where you can change the colors of the transparency grid behind sprites, backgrounds, etc. Depending on that game, the default colors can make it hard to see, so it's useful to be able to change it.

![image](https://github.com/user-attachments/assets/30f62f39-0a02-4902-89ec-a8d1da54b92b)

Closes #117

### Caveats
None

### Notes
None