### PR TITLE
Underanalyzer: Fix incorrect data type in tiles

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1196,12 +1196,12 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         /// <summary>
         /// The x coordinate of the tile in <see cref="ObjectDefinition"/>.
         /// </summary>
-        public uint SourceX { get; set; }
+        public int SourceX { get; set; }
 
         /// <summary>
         /// The y coordinate of the tile in <see cref="ObjectDefinition"/>.
         /// </summary>
-        public uint SourceY { get; set; }
+        public int SourceY { get; set; }
 
         /// <summary>
         /// The width of the tile.
@@ -1283,8 +1283,8 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                 _spriteDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleSprite, UndertaleChunkSPRT>>();
             else
                 _backgroundDefinition = reader.ReadUndertaleObject<UndertaleResourceById<UndertaleBackground, UndertaleChunkBGND>>();
-            SourceX = reader.ReadUInt32();
-            SourceY = reader.ReadUInt32();
+            SourceX = reader.ReadInt32();
+            SourceY = reader.ReadInt32();
             Width = reader.ReadUInt32();
             Height = reader.ReadUInt32();
             TileDepth = reader.ReadInt32();

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -32,7 +32,7 @@ namespace UndertaleModTool
         private static extern bool DeleteObject([In] IntPtr hObject);
 
         private static readonly ConcurrentDictionary<string, ImageSource> imageCache = new();
-        private static readonly ConcurrentDictionary<Tuple<string, Tuple<uint, uint, uint, uint>>, ImageSource> tileCache = new();
+        private static readonly ConcurrentDictionary<Tuple<string, Tuple<int, int, uint, uint>>, ImageSource> tileCache = new();
         private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
 
         private static bool _reuseTileBuffer;
@@ -59,7 +59,7 @@ namespace UndertaleModTool
             bool generate = false;
 
             string par;
-            List<Tuple<uint, uint, uint, uint>> tileRectList = null;
+            List<Tuple<int, int, uint, uint>> tileRectList = null;
             if (parameter is string)
             {
                 par = parameter as string;
@@ -68,10 +68,10 @@ namespace UndertaleModTool
                 cacheEnabled = !par.Contains("nocache");
                 generate = par.Contains("generate");
             }
-            else if (parameter is List<Tuple<uint, uint, uint, uint>>)
+            else if (parameter is List<Tuple<int, int, uint, uint>>)
             {
                 generate = true;
-                tileRectList = parameter as List<Tuple<uint, uint, uint, uint>>;
+                tileRectList = parameter as List<Tuple<int, int, uint, uint>>;
             }
 
             Tile tile = null;
@@ -111,7 +111,7 @@ namespace UndertaleModTool
             ImageSource spriteSrc;
             if (isTile)
             {
-                if (tileCache.TryGetValue(new(texName, new((uint)tile.SourceX, (uint)tile.SourceY, tile.Width, tile.Height)), out spriteSrc))
+                if (tileCache.TryGetValue(new(texName, new(tile.SourceX, tile.SourceY, tile.Width, tile.Height)), out spriteSrc))
                     return spriteSrc;
             }
 
@@ -137,7 +137,7 @@ namespace UndertaleModTool
                 if (cacheEnabled)
                 {
                     if (isTile)
-                        tileCache.TryAdd(new(texName, new((uint)tile.SourceX, (uint)tile.SourceY, tile.Width, tile.Height)), spriteSrc);
+                        tileCache.TryAdd(new(texName, new(tile.SourceX, tile.SourceY, tile.Width, tile.Height)), spriteSrc);
                     else
                         imageCache.TryAdd(texName, spriteSrc);
                 }
@@ -200,7 +200,7 @@ namespace UndertaleModTool
 
             return spriteSrc;
         }
-        private void ProcessTileSet(string textureName, Bitmap bmp, List<Tuple<uint, uint, uint, uint>> tileRectList, int targetX, int targetY)
+        private void ProcessTileSet(string textureName, Bitmap bmp, List<Tuple<int, int, uint, uint>> tileRectList, int targetX, int targetY)
         {
             BitmapData data = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, bmp.PixelFormat);
             int depth = Image.GetPixelFormatSize(data.PixelFormat) / 8;
@@ -224,8 +224,8 @@ namespace UndertaleModTool
 
             _ = Parallel.ForEach(tileRectList, (tileRect) =>
             {
-                int origX = (int)tileRect.Item1;
-                int origY = (int)tileRect.Item2;
+                int origX = tileRect.Item1;
+                int origY = tileRect.Item2;
                 int x = origX - targetX;
                 int y = origY - targetY;
                 int w = (int)tileRect.Item3;
@@ -272,7 +272,7 @@ namespace UndertaleModTool
 
                 spriteSrc.Freeze(); // allow UI thread access
 
-                Tuple<string, Tuple<uint, uint, uint, uint>> tileKey = new(textureName, new((uint)origX, (uint)origY, (uint)w, (uint)h));
+                Tuple<string, Tuple<int, int, uint, uint>> tileKey = new(textureName, new(origX, origY, (uint)w, (uint)h));
                 tileCache.TryAdd(tileKey, spriteSrc);
             });
 

--- a/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
+++ b/UndertaleModTool/Converters/UndertaleCachedImageLoader.cs
@@ -111,7 +111,7 @@ namespace UndertaleModTool
             ImageSource spriteSrc;
             if (isTile)
             {
-                if (tileCache.TryGetValue(new(texName, new(tile.SourceX, tile.SourceY, tile.Width, tile.Height)), out spriteSrc))
+                if (tileCache.TryGetValue(new(texName, new((uint)tile.SourceX, (uint)tile.SourceY, tile.Width, tile.Height)), out spriteSrc))
                     return spriteSrc;
             }
 
@@ -137,7 +137,7 @@ namespace UndertaleModTool
                 if (cacheEnabled)
                 {
                     if (isTile)
-                        tileCache.TryAdd(new(texName, new(tile.SourceX, tile.SourceY, tile.Width, tile.Height)), spriteSrc);
+                        tileCache.TryAdd(new(texName, new((uint)tile.SourceX, (uint)tile.SourceY, tile.Width, tile.Height)), spriteSrc);
                     else
                         imageCache.TryAdd(texName, spriteSrc);
                 }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -1723,7 +1723,7 @@ namespace UndertaleModTool
             UndertaleCachedImageLoader loader = new();
 
             List<Tile> tiles = null;
-            List<Tuple<UndertaleTexturePageItem, List<Tuple<uint, uint, uint, uint>>>> tileTextures = null;
+            List<Tuple<UndertaleTexturePageItem, List<Tuple<int, int, uint, uint>>>> tileTextures = null;
             List<object> allObjects = new();
             if (room.Flags.HasFlag(RoomEntryFlags.IsGMS2))
             {
@@ -1767,9 +1767,9 @@ namespace UndertaleModTool
                                  .Where(x => x.Key != "0")
                                  .Select(x =>
                                  {
-                                     return new Tuple<UndertaleTexturePageItem, List<Tuple<uint, uint, uint, uint>>>(
+                                     return new Tuple<UndertaleTexturePageItem, List<Tuple<int, int, uint, uint>>>(
                                          x.First().Tpag,
-                                         x.Select(tile => new Tuple<uint, uint, uint, uint>((uint)tile.SourceX, (uint)tile.SourceY, tile.Width, tile.Height))
+                                         x.Select(tile => new Tuple<int, int, uint, uint>(tile.SourceX, tile.SourceY, tile.Width, tile.Height))
                                           .Distinct()
                                           .ToList());
                                  })

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -790,8 +790,8 @@ namespace UndertaleModTool
             Point gridMouseCoordinates = GetGridMouseCoordinates(mousePos, room);
             scaleOriginX = gridMouseCoordinates.X;
             scaleOriginY = gridMouseCoordinates.Y;
-            clickedTile.SourceX = (uint)gridMouseCoordinates.X;
-            clickedTile.SourceY = (uint)gridMouseCoordinates.Y;
+            clickedTile.SourceX = (int)gridMouseCoordinates.X;
+            clickedTile.SourceY = (int)gridMouseCoordinates.Y;
             clickedTile.Width = (uint)room.GridWidth;
             clickedTile.Height = (uint)room.GridHeight;
         }
@@ -818,19 +818,19 @@ namespace UndertaleModTool
                 clickedTile.Height = (uint)Math.Clamp(Math.Abs(differenceY), 0, clickedTile.Tpag.BoundingHeight) + (uint)room.GridHeight;
 
                 if (differenceX < 0)
-                    clickedTile.SourceX = (uint)gridMouseCoordinates.X;
+                    clickedTile.SourceX = (int)gridMouseCoordinates.X;
                 else
-                    clickedTile.SourceX = (uint)scaleOriginX;
+                    clickedTile.SourceX = (int)scaleOriginX;
 
                 if (differenceY < 0)
-                    clickedTile.SourceY = (uint)gridMouseCoordinates.Y;
+                    clickedTile.SourceY = (int)gridMouseCoordinates.Y;
                 else
-                    clickedTile.SourceY = (uint)scaleOriginY;
+                    clickedTile.SourceY = (int)scaleOriginY;
             }
             else
             {
-                clickedTile.SourceX = (uint)gridMouseCoordinates.X;
-                clickedTile.SourceY = (uint)gridMouseCoordinates.Y;
+                clickedTile.SourceX = (int)gridMouseCoordinates.X;
+                clickedTile.SourceY = (int)gridMouseCoordinates.Y;
             }
         }
 
@@ -1769,7 +1769,7 @@ namespace UndertaleModTool
                                  {
                                      return new Tuple<UndertaleTexturePageItem, List<Tuple<uint, uint, uint, uint>>>(
                                          x.First().Tpag,
-                                         x.Select(tile => new Tuple<uint, uint, uint, uint>(tile.SourceX, tile.SourceY, tile.Width, tile.Height))
+                                         x.Select(tile => new Tuple<uint, uint, uint, uint>((uint)tile.SourceX, (uint)tile.SourceY, tile.Width, tile.Height))
                                           .Distinct()
                                           .ToList());
                                  })


### PR DESCRIPTION


## Description
changes the data type of SourceX and SourceY inside of the UndertaleRoom.Tile class to be integers instead of unsigned integers to allow for negative numbers.

### Caveats
Theres a chance that I missed a point in which the variable is used, which should be ironed out with more testing.

### Notes
This was mostly a quick fix for an issue a friend found in Undertale Yellow.