### PR TITLE
fix credits in README, and link to a more up-to-date site

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ for full details and documentation.
 
 Special thanks to everybody who did previous research on unpacking and decompiling Undertale, it was a really huge help:
 
-* [Ulyssis' UNDERTALE decompilation research](https://pcy.ulyssis.be/undertale/)
+* [PoroCYon' UNDERTALE decompilation research, maintained by Tomat](https://tomat.dev/undertale)
 * [Donkeybonks's GameMaker data.win Bytecode research](https://web.archive.org/web/20191126144953if_/https://github.com/donkeybonks/acolyte/wiki/Bytecode)
 * [PoroCYon's Altar.NET](https://github.com/PoroCYon/Altar.NET)
 * [WarlockD's GMdsam](https://github.com/WarlockD/GMdsam)


### PR DESCRIPTION
## Description

The README used to credit "Ulyssis", which is (a misspelling of) the name of the organization hosting the website, not the person who discovered the information and wrote it down. (`pcy.ulyssis.be` is one of the domain names of my website.)

Also, since I'm not maintaining the website anymore (i.e. not adding new information or publishing corrections), it's better to link to a site which does that.

### Caveats
none

### Notes
no