### PR TITLE
Zoom changes

### DIFF
--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -165,19 +165,11 @@ namespace UndertaleModTool
             if (scrollPres is null)
                 return;
 
-            double initScale = 1;
-            if (DataContext is UndertaleEmbeddedTexture texturePage)
-            {
-                int textureWidth = texturePage.TextureData?.Width ?? 1;
-                if (textureWidth < scrollPres.ActualWidth)
-                    initScale = scrollPres.ActualWidth / textureWidth;
-            }
-
             Transform t;
             double top, left;
             if (OverriddenPreviewState == default)
             {
-                t = new MatrixTransform(initScale, 0, 0, initScale, 0, 0);
+                t = new MatrixTransform(Matrix.Identity);
                 top = 0;
                 left = 0;
             }

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -373,7 +373,8 @@ namespace UndertaleModTool
             var mousePos = e.GetPosition(TextureViewbox);
             var transform = TextureViewbox.LayoutTransform as MatrixTransform;
             var matrix = transform.Matrix;
-            var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
+            var pow = Math.Pow(2, 1.0 / 8.0);
+            var scale = e.Delta >= 0 ? pow : (1.0 / pow); // choose appropriate scaling factor
 
             if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
             {

--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -375,7 +375,7 @@ namespace UndertaleModTool
             var matrix = transform.Matrix;
             var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
 
-            if ((matrix.M11 > 0.2 || (matrix.M11 <= 0.2 && scale > 1)) && (matrix.M11 < 3 || (matrix.M11 >= 3 && scale < 1)))
+            if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
             {
                 matrix.ScaleAtPrepend(scale, scale, mousePos.X, mousePos.Y);
             }

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
@@ -134,7 +134,8 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
             var mousePos = e.GetPosition(TextureScroll);
             var transform = TextureViewbox.LayoutTransform as MatrixTransform;
             var matrix = transform.Matrix;
-            var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
+            var pow = Math.Pow(2, 1.0 / 8.0);
+            var scale = e.Delta >= 0 ? pow : (1.0 / pow); // choose appropriate scaling factor
 
             if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
             {

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
@@ -93,7 +93,10 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
             double initScale = 1;
             int textureWidth = Font.Texture?.BoundingWidth ?? 1;
             if (textureWidth < scrollPres.ActualWidth)
+            {
                 initScale = scrollPres.ActualWidth / textureWidth;
+                initScale = Math.Pow(2, Math.Floor(Math.Log2(initScale))); // Round down to nearest power of 2
+            }
 
             TextureViewbox.LayoutTransform = new MatrixTransform(initScale, 0, 0, initScale, 0, 0); ;
             TextureViewbox.UpdateLayout();

--- a/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleFontEditor/EditGlyphRectangleWindow.xaml.cs
@@ -114,8 +114,8 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
                 double oldExtentWidth = e.ExtentWidth - e.ExtentWidthChange;
                 double oldExtentHeight = e.ExtentHeight - e.ExtentHeightChange;
 
-                double relx = offsetX / oldExtentWidth;
-                double rely = offsetY / oldExtentHeight;
+                double relx = oldExtentWidth != 0 ? offsetX / oldExtentWidth : 0;
+                double rely = oldExtentHeight != 0 ? offsetY / oldExtentHeight : 0;
 
                 offsetX = Math.Max(relx * e.ExtentWidth - xMousePositionOnScrollViewer, 0);
                 offsetY = Math.Max(rely * e.ExtentHeight - yMousePositionOnScrollViewer, 0);
@@ -136,7 +136,7 @@ namespace UndertaleModTool.Editors.UndertaleFontEditor
             var matrix = transform.Matrix;
             var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
 
-            if ((matrix.M11 > 0.2 || (matrix.M11 <= 0.2 && scale > 1)) && (matrix.M11 < 3 || (matrix.M11 >= 3 && scale < 1)))
+            if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
             {
                 matrix.ScaleAtPrepend(scale, scale, mousePos.X, mousePos.Y);
             }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -842,7 +842,7 @@ namespace UndertaleModTool
             var matrix = transform.Matrix;
             var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
 
-            if ((matrix.M11 > 0.2 || (matrix.M11 <= 0.2 && scale > 1)) && (matrix.M11 < 3 || (matrix.M11 >= 3 && scale < 1)))
+            if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
             {
                 matrix.ScaleAtPrepend(scale, scale, mousePos.X, mousePos.Y);
             }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -840,7 +840,8 @@ namespace UndertaleModTool
             var mousePos = e.GetPosition(RoomGraphics);
             var transform = RoomGraphics.LayoutTransform as MatrixTransform;
             var matrix = transform.Matrix;
-            var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
+            var pow = Math.Pow(2, 1.0 / 8.0);
+            var scale = e.Delta >= 0 ? pow : (1.0 / pow); // choose appropriate scaling factor
 
             if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
             {

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleTileEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleTileEditor.xaml.cs
@@ -779,7 +779,7 @@ namespace UndertaleModTool
                 var matrix = transform.Matrix;
                 var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
 
-                if ((matrix.M11 > 0.2 || (matrix.M11 <= 0.2 && scale > 1)) && (matrix.M11 < 6 || (matrix.M11 >= 6 && scale < 1)))
+                if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
                 {
                     matrix.ScaleAtPrepend(scale, scale, mousePos.X, mousePos.Y);
                 }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleTileEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleTileEditor.xaml.cs
@@ -777,7 +777,8 @@ namespace UndertaleModTool
                 var mousePos = e.GetPosition(canvas);
                 var transform = canvas.LayoutTransform as MatrixTransform;
                 var matrix = transform.Matrix;
-                var scale = e.Delta >= 0 ? 1.1 : (1.0 / 1.1); // choose appropriate scaling factor
+                var pow = Math.Pow(2, 1.0 / 8.0);
+                var scale = e.Delta >= 0 ? pow : (1.0 / pow); // choose appropriate scaling factor
 
                 if ((matrix.M11 > 0.001 || (matrix.M11 <= 0.001 && scale > 1)) && (matrix.M11 < 1000 || (matrix.M11 >= 1000 && scale < 1)))
                 {


### PR DESCRIPTION
## Description
The main thing this PR does is increase the max and min zoom levels and make them align with powers of 2, so it's possible to get to 200% or 50%. It also changes the embedded texture editor so it starts at 100% instead of at the max width. And the font glyph editor initial scale rounds to a power of 2 so you can have the alignment said before.

Helps with #2055.

### Caveats
None

### Notes
None