### PR TITLE
More room editor tweaks (more CE backports)

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml
@@ -58,11 +58,13 @@
     <UserControl.CommandBindings>
         <CommandBinding Command="Copy" Executed="Command_Copy" />
         <CommandBinding Command="Paste" Executed="Command_Paste" />
+        <CommandBinding Command="{x:Static local:UndertaleRoomEditor.PasteShiftCommand}" Executed="Command_PasteShift" />
         <CommandBinding Command="Undo" Executed="Command_Undo" />
     </UserControl.CommandBindings>
     <UserControl.InputBindings>
         <KeyBinding Modifiers="Control" Key="C" Command="Copy"/>
         <KeyBinding Modifiers="Control" Key="P" Command="Paste"/>
+        <KeyBinding Modifiers="Control+Shift" Key="V" Command="{x:Static local:UndertaleRoomEditor.PasteShiftCommand}"/>
         <KeyBinding Modifiers="Control" Key="Z" Command="Undo"/>
     </UserControl.InputBindings>
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -46,6 +46,8 @@ namespace UndertaleModTool
                 typeof(UndertaleRoomEditor),
                 new FrameworkPropertyMetadata(null));
 
+        public static RoutedUICommand PasteShiftCommand = new("Alternate paste command", "PasteShift", typeof(UndertaleRoomEditor));
+
         public static readonly PropertyInfo visualOffProp = typeof(Canvas).GetProperty("VisualOffset", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
         private static readonly Regex trailingNumberRegex = new(@"\d+$", RegexOptions.Compiled);
@@ -1438,6 +1440,14 @@ namespace UndertaleModTool
 
         public void Command_Paste(object sender, ExecutedRoutedEventArgs e)
         {
+            Paste();
+        }
+        public void Command_PasteShift(object sender, ExecutedRoutedEventArgs e)
+        {
+            Paste(true);
+        }
+        public void Paste(bool shiftPressed = false)
+        {
             /*IDataObject data = Clipboard.GetDataObject();
             UndertaleObject obj = data.GetData(data.GetFormats()[0]) as UndertaleObject;
             if (obj != null)
@@ -1470,6 +1480,12 @@ namespace UndertaleModTool
 
                 RoomCanvas roomCanvas = GetRoomCanvas();
                 Point mousePos = roomCanvas.IsMouseOver ? Mouse.GetPosition(roomCanvas) : new();
+                if (!shiftPressed)
+                {
+                    int gridWidth = Math.Max(Convert.ToInt32(room.GridWidth), 1);
+                    int gridHeight = Math.Max(Convert.ToInt32(room.GridHeight), 1);
+                    mousePos = new Point(Math.Floor(mousePos.X / gridWidth) * gridWidth, Math.Floor(mousePos.Y / gridHeight) * gridHeight);
+                }
                 UndertaleObject newObj = AddObjectCopy(room, layer, copied, true, -1, mousePos);
 
                 if (newObj is not null)

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -2227,14 +2227,18 @@ namespace UndertaleModTool
                     mainWindow.ShowMessage("The layer must have a tileset set!");
                     return;
                 }
-                if (data.TilesX <= 0)
+                if (data.TilesX <= 0 && data.TilesY <= 0)
                 {
-                    mainWindow.ShowMessage("The layer's horizontal size must be larger than 0 tiles!");
+                    mainWindow.ShowMessage("The layer's horizontal and vertical size must be larger than 0 tiles!\n(Use the Auto button to set the tilemap size based on the room size.)");
                     return;
                 }
-                if (data.TilesY <= 0)
+                else if (data.TilesX <= 0)
                 {
-                    mainWindow.ShowMessage("The layer's horizontal size must be larger than 0 tiles!");
+                    mainWindow.ShowMessage("The layer's horizontal size must be larger than 0 tiles!\n(Use the Auto button to set the tilemap size based on the room size.)");
+                    return;
+                } else if (data.TilesY <= 0)
+                {
+                    mainWindow.ShowMessage("The layer's vertical size must be larger than 0 tiles!\n(Use the Auto button to set the tilemap size based on the room size.)");
                     return;
                 }
 

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -1231,22 +1231,23 @@ namespace UndertaleModTool
                     var snappedPos = GetGridMouseCoordinates(mousePos, room);
 
                     if (
-                        (mainWindow.IsGMS2 == Visibility.Visible && layer == null) ||
-                        (layer != null && layer.InstancesData == null)
+                        mainWindow.IsGMS2 == Visibility.Visible &&
+                        (layer == null || (layer != null && layer.InstancesData == null))
                     )
                     {
                         // Try to find a valid layer.
                         // If there isn't one, create one.
+                        bool foundLayer = false;
                         foreach (Layer Layer in room.Layers)
                         {
-                            Debug.WriteLine(Layer);
                             if (Layer.InstancesData != null)
                             {
                                 layer = Layer;
+                                foundLayer = true;
                                 break;
                             }
                         }
-                        if (layer == null)
+                        if (!foundLayer)
                         {
                             layer = AddLayer<Layer.LayerInstancesData>(LayerType.Instances, "Instances");
                         }

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -2325,29 +2325,36 @@ namespace UndertaleModTool
                 Thickness canvasOffset = roomCanvas.Margin;
                 var currentPosition = e.GetPosition(scrollViewer);
                 var offset = roomCanvas.startPosition - currentPosition;
-                roomCanvas.startPosition = currentPosition;
 
+                var transform = RoomGraphics.LayoutTransform as MatrixTransform;
+
+                var scrollX = scrollViewer.HorizontalOffset + offset.X;
+                var scrollY = scrollViewer.VerticalOffset + offset.Y;
+                var multX = (scrollViewer.ScrollableWidth == 0 ? 2.0 : 1.0) / transform.Matrix.M11;
+                var multY = (scrollViewer.ScrollableHeight == 0 ? 2.0 : 1.0) / transform.Matrix.M22;
+
+                roomCanvas.startPosition = currentPosition;
                 // Change margins if outside view
-                if (offset.X < 0 && scrollViewer.HorizontalOffset == 0)
+                if (offset.X < 0 && scrollX <= 0)
                 {
-                    canvasOffset.Left -= offset.X;
+                    canvasOffset.Left -= offset.X * multX;
                 }
-                else if (offset.X > 0 && scrollViewer.HorizontalOffset == scrollViewer.ScrollableWidth)
+                else if (offset.X > 0 && scrollX >= scrollViewer.ScrollableWidth)
                 {
-                    canvasOffset.Right += offset.X;
+                    canvasOffset.Right += offset.X * multX;
                 }
-                if (offset.Y < 0 && scrollViewer.VerticalOffset == 0)
+                if (offset.Y < 0 && scrollY <= 0)
                 {
-                    canvasOffset.Top -= offset.Y;
+                    canvasOffset.Top -= offset.Y * multY;
                 }
-                else if (offset.Y > 0 && scrollViewer.VerticalOffset == scrollViewer.ScrollableHeight)
+                else if (offset.Y > 0 && scrollY >= scrollViewer.ScrollableHeight)
                 {
-                    canvasOffset.Bottom += offset.Y;
+                    canvasOffset.Bottom += offset.Y * multY;
                 }
                 roomCanvas.Margin = canvasOffset;
 
-                scrollViewer.ScrollToVerticalOffset(scrollViewer.VerticalOffset + offset.Y);
-                scrollViewer.ScrollToHorizontalOffset(scrollViewer.HorizontalOffset + offset.X);
+                scrollViewer.ScrollToVerticalOffset(scrollY);
+                scrollViewer.ScrollToHorizontalOffset(scrollX);
             }
         }
     }


### PR DESCRIPTION
## Description
This mostly backports UTMTCE's other changes to the room editor (first 2 commits), some of being improvements to AwfulNasty's original changes.

- Ctrl+V paste now snaps to the grid, mainly for GMS1 tile editing (if you don't want to use Alt+Click). Ctrl+Shift+V was added for if you don't want the snapping.
- Mostly fix middle-click scrolling going way slower (or way faster depending on the zoom) if it needs to expand the scroll viewer. It still has a very minor desync for some reason, but it's better than before.

Other changes:
- Fix automatic instance layer creation not working when a non-instance layer is selected. The instance layer creation feature itself was [actually originally created for UTMTCE](https://github.com/XDOneDude/UndertaleModToolCE/commit/22d9b3105cb6733f8925c2d3f5f9dfd3367bfa9a), and I guess AwfulNasty added it to his PR. (I was gonna backport it anyways though, so it doesn't matter). Anyways, this fix itself though, was not in UTMTCE.
- Point the user to the Auto button when trying to edit a 0-sized tilemap. The dialog for when the vertical size is 0 also no longer mistakenly says "horizontal size" instead of "vertical size".


### Caveats
The middle-click scrolling fix:
> It still has a very minor desync for some reason, but it's better than before.

### Notes
<!-- Any notes or closing words -->