### PR TITLE
Add remove buttons for object actions, global inits and sprite collision masks

### DIFF
--- a/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml
@@ -489,6 +489,7 @@
                                                             <DataTemplate>
                                                                 <local:UndertaleObjectReference ObjectReference="{Binding CodeId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertale:UndertaleCode}"
                                                                                                 Margin="23,3,3,3" CanRemove="False"
+                                                                                                Loaded="UndertaleObjectReference_Loaded"
                                                                                                 GameObject="{Binding DataContext, RelativeSource={RelativeSource AncestorType=local:DataUserControl}}"
                                                                                                 ObjectEventType="{Binding Text, Mode=OneTime, ElementName=EventTypeName, Converter={StaticResource EventNameConverter}, ConverterParameter=EventType}"
                                                                                                 ObjectEventSubtype="{Binding DataContext.EventSubtype, Mode=OneWay, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>

--- a/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
@@ -67,7 +67,7 @@ namespace UndertaleModTool
         private void ComboBox_DropDownClosed(object sender, EventArgs e)
         {
             handleMouseScroll = true;
-        }        
+        }
         private void UndertaleObjectReference_Loaded(object sender, RoutedEventArgs e)
         {
             var objRef = sender as UndertaleObjectReference;
@@ -82,23 +82,27 @@ namespace UndertaleModTool
             var btn = (ButtonDark)sender;
             var objRef = (UndertaleObjectReference)((Grid)btn.Parent).Parent;
 
-            if (objRef.ObjectReference is not null)
-            {
-                objRef.ObjectReference = null;
-                return;
-            }
-
             var obj = (UndertaleGameObject)DataContext;
             var evType = objRef.ObjectEventType;
             var evSubtype = objRef.ObjectEventSubtype;
             var action = (UndertaleGameObject.EventAction)btn.DataContext;
             var evList = ((UndertaleGameObject)DataContext).Events[(int)evType];
-            var ev = evList[(int)evSubtype];
-            ev.Actions.Remove(action);
-            if (ev.Actions.Count <= 0)
+
+            UndertaleGameObject.Event foundEvent = null;
+            foreach (var ev in evList)
             {
-                evList.Remove(ev);
+                if (ev.EventSubtype == evSubtype)
+                {
+                    foundEvent = ev;
+                    break;
+                }
             }
-    }
+            if (foundEvent is null) return;
+            foundEvent.Actions.Remove(action);
+            if (foundEvent.Actions.Count <= 0)
+            {
+                evList.Remove(foundEvent);
+            }
+        }
     }
 }

--- a/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
@@ -67,6 +67,38 @@ namespace UndertaleModTool
         private void ComboBox_DropDownClosed(object sender, EventArgs e)
         {
             handleMouseScroll = true;
+        }        
+        private void UndertaleObjectReference_Loaded(object sender, RoutedEventArgs e)
+        {
+            var objRef = sender as UndertaleObjectReference;
+
+            objRef.ClearRemoveClickHandler();
+            objRef.RemoveButton.Click += Remove_Click_Override;
+            objRef.RemoveButton.ToolTip = "Remove action";
+            objRef.RemoveButton.IsEnabled = true;
         }
+        private void Remove_Click_Override(object sender, RoutedEventArgs e)
+        {
+            var btn = (ButtonDark)sender;
+            var objRef = (UndertaleObjectReference)((Grid)btn.Parent).Parent;
+
+            if (objRef.ObjectReference is not null)
+            {
+                objRef.ObjectReference = null;
+                return;
+            }
+
+            var obj = (UndertaleGameObject)DataContext;
+            var evType = objRef.ObjectEventType;
+            var evSubtype = objRef.ObjectEventSubtype;
+            var action = (UndertaleGameObject.EventAction)btn.DataContext;
+            var evList = ((UndertaleGameObject)DataContext).Events[(int)evType];
+            var ev = evList[(int)evSubtype];
+            ev.Actions.Remove(action);
+            if (ev.Actions.Count <= 0)
+            {
+                evList.Remove(ev);
+            }
+    }
     }
 }

--- a/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGameObjectEditor.xaml.cs
@@ -88,20 +88,12 @@ namespace UndertaleModTool
             var action = (UndertaleGameObject.EventAction)btn.DataContext;
             var evList = ((UndertaleGameObject)DataContext).Events[(int)evType];
 
-            UndertaleGameObject.Event foundEvent = null;
-            foreach (var ev in evList)
+            var ev = evList.FirstOrDefault(x => x.EventSubtype == evSubtype);
+            if (ev is null) return;
+            ev.Actions.Remove(action);
+            if (ev.Actions.Count <= 0)
             {
-                if (ev.EventSubtype == evSubtype)
-                {
-                    foundEvent = ev;
-                    break;
-                }
-            }
-            if (foundEvent is null) return;
-            foundEvent.Actions.Remove(action);
-            if (foundEvent.Actions.Count <= 0)
-            {
-                evList.Remove(foundEvent);
+                evList.Remove(ev);
             }
         }
     }

--- a/UndertaleModTool/Editors/UndertaleGlobalInitEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGlobalInitEditor.xaml
@@ -45,7 +45,7 @@
                 <DataGridTemplateColumn Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <local:UndertaleObjectReference Margin="20,0,0,0" ObjectReference="{Binding Code, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleCode}" CanRemove="False"/>
+                            <local:UndertaleObjectReference Margin="20,0,0,0" ObjectReference="{Binding Code, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Loaded="UndertaleObjectReference_Loaded" ObjectType="{x:Type undertaleModels:UndertaleCode}" CanRemove="True"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/UndertaleModTool/Editors/UndertaleGlobalInitEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGlobalInitEditor.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using UndertaleModLib.Models;
 
 namespace UndertaleModTool
 {
@@ -23,6 +24,28 @@ namespace UndertaleModTool
         public UndertaleGlobalInitEditor()
         {
             InitializeComponent();
+        }
+        private void UndertaleObjectReference_Loaded(object sender, RoutedEventArgs e)
+        {
+            var objRef = sender as UndertaleObjectReference;
+
+            objRef.ClearRemoveClickHandler();
+            objRef.RemoveButton.Click += Remove_Click_Override;
+            objRef.RemoveButton.ToolTip = "Remove action";
+            objRef.RemoveButton.IsEnabled = true;
+        }
+        private void Remove_Click_Override(object sender, RoutedEventArgs e)
+        {
+            var btn = (ButtonDark)sender;
+            var objRef = (UndertaleObjectReference)((Grid)btn.Parent).Parent;
+
+            var data = (GlobalInitEditor)DataContext;
+            var globalInits = data.GlobalInits;
+            if (btn.DataContext is not UndertaleGlobalInit)
+            {
+                return;
+            }
+            globalInits.Remove((UndertaleGlobalInit)btn.DataContext);
         }
     }
 }

--- a/UndertaleModTool/Editors/UndertaleGlobalInitEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleGlobalInitEditor.xaml.cs
@@ -31,7 +31,7 @@ namespace UndertaleModTool
 
             objRef.ClearRemoveClickHandler();
             objRef.RemoveButton.Click += Remove_Click_Override;
-            objRef.RemoveButton.ToolTip = "Remove action";
+            objRef.RemoveButton.ToolTip = "Remove script";
             objRef.RemoveButton.IsEnabled = true;
         }
         private void Remove_Click_Override(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
@@ -192,7 +192,15 @@
                 <DataGridTemplateColumn Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBlock Margin="20,0,0,0" Text="(CollisionMask)"/>
+                            <Grid Margin="20,0,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="(CollisionMask)"/>
+                                <local:ButtonDark Grid.Column="1" x:Name="RemoveButton" Content=" X " Click="RemoveMask_Clicked" ToolTip="Remove">
+                                </local:ButtonDark>
+                            </Grid>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml.cs
@@ -210,5 +210,10 @@ namespace UndertaleModTool
             if (DataContext is UndertaleSprite sprite && (sender as FrameworkElement).DataContext is UndertaleSprite.TextureEntry entry)
                 sprite.Textures.Remove(entry);
         }
+        private void RemoveMask_Clicked(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is UndertaleSprite sprite && (sender as FrameworkElement).DataContext is UndertaleSprite.MaskEntry entry)
+                sprite.CollisionMasks.Remove(entry);
+        }
     }
 }


### PR DESCRIPTION
Resolves #1728

## Description
Another (enhanced) UTMTCE backport, probably the [second-to-last](https://github.com/XDOneDude/UndertaleModToolCE/pull/3) feature remaining.

![Deletion button for game object actions](https://github.com/user-attachments/assets/617cf304-6fc0-4c70-9e74-7f0c3fe709a3)
![Deletion button for global init scripts](https://github.com/user-attachments/assets/81fd38c2-513e-4f09-b4e2-43a6c4869c59)
![Deletion button for sprite collision masks](https://github.com/user-attachments/assets/8b4035f0-7776-46c9-b141-2cd8e3c204b4)

This makes it clearer to the user that yes, you *can* remove these objects.

### Caveats
There are still some other objects that haven't gotten remove buttons (like vertex shader attributes and code local variables), but object actions are the most likely ones a new user would need to remove. (For the other 2 I just felt like adding them.)

### Notes
<!-- Any notes or closing words -->