### PR TITLE
Refactor list structures, change list base class to a generic observable list

### DIFF
--- a/UndertaleModLib/UndertaleLists.cs
+++ b/UndertaleModLib/UndertaleLists.cs
@@ -7,99 +7,124 @@ using UndertaleModLib.Models;
 
 namespace UndertaleModLib
 {
-    public abstract class UndertaleListBase<T> : ObservableCollection<T>, UndertaleObject
+    /// <summary>
+    /// Basic observable list type, usable for data models to be presented in interfaces.
+    /// </summary>
+    public class UndertaleObservableList<T> : ObservableCollection<T>
     {
+        // Reference to the private internal list inside Collection<T>
         private readonly List<T> internalList;
 
-        public UndertaleListBase()
-        {
-            try
-            {
-                FieldInfo itemsField = typeof(Collection<T>)
-                                       .GetField("items", BindingFlags.NonPublic | BindingFlags.Instance);
-                internalList = (List<T>)itemsField.GetValue(this);
+        // Internal list field (name is guaranteed not to change due to the underlying type being serializable)
+        private static readonly FieldInfo itemsField = typeof(Collection<T>).GetField("items", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            }
-            catch (Exception e)
-            {
-                throw new UndertaleSerializationException($"{e.Message}\nwhile trying to initialize \"UndertalePointerList<{typeof(T).FullName}>\".");
-            }
+        /// <summary>
+        /// Creates a new observable list, which is empty and has default capacity.
+        /// </summary>
+        public UndertaleObservableList()
+        {
+            // Get ahold of internal list
+            internalList = (List<T>)itemsField.GetValue(this);
         }
 
-        /// <inheritdoc />
-        public abstract void Serialize(UndertaleWriter writer);
+        /// <summary>
+        /// Creates a new observable list, which is empty and has the specified initial capacity.
+        /// </summary>
+        public UndertaleObservableList(int capacity)
+        {
+            // Get ahold of internal list
+            internalList = (List<T>)itemsField.GetValue(this);
 
-        /// <inheritdoc />
-        public abstract void Unserialize(UndertaleReader reader);
+            // Set capacity directly
+            internalList.Capacity = capacity;
+        }
 
+        /// <summary>
+        /// Sets the capacity of the internal list of this collection.
+        /// </summary>
         public void SetCapacity(int capacity)
         {
-            try
-            {
-                internalList.Capacity = capacity;
-            }
-            catch (Exception e)
-            {
-                throw new UndertaleSerializationException($"{e.Message}\nwhile trying to \"SetCapacity()\" of \"UndertalePointerList<{typeof(T).FullName}>\".");
-            }
+            internalList.Capacity = capacity;
         }
+
+        /// <summary>
+        /// Sets the capacity of the internal list of this collection.
+        /// </summary>
         public void SetCapacity(uint capacity) => SetCapacity((int)capacity);
 
+        /// <summary>
+        /// Adds an item to the internal list of this collection (that is, without notifying any observers).
+        /// </summary>
+        /// <param name="item">Item to add.</param>
         public void InternalAdd(T item)
         {
             internalList.Add(item);
         }
     }
 
-    public class UndertaleSimpleList<T> : UndertaleListBase<T> where T : UndertaleObject, new()
+    /// <summary>
+    /// Simple list object, serialized as a 32-bit count followed immediately by all objects in the list.
+    /// </summary>
+    public class UndertaleSimpleList<T> : UndertaleObservableList<T>, UndertaleObject where T : UndertaleObject, new()
     {
         /// <inheritdoc />
-        public override void Serialize(UndertaleWriter writer)
+        public void Serialize(UndertaleWriter writer)
         {
-            writer.Write((uint)Count);
-            for (int i = 0; i < Count; i++)
+            // Write list count
+            int count = Count;
+            writer.Write((uint)count);
+
+            // Write actual objects
+            int i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
-                    writer.WriteUndertaleObject<T>(this[i]);
+                    writer.WriteUndertaleObject(this[i]);
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile writing item " + (i + 1) + " of " + Count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile writing item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
         }
 
         /// <inheritdoc />
-        public override void Unserialize(UndertaleReader reader)
+        public void Unserialize(UndertaleReader reader)
         {
+            // Read count and initialize list with that capacity
             uint count = reader.ReadUInt32();
             Clear();
             SetCapacity(count);
-            for (uint i = 0; i < count; i++)
+
+            // Read actual objects
+            uint i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     InternalAdd(reader.ReadUndertaleObject<T>());
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
         }
 
         /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
         public static uint UnserializeChildObjectCount(UndertaleReader reader)
         {
+            // Read base object count
             uint count = reader.ReadUInt32();
             if (count == 0)
+            {
+                // Short-circuit if there's no objects
                 return 0;
+            }
 
-            uint totalCount = 0;
-
-            Type t = typeof(T);
-            if (t.IsAssignableTo(typeof(UndertaleResourceRef)))
+            // If the objects are resource refs, the size is known as 4 bytes
+            if (typeof(T).IsAssignableTo(typeof(UndertaleResourceRef)))
             {
                 // UndertaleResourceById<T, ChunkT> = 4 bytes
                 reader.Position += count * 4;
@@ -107,71 +132,89 @@ namespace UndertaleModLib
                 return count;
             }
 
-            if (t.IsAssignableTo(typeof(IStaticChildObjectsSize)))
+            // If objects have a static child object size/count, simply multiply to determine the number of total objects
+            if (typeof(T).IsAssignableTo(typeof(IStaticChildObjectsSize)))
             {
-                uint subSize = reader.GetStaticChildObjectsSize(t);
+                uint subSize = reader.GetStaticChildObjectsSize(typeof(T));
                 uint subCount = 0;
 
-                if (t.IsAssignableTo(typeof(IStaticChildObjCount)))
-                    subCount = reader.GetStaticChildCount(t);
+                if (typeof(T).IsAssignableTo(typeof(IStaticChildObjCount)))
+                {
+                    subCount = reader.GetStaticChildCount(typeof(T));
+                }
 
                 reader.Position += count * subSize;
 
-                return count + count * subCount;
+                return count + (count * subCount);
             }
 
-            var unserializeFunc = reader.GetUnserializeCountFunc(t);
-            for (uint i = 0; i < count; i++)
+            // Determine object counts recursively for all objects
+            Func<UndertaleReader, uint> unserializeFunc = reader.GetUnserializeCountFunc(typeof(T));
+            uint totalCount = 0;
+            uint i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     totalCount += 1 + unserializeFunc(reader);
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading child object count of item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading child object count of item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
 
             return totalCount;
         }
     }
 
-    public class UndertaleSimpleListString : UndertaleListBase<UndertaleString>
+    /// <summary>
+    /// Simple list object, specifically for strings, serialized as a count followed immediately by all strings in the list.
+    /// </summary>
+    public class UndertaleSimpleListString : UndertaleObservableList<UndertaleString>, UndertaleObject
     {
         /// <inheritdoc />
-        public override void Serialize(UndertaleWriter writer)
+        public void Serialize(UndertaleWriter writer)
         {
-            writer.Write((uint)Count);
-            for (int i = 0; i < Count; i++)
+            // Write count
+            int count = Count;
+            writer.Write((uint)count);
+
+            // Write all of the strings
+            int i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     writer.WriteUndertaleString(this[i]);
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile writing item " + (i + 1) + " of " + Count + " in a string-list", e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile writing item {i + 1} of {count} in a string-list", e);
             }
         }
 
         /// <inheritdoc />
-        public override void Unserialize(UndertaleReader reader)
+        public void Unserialize(UndertaleReader reader)
         {
+            // Read count and initialize list with that capacity
             uint count = reader.ReadUInt32();
             Clear();
             SetCapacity(count);
-            for (uint i = 0; i < count; i++)
+
+            // Read all of the strings
+            uint i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     InternalAdd(reader.ReadUndertaleString());
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading item " + (i + 1) + " of " + count + " in a string-list", e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading item {i + 1} of {count} in a string-list", e);
             }
         }
 
@@ -184,7 +227,10 @@ namespace UndertaleModLib
         }
     }
 
-    public class UndertaleSimpleListShort<T> : UndertaleListBase<T> where T : UndertaleObject, new()
+    /// <summary>
+    /// Simple list object, serialized as a 16-bit count followed immediately by all objects in the list.
+    /// </summary>
+    public class UndertaleSimpleListShort<T> : UndertaleObservableList<T>, UndertaleObject where T : UndertaleObject, new()
     {
         private void EnsureShortCount()
         {
@@ -200,139 +246,187 @@ namespace UndertaleModLib
         }
 
         /// <inheritdoc />
-        public override void Serialize(UndertaleWriter writer)
+        public void Serialize(UndertaleWriter writer)
         {
-            writer.Write((ushort)Count);
-            for (int i = 0; i < Count; i++)
+            // Write list count
+            int count = Count;
+            writer.Write((ushort)count);
+
+            // Write actual objects
+            int i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
-                    writer.WriteUndertaleObject<T>(this[i]);
+                    writer.WriteUndertaleObject(this[i]);
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile writing item " + (i + 1) + " of " + Count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile writing item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
         }
 
         /// <inheritdoc />
-        public override void Unserialize(UndertaleReader reader)
+        public void Unserialize(UndertaleReader reader)
         {
+            // Read count and initialize list with that capacity
             ushort count = reader.ReadUInt16();
             Clear();
             SetCapacity(count);
-            for (ushort i = 0; i < count; i++)
+
+            // Read actual objects
+            ushort i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     InternalAdd(reader.ReadUndertaleObject<T>());
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
         }
 
         /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
         public static uint UnserializeChildObjectCount(UndertaleReader reader)
         {
+            // Read base object count
             ushort count = reader.ReadUInt16();
             if (count == 0)
-                return 0;
-
-            uint totalCount = 0;
-
-            Type t = typeof(T);
-            if (t.IsAssignableTo(typeof(IStaticChildObjectsSize)))
             {
-                uint subSize = reader.GetStaticChildObjectsSize(t);
+                // Short-circuit if there's no objects
+                return 0;
+            }
+
+            // If objects have a static child object size/count, simply multiply to determine the number of total objects
+            if (typeof(T).IsAssignableTo(typeof(IStaticChildObjectsSize)))
+            {
+                uint subSize = reader.GetStaticChildObjectsSize(typeof(T));
                 uint subCount = 0;
 
-                if (t.IsAssignableTo(typeof(IStaticChildObjCount)))
-                    subCount = reader.GetStaticChildCount(t);
+                if (typeof(T).IsAssignableTo(typeof(IStaticChildObjCount)))
+                {
+                    subCount = reader.GetStaticChildCount(typeof(T));
+                }
 
                 reader.Position += count * subSize;
 
-                return count + count * subCount;
+                return count + (count * subCount);
             }
 
-            var unserializeFunc = reader.GetUnserializeCountFunc(t);
-            for (uint i = 0; i < count; i++)
+            // Determine object counts recursively for all objects
+            Func<UndertaleReader, uint> unserializeFunc = reader.GetUnserializeCountFunc(typeof(T));
+            uint totalCount = 0;
+            uint i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     totalCount += 1 + unserializeFunc(reader);
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading child object count of item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading child object count of item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
 
             return totalCount;
         }
     }
 
-    public class UndertalePointerList<T> : UndertaleListBase<T> where T : UndertaleObject, new()
+    public class UndertalePointerList<T> : UndertaleObservableList<T>, UndertaleObject where T : UndertaleObject, new()
     {
         /// <inheritdoc />
-        public override void Serialize(UndertaleWriter writer)
+        public void Serialize(UndertaleWriter writer)
         {
-            writer.Write((uint)Count);
+            // Write count
+            int count = Count;
+            writer.Write((uint)count);
+
+            // Write all pointers
             foreach (T obj in this)
-                writer.WriteUndertaleObjectPointer<T>(obj);
-            for (int i = 0; i < Count; i++)
             {
+                writer.WriteUndertaleObjectPointer<T>(obj);
+            }
+
+            // Write blobs, if necessary for the given type
+            if (typeof(T).IsAssignableTo(typeof(UndertaleObjectWithBlobs)))
+            {
+                int i = 0;
                 try
                 {
-                    (this[i] as UndertaleObjectWithBlobs)?.SerializeBlobBefore(writer);
+                    for (; i < count; i++)
+                    {
+                        ((UndertaleObjectWithBlobs)this[i]).SerializeBlobBefore(writer);
+                    }
                 }
                 catch (UndertaleSerializationException e)
                 {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile writing blob for item " + (i + 1) + " of " + Count + " in a list of " + typeof(T).FullName, e);
+                    throw new UndertaleSerializationException($"{e.Message}\nwhile writing blob for item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
                 }
             }
-            for (int i = 0; i < Count; i++)
+
+            // Write actual objects
+            int j = 0;
+            try
             {
-                try
+                for (; j < count; j++)
                 {
-                    T obj = this[i];
+                    T obj = this[j];
 
-                    (obj as PrePaddedObject)?.SerializePrePadding(writer);
+                    // Serialize pre-padding, if this is a type that requires it
+                    if (typeof(T).IsAssignableTo(typeof(PrePaddedObject)))
+                    {
+                        ((PrePaddedObject)obj).SerializePrePadding(writer);
+                    }
 
-                    writer.WriteUndertaleObject<T>(obj);
+                    // Write object
+                    writer.WriteUndertaleObject(obj);
 
-                    // The last object does NOT get padding (TODO: at least in AUDO)
-                    if (i != Count - 1)
-                        (obj as PaddedObject)?.SerializePadding(writer);
+                    // Serialize padding, if this is a type that requires it
+                    if (typeof(T).IsAssignableTo(typeof(PaddedObject)))
+                    {
+                        // The last object does NOT get padding (TODO: at least in AUDO)
+                        if (j != count - 1)
+                        {
+                            ((PaddedObject)obj).SerializePadding(writer);
+                        }
+                    }
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile writing item " + (i + 1) + " of " + Count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile writing item {j + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
         }
 
         /// <inheritdoc />
-        public override void Unserialize(UndertaleReader reader)
+        public void Unserialize(UndertaleReader reader)
         {
+            // Read count and initialize list with that capacity
             uint count = reader.ReadUInt32();
             Clear();
             SetCapacity(count);
-            for (uint i = 0; i < count; i++)
+
+            // Read in all object pointers
+            uint i = 0;
+            try
             {
-                try
+                for (; i < count; i++)
                 {
                     InternalAdd(reader.ReadUndertaleObjectPointer<T>());
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading pointer to item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
             }
-            if (Count > 0)
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading pointer to item {i + 1} of {count} in a list of {typeof(T).FullName}", e);
+            }
+
+            // Advance to start of first object (particularly, if blobs exist)
+            if (count > 0)
             {
                 uint pos = reader.GetAddressForUndertaleObject(this[0]);
                 if (reader.AbsPosition != pos)
@@ -340,91 +434,126 @@ namespace UndertaleModLib
                     long skip = pos - reader.AbsPosition;
                     if (skip > 0)
                     {
-                        //Console.WriteLine("Skip " + skip + " bytes of blobs");
                         reader.AbsPosition += skip;
                     }
                     else
-                        throw new IOException("First list item starts inside the pointer list?!?!");
+                    {
+                        throw new IOException("First list item starts inside pointer list");
+                    }
                 }
             }
-            for (uint i = 0; i < count; i++)
+
+            // Read in actual objects
+            uint j = 0;
+            try
             {
-                try
+                for (; j < count; j++)
                 {
-                    T obj = this[(int)i];
+                    T obj = this[(int)j];
+                    
+                    // Unserialize pre-padding, if this is a type that requires it
+                    if (typeof(T).IsAssignableTo(typeof(PrePaddedObject)))
+                    {
+                        ((PrePaddedObject)obj).UnserializePrePadding(reader);
+                    }
 
-                    (obj as PrePaddedObject)?.UnserializePrePadding(reader);
-
+                    // Read object
                     reader.ReadUndertaleObject(obj);
 
-                    if (i != count - 1)
-                        (obj as PaddedObject)?.UnserializePadding(reader);
+                    // Unserialize padding, if this is a type that requires it
+                    if (typeof(T).IsAssignableTo(typeof(PaddedObject)))
+                    {
+                        // The last object does NOT get padding (TODO: at least in AUDO)
+                        if (j != count - 1)
+                        {
+                            ((PaddedObject)obj).UnserializePadding(reader);
+                        }
+                    }
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
+            }
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading item {j + 1} of {count} in a list of {typeof(T).FullName}", e);
             }
         }
 
         /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
         public static uint UnserializeChildObjectCount(UndertaleReader reader)
         {
+            // Read base object count
             uint count = reader.ReadUInt32();
             if (count == 0)
-                return 0;
-
-            uint totalCount = 0;
-
-            Type t = typeof(T);
-            if (t.IsAssignableTo(typeof(IStaticChildObjectsSize)))
             {
-                uint subSize = reader.GetStaticChildObjectsSize(t);
-                uint subCount = 0;
-
-                if (t.IsAssignableTo(typeof(IStaticChildObjCount)))
-                    subCount = reader.GetStaticChildCount(t);
-
-                reader.Position += count * 4 + count * subSize;
-
-                return count + count * subCount;
+                // Short-circuit if there's no objects
+                return 0;
             }
 
+            // If objects have a static child object size/count, simply multiply to determine the number of total objects
+            if (typeof(T).IsAssignableTo(typeof(IStaticChildObjectsSize)))
+            {
+                uint subSize = reader.GetStaticChildObjectsSize(typeof(T));
+                uint subCount = 0;
+
+                if (typeof(T).IsAssignableTo(typeof(IStaticChildObjCount)))
+                {
+                    subCount = reader.GetStaticChildCount(typeof(T));
+                }
+
+                reader.Position += (count * 4) + (count * subSize);
+
+                return count + (count * subCount);
+            }
+
+            // Read pointers of all objects
             uint[] pointers = reader.ListPtrsPool.Rent((int)count);
             for (uint i = 0; i < count; i++)
+            {
                 pointers[i] = reader.ReadUInt32();
+            }
 
+            // Advance to start of first object (particularly, if blobs exist)
             uint pos = pointers[0];
             if (reader.AbsPosition != pos)
             {
                 long skip = pos - reader.AbsPosition;
                 if (skip > 0)
+                {
                     reader.AbsPosition += skip;
+                }
                 else
-                    throw new IOException("First list item starts inside the pointer list?!?!");
+                {
+                    throw new IOException("First list item starts inside pointer list");
+                }
             }
 
-            var unserializeFunc = reader.GetUnserializeCountFunc(t);
-            for (uint i = 0; i < count; i++)
+            // Determine object counts recursively for all objects
+            var unserializeFunc = reader.GetUnserializeCountFunc(typeof(T));
+            uint totalCount = 0;
+            uint j = 0;
+            try
             {
-                try
+                for (; j < count; j++)
                 {
-                    reader.AbsPosition = pointers[i];
+                    reader.AbsPosition = pointers[j];
                     totalCount += 1 + unserializeFunc(reader);
                 }
-                catch (UndertaleSerializationException e)
-                {
-                    reader.ListPtrsPool.Return(pointers);
-                    throw new UndertaleSerializationException(e.Message + "\nwhile reading child object count of item " + (i + 1) + " of " + count + " in a list of " + typeof(T).FullName, e);
-                }
             }
-
-            reader.ListPtrsPool.Return(pointers);
+            catch (UndertaleSerializationException e)
+            {
+                throw new UndertaleSerializationException($"{e.Message}\nwhile reading child object count of item {j + 1} of {count} in a list of {typeof(T).FullName}", e);
+            }
+            finally
+            {
+                reader.ListPtrsPool.Return(pointers);
+            }
 
             return totalCount;
         }
     }
 
+    /// <summary>
+    /// Shorthand for <see cref="UndertaleSimpleList{T}"/> containing <see cref="UndertaleResourceById{T, ChunkT}"/>.
+    /// </summary>
     public class UndertaleSimpleResourcesList<T, ChunkT> : UndertaleSimpleList<UndertaleResourceById<T, ChunkT>> where T : UndertaleResource, new() where ChunkT : UndertaleListChunk<T>
     {
         // TODO: Allow direct access to Resource elements?


### PR DESCRIPTION
## Description
Refactors all of the list classes inheriting from `UndertaleListBase<T>`, which itself is no longer an abstract class, and has been renamed to `UndertaleObservableList<T>`. This allows data models to take advantage of observable collections for lists that need to unserialize using `InternalAdd()` (for performance purposes), when those lists have an irregular format in the WAD that the other lists can't handle. This functionality is currently unused in this PR, but will be taken advantage of in at least `UndertaleGameObject` in a future project system PR, for the list of physics vertices.

In general, I took to cleaning up and commenting all of the list code, as well as moving try/catch statements outside of loops to reduce their overhead. I have no idea if this has any noticeable impact on performance, but if it does, it's probably marginally faster now.

### Caveats
There's probably an extremely small chance something has been broken with these changes, but I ran through my whole game test suite and everything saved/loaded identically byte-for-byte, as usual (and the tool operates as normal).

### Notes
It's a little bit hacky how the base observable list has to use reflection to get and modify an internal member of `Collection<T>`, but it was already that way previously, and I'm not sure if we have any better alternatives. Perhaps a future PR could address that, if there is another way.