### PR TITLE
OGG "support" for the embedded audio editor

### DIFF
--- a/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml
@@ -33,7 +33,8 @@
 
             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
                 <TextBlock.Text>
-                    <MultiBinding StringFormat="{}WAV data, length: {0}">
+                    <MultiBinding StringFormat="{}{0} data, {1} bytes">
+                        <Binding Path="FileType" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:UndertaleEmbeddedAudioEditor}}" Mode="OneWay" />
                         <Binding Path="Data.Length"/>
                     </MultiBinding>
                 </TextBlock.Text>

--- a/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedAudioEditor.xaml.cs
@@ -3,6 +3,7 @@ using NAudio.Vorbis;
 using NAudio.Wave;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -23,7 +24,7 @@ namespace UndertaleModTool
     /// <summary>
     /// Logika interakcji dla klasy UndertaleEmbeddedAudioEditor.xaml
     /// </summary>
-    public partial class UndertaleEmbeddedAudioEditor : DataUserControl
+    public partial class UndertaleEmbeddedAudioEditor : DataUserControl, INotifyPropertyChanged
     {
         private WaveOutEvent waveOut;
         private WaveFileReader wavReader;
@@ -31,9 +32,28 @@ namespace UndertaleModTool
 
         private static readonly MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
 
+		public string FileType
+        {
+            get
+            {
+                if (DataContext is not UndertaleEmbeddedAudio target)
+                    return "Unknown";
+                
+                if (IsWav(target.Data))
+                    return "WAV";
+                if (IsOgg(target.Data))
+                    return "OGG";
+                return "Unknown";
+            }
+        }
+
         public UndertaleEmbeddedAudioEditor()
         {
             InitializeComponent();
+            DataContextChanged += (sender, args) =>
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FileType)));
+            };
             this.Unloaded += Unload;
         }
 
@@ -49,18 +69,29 @@ namespace UndertaleModTool
 
             OpenFileDialog dlg = new OpenFileDialog();
 
-            dlg.DefaultExt = ".wav";
-            dlg.Filter = "WAV files (.wav)|*.wav|All files|*";
+            if (IsWav(target.Data)) {
+                dlg.DefaultExt = ".wav";
+                dlg.Filter = "WAV files|*.wav|All files|*";
+            } else if (IsOgg(target.Data)) {
+                dlg.DefaultExt = ".ogg";
+                dlg.Filter = "OGG files|*.ogg|All files|*";
+            } else {
+                dlg.DefaultExt = "";
+                dlg.Filter = "All files|*";
+            }
 
             if (dlg.ShowDialog() == true)
             {
                 try
                 {
                     byte[] data = File.ReadAllBytes(dlg.FileName);
-
-                    // TODO: Make sure it's valid WAV
-
-                    target.Data = data;
+                    if (!IsWav(data) && !IsOgg(data)) {
+                        mainWindow.ShowError("Failed to import file!\r\nNot a WAV or OGG.", "Failed to import file");
+                    }
+                    else if ((IsWav(target.Data) && IsOgg(data)) || (IsOgg(target.Data) && IsWav(data))) {
+                        mainWindow.ShowError("Failed to import file!\r\nFormat doesn't match the original file.", "Failed to import file");
+                    } else
+                        target.Data = data;
                 }
                 catch (Exception ex)
                 {
@@ -75,8 +106,16 @@ namespace UndertaleModTool
 
             SaveFileDialog dlg = new SaveFileDialog();
 
-            dlg.DefaultExt = ".wav";
-            dlg.Filter = "WAV files (.wav)|*.wav|All files|*";
+            if (IsWav(target.Data)) {
+                dlg.DefaultExt = ".wav";
+                dlg.Filter = "WAV files|*.wav|All files|*";
+            } else if (IsOgg(target.Data)) {
+                dlg.DefaultExt = ".ogg";
+                dlg.Filter = "OGG files|*.ogg|All files|*";
+            } else {
+                dlg.DefaultExt = "";
+                dlg.Filter = "All files|*";
+            }
 
             if (dlg.ShowDialog() == true)
             {
@@ -107,14 +146,14 @@ namespace UndertaleModTool
             {
                 try
                 {
-                    if (target.Data[0] == 'R' && target.Data[1] == 'I' && target.Data[2] == 'F' && target.Data[3] == 'F')
+                    if (IsWav(target.Data))
                     {
                         wavReader = new WaveFileReader(new MemoryStream(target.Data));
                         InitAudio();
                         waveOut.Init(wavReader);
                         waveOut.Play();
                     }
-                    else if (target.Data[0] == 'O' && target.Data[1] == 'g' && target.Data[2] == 'g' && target.Data[3] == 'S')
+                    else if (IsOgg(target.Data))
                     {
                         oggReader = new VorbisWaveReader(new MemoryStream(target.Data));
                         InitAudio();
@@ -136,5 +175,13 @@ namespace UndertaleModTool
             if (waveOut != null)
                 waveOut.Stop();
         }
+		
+		private bool IsWav(byte[] data) {
+			return data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F';
+		}
+		
+		private bool IsOgg(byte[] data) {
+            return data[0] == 'O' && data[1] == 'g' && data[2] == 'g' && data[3] == 'S';
+		}
     }
 }


### PR DESCRIPTION
## Description
this makes the embedded audio editor use the correct extension for exporting/importing depending on whether the audio is wav or ogg and also changes that "WAV data" label finally

### Notes
- this feature was from utmtce (except the label text i just figured that out now)
- i hate wpf and i have no idea what's going on!
- this feature led to [72ea328](https://github.com/UnderminersTeam/UndertaleModTool/commit/72ea3289279a06f543181fc6c72fc558fd8d9565) happening