### PR TITLE
ImportGraphics(+Advanced): fix empty sprites not working

### DIFF
--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphics.csx
@@ -320,9 +320,24 @@ public class Packer
                     atlas.Height /= 2;
                     leftovers = LayoutAtlas(textures, atlas);
                 }
-                // we need to go 1 step larger as we found the first size that is to small
-                atlas.Width *= 2;
-                atlas.Height *= 2;
+                // we need to go 1 step larger as we found the first size that is too small
+                // if the atlas is 0x0 then it should be 1x1 instead
+                if (atlas.Width == 0)
+                {
+                    atlas.Width = 1;
+                }
+                else
+                {
+                    atlas.Width *= 2;
+                }
+                if (atlas.Height == 0)
+                {
+                    atlas.Height = 1;
+                }
+                else
+                {
+                    atlas.Height *= 2;
+                }
                 leftovers = LayoutAtlas(textures, atlas);
             }
             Atlasses.Add(atlas);
@@ -405,14 +420,18 @@ public class Packer
                     {
                         ti.TargetX = bbox.X;
                         ti.TargetY = bbox.Y;
+                        // yes, .Trim() mutates the image...
+                        // it doesn't really matter though since it isn't written back or anything
+                        img.Trim();
                     }
                     else
                     {
-                        throw new ScriptException("ERROR: " + fi.FullName + "'s bounding box is null somehow");
+                        // Empty sprites should be 1x1
+                        ti.TargetX = 0;
+                        ti.TargetY = 0;
+                        img.Crop(1, 1);
                     }
-                    // yes, .Trim() mutates the image...
-                    // it doesn't really matter though since it isn't written back or anything
-                    img.Trim();
+                    img.ResetPage();
                 }
                 ti.Width = (int)img.Width;
                 ti.Height = (int)img.Height;

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportGraphicsAdvanced.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportGraphicsAdvanced.csx
@@ -441,9 +441,23 @@ public class Packer
                     atlas.Height /= 2;
                     leftovers = LayoutAtlas(textures, atlas);
                 }
-                // we need to go 1 step larger as we found the first size that is to small
-                atlas.Width *= 2;
-                atlas.Height *= 2;
+                // we need to go 1 step larger as we found the first size that is too small
+                // if the atlas is 0x0 then it should be 1x1 instead
+                if (atlas.Width == 0)
+                {
+                    atlas.Width = 1;
+                } else
+                {
+                    atlas.Width *= 2;
+                }
+                if (atlas.Height == 0)
+                {
+                    atlas.Height = 1;
+                }
+                else
+                {
+                    atlas.Height *= 2;
+                }
                 leftovers = LayoutAtlas(textures, atlas);
             }
             Atlasses.Add(atlas);
@@ -632,14 +646,18 @@ public class Packer
                 {
                     ti.TargetX = bbox.X;
                     ti.TargetY = bbox.Y;
+                    // yes, .Trim() mutates the image...
+                    // it doesn't really matter though since it isn't written back or anything
+                    img.Trim();
                 }
                 else
                 {
-                    throw new ScriptException("ERROR: " + fullName + "'s bounding box is null somehow");
+                    // Empty sprites should be 1x1
+                    ti.TargetX = 0;
+                    ti.TargetY = 0;
+                    img.Crop(1, 1);
                 }
-                // yes, .Trim() mutates the image...
-                // it doesn't really matter though since it isn't written back or anything
-                img.Trim();
+                img.ResetPage();
             }
             ti.Width = (int)img.Width;
             ti.Height = (int)img.Height;


### PR DESCRIPTION
## Description
apparently the bounding boxes of images are null when they're empty. in this case, gamemaker makes the page items 1x1 so i did that here too

### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

### Notes
<!-- Any notes or closing words -->