### PR TITLE
Correction to XML API documentation for Tile.ObjectDefinition and Tile.spriteMode

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1121,7 +1121,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         public static readonly uint ChildObjectsSize = 48;
 
         /// <summary>
-        /// Whether this tile is from an asset layer.<br/>
+        /// Whether this tile represents a <see cref="UndertaleSprite"/> or a <see cref="UndertaleBackground"/>.<br/>
         /// <see langword="true"/> for GameMaker Studio: 2 games, otherwise <see langword="false"/>.
         /// </summary>
         /// <remarks>

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1173,8 +1173,8 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
 
         /// <summary>
         /// From which object this tile stems from.<br/>
-        /// Will return a <see cref="UndertaleBackground"/> if <see cref="spriteMode"/> is <see langword="true"/>,
-        /// a <see cref="UndertaleSprite"/> if it's <see langword="false"/>.
+        /// Will return a <see cref="UndertaleSprite"/> if <see cref="spriteMode"/> is <see langword="true"/>,
+        /// a <see cref="UndertaleBackground"/> if it's <see langword="false"/>.
         /// </summary>
         public UndertaleNamedResource ObjectDefinition
         {


### PR DESCRIPTION
## Description
Fixes an XML API documentation mistake for `Tile.ObjectDefinition`. Summary previously stated that an `UndertaleSprite` would be returned if `spriteMode` was false, which is incorrect. This information has also been added to the `spriteMode` documentation.

### Notes
The implementation details of `ObjectDefinition` or `spriteMode` haven't changed. This PR merely clarifies the function of `spriteMode`.