### PR TITLE
[NewTextureRepacker] Group textures to dump by their texture page to prevent explosive memory growth

### DIFF
--- a/UndertaleModTool/Scripts/Resource Repackers/NewTextureRepacker.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/NewTextureRepacker.csx
@@ -238,13 +238,21 @@ TPageItem dumpTexturePageItem(UndertaleTexturePageItem pageItem, TextureWorker w
 
 async Task<List<TPageItem>> dumpTexturePageItems(string dir, bool reuse)
 {
-    using var worker = new TextureWorker();
+    var groupedByTexturePage = Data.TexturePageItems
+        .GroupBy(item => item.TexturePage.ToString());
 
-    var tpageitems = await Task.Run(() => Data.TexturePageItems
-        .AsParallel()
-        .Select(item => dumpTexturePageItem(item, worker, Path.Combine(dir, $"texture_page_{Data.TexturePageItems.IndexOf(item)}.png"), reuse))
-        .ToList());
+    var tpageitems = new List<TPageItem>();
+    foreach (var group in groupedByTexturePage)
+    {
+        using var worker = new TextureWorker();
 
+        var tpageitemsNew = await Task.Run(() => group
+            .AsParallel()
+            .Select(item => dumpTexturePageItem(item, worker, Path.Combine(dir, $"texture_page_{Data.TexturePageItems.IndexOf(item)}.png"), reuse))
+            .ToList());
+
+        tpageitems.AddRange(tpageitemsNew);
+    }
     return tpageitems;
 }
 


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->
Some games such as vivid/stasis, due to developer ignorance, have 10s to 100s of 4096x4096 texture pages. With the current design of the script, eventually all the texture pages will be loaded and held in memory by the `TextureWorker`, causing explosive memory growth (up to 7GB in my case).
This PR changes the dump function to only process one texture page at a time, avoiding the excessive memory usage.

### Caveats
<!-- Any caveats, side effects or regressions of this PR -->
Parallelism might be reduced, but not dying due to running out of memory is arguably more important.

### Notes
<!-- Any notes or closing words -->