### PR TITLE
feat: Making some scripts crossplatforms

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -389,6 +389,28 @@ public partial class Program : IScriptInterface
         return path;
     }
 
+    public string PromptSaveFile(string defaultExt, string filter)
+    {
+        string path;
+        do
+        {
+            Console.WriteLine("Please type a path (or drag and drop) to save the file:");
+            Console.Write("Path: ");
+            path = RemoveQuotes(Console.ReadLine());
+
+            if (Directory.Exists(path))
+            {
+                Console.WriteLine("You selected a directory");
+            }
+
+            if (string.IsNullOrWhiteSpace(Path.GetExtension(path)))
+            {
+                path += defaultExt.StartsWith(".") ? defaultExt : "." + defaultExt;
+            }
+        } while (string.IsNullOrWhiteSpace(path));
+        return path;
+    }
+
     /// <inheritdoc/>
     public string GetDecompiledText(string codeName, GlobalDecompileContext context = null, IDecompileSettings settings = null)
     {

--- a/UndertaleModLib/Scripting/IScriptInterface.cs
+++ b/UndertaleModLib/Scripting/IScriptInterface.cs
@@ -432,4 +432,12 @@ public interface IScriptInterface
     /// <param name="filter">The filters used for the file select.</param>
     /// <returns>The file selected by the user.</returns>
     string PromptLoadFile(string defaultExt, string filter);
+
+    /// <summary>
+    /// Used to prompt the user to select a location and name to save a file..
+    /// </summary>
+    /// <param name="defaultExt">The default extension that should be used when saving the file.</param>
+    /// <param name="filter">The filters used to specify the file types in the dialog.</param>
+    /// <returns>The file path specified by the user for saving.</returns>
+    string PromptSaveFile(string defaultExt, string filter);
 }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2444,6 +2444,14 @@ namespace UndertaleModTool
             return dlg.ShowDialog() == true ? dlg.FileName : null;
         }
 
+        public string PromptSaveFile(string defaultExt, string filter)
+        {
+            SaveFileDialog dlg = new SaveFileDialog();
+            dlg.DefaultExt = defaultExt ?? "win";
+            dlg.Filter = filter ?? "GameMaker data files (.win, .unx, .ios, .droid, audiogroup*.dat)|*.win;*.unx;*.ios;*.droid;audiogroup*.dat|All files|*";
+            return dlg.ShowDialog() == true ? dlg.FileName : null;
+        }
+
         public string PromptChooseDirectory()
         {
             VistaFolderBrowserDialog folderBrowser = new VistaFolderBrowserDialog();

--- a/UndertaleModTool/Scripts/Builtin Scripts/UndertaleDialogSimulator.csx
+++ b/UndertaleModTool/Scripts/Builtin Scripts/UndertaleDialogSimulator.csx
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System;
-using System.Windows.Forms;
 using UndertaleModLib.Util;
 
 EnsureDataLoaded();

--- a/UndertaleModTool/Scripts/Community Scripts/ExportAllStringsBetter.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ExportAllStringsBetter.csx
@@ -1,15 +1,10 @@
 using System.Linq;
 using System.Text;
-using System.Windows.Forms; // Needed for SaveFileDialog prompt
 
 EnsureDataLoaded();
 
-SaveFileDialog saveFileDialog = new SaveFileDialog()
-{
-    InitialDirectory = FilePath,
-    Filter = "TXT files (*.txt)|*.txt|JSON files (*.json)|*.json|All files (*.*)|*.*"
-};
-if (saveFileDialog.ShowDialog() != DialogResult.OK)
+string path = PromptSaveFile(".json", "TXT files (*.txt)|*.txt|JSON files (*.json)|*.json|All files (*.*)|*.*");
+if (string.IsNullOrWhiteSpace(path))
     return;
 
 StringBuilder json = new StringBuilder("{\r\n    \"Strings\": [\r\n");
@@ -24,8 +19,8 @@ foreach (string str in Data.Strings.Select(str => str.Content))
 json.Length -= suffix.Length;
 json.Append("\r\n    ]\r\n}");
 
-File.WriteAllText(saveFileDialog.FileName, json.ToString());
-ScriptMessage($"Successfully exported to\n{saveFileDialog.FileName}");
+File.WriteAllText(path, json.ToString());
+ScriptMessage($"Successfully exported to\n{path}");
 
 static string JsonifyString(string str)
 {

--- a/UndertaleModTool/Scripts/Community Scripts/FindObjectsInRooms.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/FindObjectsInRooms.csx
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Windows;
 using UndertaleModLib.Scripting;
 
 EnsureDataLoaded();

--- a/UndertaleModTool/Scripts/Community Scripts/ImportAllStringsBetter.csx
+++ b/UndertaleModTool/Scripts/Community Scripts/ImportAllStringsBetter.csx
@@ -1,20 +1,15 @@
 using System.Text.Json;
-using System.Windows.Forms;
 
 EnsureDataLoaded();
 
-OpenFileDialog openFileDialog = new OpenFileDialog()
-{
-    InitialDirectory = FilePath,
-    Filter = "TXT files (*.txt)|*.txt|JSON files (*.json)|*.json|All files (*.*)|*.*"
-};
-if (openFileDialog.ShowDialog() != DialogResult.OK)
+string path = PromptLoadFile("", "TXT files (*.txt)|*.txt|JSON files (*.json)|*.json|All files (*.*)|*.*");
+if (string.IsNullOrWhiteSpace(path))
     return;
 
-string file = File.ReadAllText(openFileDialog.FileName);
+string file = File.ReadAllText(path);
 JsonElement json = JsonSerializer.Deserialize<JsonElement>(file);
 JsonElement.ArrayEnumerator array = json.GetProperty("Strings").EnumerateArray();
 int i = 0;
 foreach (JsonElement elmnt in array)
     Data.Strings[i++].Content = elmnt.ToString();
-MessageBox.Show("Successfully imported", "Strings import");
+ScriptMessage("Successfully imported");

--- a/UndertaleModTool/Scripts/Resource Repackers/CopySound.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/CopySound.csx
@@ -3,7 +3,6 @@
 using System;
 using System.ComponentModel;
 using System.IO;
-using System.Windows;
 using UndertaleModLib;
 using UndertaleModLib.Scripting;
 using UndertaleModLib.Models;

--- a/UndertaleModTool/Scripts/Resource Repackers/CopySoundInternal.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/CopySoundInternal.csx
@@ -3,7 +3,6 @@
 using System;
 using System.ComponentModel;
 using System.IO;
-using System.Windows;
 using UndertaleModLib;
 using UndertaleModLib.Scripting;
 using UndertaleModLib.Models;
@@ -220,7 +219,7 @@ IList<UndertaleEmbeddedAudio> GetAudioGroupData(UndertaleSound sound, string win
     {
         UndertaleData data = null;
         using (var stream = new FileStream(groupFilePath, FileMode.Open, FileAccess.Read))
-            data = UndertaleIO.Read(stream, warning => ScriptMessage("A warning occured while trying to load " + audioGroupName + ":\n" + warning));
+            data = UndertaleIO.Read(stream, (warning, _) => ScriptMessage("A warning occured while trying to load " + audioGroupName + ":\n" + warning));
 
         loadedAudioGroups[audioGroupName] = data.EmbeddedAudio;
         return data.EmbeddedAudio;

--- a/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopy.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopy.csx
@@ -2,8 +2,6 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
-using System.Windows;
-using System.Windows.Threading;
 using UndertaleModLib;
 using UndertaleModLib.Scripting;
 using System.Security.Cryptography;

--- a/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopyInternal.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/GameObjectCopyInternal.csx
@@ -2,8 +2,6 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
-using System.Windows;
-using System.Windows.Threading;
 using UndertaleModLib;
 using UndertaleModLib.Scripting;
 using System.Security.Cryptography;

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportASound.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportASound.csx
@@ -5,7 +5,6 @@
 // By Jockeholm & Nik the Neko - Version 3 03/01/2020 - Massive im_purr_ovements.
 // By Jockeholm                - Version 2 15/02/2020 - Currently supports embedded WAV files only
 
-using System.Windows.Forms;
 using UndertaleModLib;
 using UndertaleModLib.Models;
 using static UndertaleModLib.Models.UndertaleSound;
@@ -34,17 +33,13 @@ if (Data.IsVersionAtLeast(2024, 14))
     ScriptWarning("This script may act erroneously on GameMaker version 2024.14 and later.");
 }
 
-OpenFileDialog fileDialog   = new OpenFileDialog();
-fileDialog.InitialDirectory = Path.GetDirectoryName(FilePath) + Path.DirectorySeparatorChar;
-fileDialog.Filter           = "Sound files (*.WAV;*.OGG)|*.WAV;*.OGG"; // Limits the dialog to displaying WAV files only
-fileDialog.Title            = "Select a sound file to import"; // Sets the dialog title
-DialogResult dialogRet      = fileDialog.ShowDialog(); // opens a file select window
+string sound_path = PromptLoadFile("", "Sound files (*.WAV;*.OGG)|*.WAV;*.OGG");
 
-if (dialogRet == DialogResult.OK)
+if (!string.IsNullOrEmpty(sound_path))
 {
-    string fname      = fileDialog.SafeFileName;
+    string fname      = sound_path;
     string sound_name = fname.Substring(0, fname.LastIndexOf('.')); // creates a string of the wav file's filename without it's extension
-    bool   isOGG      = Path.GetExtension(fileDialog.FileName) == ".ogg";
+    bool   isOGG      = Path.GetExtension(sound_path) == ".ogg";
     bool   embedSound = false;
     bool   decodeLoad = false;
     if (isOGG)
@@ -63,7 +58,7 @@ if (dialogRet == DialogResult.OK)
         decodeLoad = false;
     }
     string AGRPname    = "";
-    string FolderName  = Path.GetFileName( Path.GetDirectoryName( fileDialog.FileName ) );
+    string FolderName  = Path.GetFileName( Path.GetDirectoryName( sound_path ) );
     bool   needAGRP    = false;
     bool   ifRightAGRP = false;
     string[] splitArr  = new string[2];
@@ -144,7 +139,7 @@ if (dialogRet == DialogResult.OK)
 
     if ((embedSound && !needAGRP) || (needAGRP))
     {
-        soundData = new UndertaleEmbeddedAudio() { Data = File.ReadAllBytes(fileDialog.FileName) };
+        soundData = new UndertaleEmbeddedAudio() { Data = File.ReadAllBytes(sound_path) };
         Data.EmbeddedAudio.Add(soundData);
         if (soundExists)
             Data.EmbeddedAudio.Remove(existing_snd.AudioFile);

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportMasks.csx
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using System.Drawing;
+using ImageMagick;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,7 +42,7 @@ foreach (string file in dirFiles)
     {
         throw new ScriptException(FileNameWithExtension + " could not be imported as the sprite " + spriteName + " does not exist.");
     }
-    using (Image img = Image.FromFile(file))
+    using (MagickImage img = TextureWorker.ReadBGRAImageFromFile(file))
     {
         if ((Data.Sprites.ByName(spriteName).Width != (uint)img.Width) || (Data.Sprites.ByName(spriteName).Height != (uint)img.Height))
             throw new ScriptException(FileNameWithExtension + " is not the proper size to be imported! Please correct this before importing! The proper dimensions are width: " + Data.Sprites.ByName(spriteName).Width.ToString() + " px, height: " + Data.Sprites.ByName(spriteName).Height.ToString() + " px.");

--- a/UndertaleModTool/Scripts/Resource Repackers/ImportSoundsBulk.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/ImportSoundsBulk.csx
@@ -6,7 +6,6 @@
 // By Jockeholm & Nik the Neko - Version 3 03/01/2020 - Massive im_purr_ovements.
 // By Jockeholm                - Version 2 15/02/2020 - Currently supports embedded WAV files only
 
-using System.Windows.Forms;
 using UndertaleModLib;
 using UndertaleModLib.Models;
 using static UndertaleModLib.Models.UndertaleSound;

--- a/UndertaleModTool/Scripts/Resource Repackers/NewTextureRepacker.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/NewTextureRepacker.csx
@@ -21,7 +21,6 @@ using System;
 using System.Linq;
 using System.ComponentModel;
 using System.IO;
-using System.Windows.Forms;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -366,10 +365,7 @@ bool reuseTextures = false;
 string packagerDirectory = Path.Combine(ExePath, "Packager");
 if (Directory.Exists(packagerDirectory))
 {
-    DialogResult dr = MessageBox.Show("Do you want to reuse previously extracted page items?", 
-        "Texture Repacker", MessageBoxButtons.YesNo);
-
-    reuseTextures = dr == DialogResult.Yes;
+    reuseTextures = ScriptQuestion("Do you want to reuse previously extracted page items?");
 }
 
 Directory.CreateDirectory(packagerDirectory);

--- a/UndertaleModTool/Scripts/Resource Repackers/SpriteOriginCopy.csx
+++ b/UndertaleModTool/Scripts/Resource Repackers/SpriteOriginCopy.csx
@@ -2,8 +2,6 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
-using System.Windows;
-using System.Windows.Threading;
 using UndertaleModLib;
 using UndertaleModLib.Scripting;
 using UndertaleModLib.Models;
@@ -18,7 +16,7 @@ if (donorDataPath == null)
     throw new ScriptException("The donor data path was not set.");
 
 using (var stream = new FileStream(donorDataPath, FileMode.Open, FileAccess.Read))
-    donorData = UndertaleIO.Read(stream, warning => ScriptMessage("A warning occured while trying to load " + donorDataPath + ":\n" + warning));
+    donorData = UndertaleIO.Read(stream, (warning, _) => ScriptMessage("A warning occured while trying to load " + donorDataPath + ":\n" + warning));
 
 foreach (var sprite in Data.Sprites)
 {

--- a/UndertaleModTool/Scripts/Resource Unpackers/ExportSpritesAsGIF.csx
+++ b/UndertaleModTool/Scripts/Resource Unpackers/ExportSpritesAsGIF.csx
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Reflection;
 using System.IO;
 using System.Threading.Tasks;

--- a/UndertaleModTool/Scripts/Technical Scripts/FindNullsInOffsetMap.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/FindNullsInOffsetMap.csx
@@ -1,30 +1,19 @@
-using Microsoft.Win32;
 using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows;
 using UndertaleModLib;
 
-OpenFileDialog dlg = new OpenFileDialog();
+string dlg = PromptLoadFile("win", "GameMaker data files (.win, .unx, .ios)|*.win;*.unx;*.ios|All files|*");
 
-dlg.DefaultExt = "win";
-dlg.Filter = "GameMaker data files (.win, .unx, .ios)|*.win;*.unx;*.ios|All files|*";
-
-if (dlg.ShowDialog() == true)
+if (!string.IsNullOrEmpty(dlg))
 {
-    SaveFileDialog dlgout = new SaveFileDialog();
-    dlgout.DefaultExt = "txt";
-    dlgout.Filter = "Text files (.txt)|*.txt|All files|*";
-    dlgout.FileName = dlg.FileName + ".nulltrunc.txt";
+    string dlgout = PromptSaveFile("txt", "Text files (.txt)|*.txt|All files|*");
 
-    OpenFileDialog dlgin = new OpenFileDialog();
-    dlgin.DefaultExt = "txt";
-    dlgin.Filter = "Text files (.txt)|*.txt|All files|*";
-    dlgin.FileName = "Select the null_offsets.txt file.";
-    if (dlgin.ShowDialog() == false)
+    string dlgin = PromptLoadFile("txt", "Text files (.txt)|*.txt|All files|*");
+    if (string.IsNullOrEmpty(dlgin))
     {
-        MessageBox.Show("An error occured.", "Load error", MessageBoxButton.OK, MessageBoxImage.Error);
+        ScriptMessage("An error occured.");
         return;
     }
     uint scrutiny = 0;
@@ -38,19 +27,19 @@ if (dlg.ShowDialog() == true)
         {
         }
     }
-    if (dlgout.ShowDialog() == true)
+    if (!string.IsNullOrEmpty(dlgout))
     {
         Task t = Task.Run(() =>
         {
             try
             {
-                StreamReader file = new StreamReader(dlgin.FileName);
+                StreamReader file = new StreamReader(dlgin);
                 string line;
                 line = file.ReadLine();
-                using (var stream = new FileStream(dlg.FileName, FileMode.Open, FileAccess.Read))
+                using (var stream = new FileStream(dlg, FileMode.Open, FileAccess.Read))
                 {
                     var offsets = UndertaleIO.GenerateOffsetMap(stream);
-                    using (var writer = File.CreateText(dlgout.FileName))
+                    using (var writer = File.CreateText(dlgout))
                     {
                         while((line = file.ReadLine()) != null)
                         {
@@ -73,7 +62,7 @@ if (dlg.ShowDialog() == true)
             }
             catch (Exception ex)
             {
-                MessageBox.Show("An error occured while trying to load:\n" + ex.Message, "Load error", MessageBoxButton.OK, MessageBoxImage.Error);
+                ScriptError("An error occured while trying to load:\n" + ex.Message);
             }
 
         });


### PR DESCRIPTION
Makes some scripts crossplatfrom

NewTextureRepacker, ExportAllStringsBetter, ImportAllStringsBetter, ImportASound and FindNullsInOffsetMap by removing WinForms use.

ImportMask by using ImageMagick instead of System.Drawing.

UndertaleDialogSimulator, FindObjectsinRoom, CopySound, GameOjectCopy, GameOjectCopyInternal, ImportSoundsBulk, SpriteOriginCopy and ExportSpritesAsGIF by removing unecessary "using windows_only_api" statements.

**NOTE**
I also added a method to the IScriptInterface to save files. Called "PromptSaveFile"