### PR TITLE
Fix errors caused when copying certain text

### DIFF
--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesResults.xaml.cs
@@ -299,7 +299,15 @@ namespace UndertaleModTool.Windows
                 else
                     itemName = item.DataContext.ToString();
 
-                Clipboard.SetText(itemName);
+                try
+                {
+                    Clipboard.SetText(itemName);
+                }
+                catch (Exception ex)
+                {
+                    this.ShowError("Can't copy the item name to clipboard due to this error:\n" +
+                                   ex.Message + ".\nYou probably should try again.");
+                }
             }
         }
         private void MenuItem_FindAllReferences_Click(object sender, RoutedEventArgs e)

--- a/UndertaleModTool/Windows/SearchInCodeWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SearchInCodeWindow.xaml.cs
@@ -290,12 +290,20 @@ namespace UndertaleModTool.Windows
             }
         }
 
-        static void CopyListViewItems(IEnumerable items)
+        void CopyListViewItems(IEnumerable items)
         {
             string str = String.Join("\n", items
                 .Cast<Result>()
                 .Select(result => $"{result.Code}\t{result.LineNumber}\t{result.LineText}"));
-            Clipboard.SetText(str);
+            try
+            {
+                Clipboard.SetText(str);
+            }
+            catch (Exception ex)
+            {
+                this.ShowError("Can't copy the item name to clipboard due to this error:\n" +
+                               ex.Message + ".\nYou probably should try again.");
+            }
         }
 
         private async void SearchTextBox_PreviewKeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
## Description
Sometimes [errors](https://discord.com/channels/566861759210586112/568950566122946580/1374886848878346310) occur when copying text with Clipboard.SetText, unknown reason. There was already another place in the code with this safe-guard, I just copied it.

### Caveats
None

### Notes
None