### PR TITLE
Use actual tileset size for automatic room grid size calculation

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -513,9 +513,14 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                     tileList = tileList.Concat(layer.AssetsData.LegacyTiles);
                 else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0)
                 {
-                    int w = (int) (Width / layer.TilesData.TilesX);
-                    int h = (int) (Height / layer.TilesData.TilesY);
-                    tileSizes[new(w, h)] = layer.TilesData.TilesX * layer.TilesData.TilesY;
+                    int w = (int)layer.TilesData.Background.GMS2TileWidth;
+                    int h = (int)layer.TilesData.Background.GMS2TileHeight;
+                    Point scale = new(w, h);
+                    uint numTiles = layer.TilesData.TilesX * layer.TilesData.TilesY;
+                    if (tileSizes.ContainsKey(scale))
+                        tileSizes[scale] += numTiles;
+                    else
+                        tileSizes[scale] = numTiles;
                 }
             }
 

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -511,7 +511,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             {
                 if (layer.LayerType == LayerType.Assets)
                     tileList = tileList.Concat(layer.AssetsData.LegacyTiles);
-                else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0)
+                else if (layer.LayerType == LayerType.Tiles && layer.TilesData.TileData.Length != 0 && layer.TilesData.Background is not null)
                 {
                     int w = (int)layer.TilesData.Background.GMS2TileWidth;
                     int h = (int)layer.TilesData.Background.GMS2TileHeight;


### PR DESCRIPTION
(alt title: Fix incorrect calculated grid sizes in rooms with GMS2 tile layers)

## Description
Previously, the automatic grid size calculation (if there's no global grid size set) determined the tile size by dividing the room size by the size of the tile layer in tiles, instead of using the tile width/height properties present on the tileset.
This doesn't work properly if a GMS2 tile layer isn't the exact same size as the room, which can happen through UTMT editing or through an extra row/column getting added for non-tile-size-divisible room sizes; for instance see `tower_1` in Pizza Tower, which should have a grid size of 32x32 but is 31x31.
This PR fixes that.

### Caveats
Didn't test much.

### Notes
<!-- Any notes or closing words -->