### PR TITLE
Fix an obscure crash on right-clicking some blank spots in `DataGrid`.

### DIFF
--- a/UndertaleModTool/Controls/System/DataGridDark.cs
+++ b/UndertaleModTool/Controls/System/DataGridDark.cs
@@ -17,7 +17,15 @@ namespace UndertaleModTool
             Loaded += DataGrid_Loaded;
             AddingNewItem += DataGrid_AddingNewItem;
         }
-        
+
+        protected override void OnSelectionChanged(SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count > 0 && e.AddedItems[0] != DependencyProperty.UnsetValue)
+                base.OnSelectionChanged(e);
+            else
+                System.Diagnostics.Debug.WriteLine("DataGridDark.OnSelectionChanged() - e.AddedItems[0] is \"UnsetValue\", skipping event handling.");
+        }
+
         private void DataGrid_AddingNewItem(object sender, AddingNewItemEventArgs e)
         {
             _ = Task.Run(() =>


### PR DESCRIPTION
## Description
https://github.com/user-attachments/assets/aa300845-2256-4b29-b086-8e2deea0d242