### PR TITLE
Basic emergency save

### DIFF
--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -63,8 +63,21 @@ namespace UndertaleModTool
 
         private Tab _currentTab;
 
-        public UndertaleData Data { get; set; }
-        public string FilePath { get; set; }
+
+        private UndertaleData _data;
+        private string _filePath;
+
+        public UndertaleData Data { get => _data; set {
+                _data = value;
+                LastData = value;
+            } }
+        public string FilePath { get => _filePath; set {
+                _filePath = value;
+                LastFilePath = value;
+            } }
+        public static UndertaleData LastData { get; set; }
+        public static string LastFilePath { get; set; }
+
         public string ScriptPath { get; set; } // For the scripting interface specifically
 
         public string TitleMain { get; set; }

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -65,14 +65,24 @@ namespace UndertaleModTool
 
         private UndertaleData _data;
         private string _filePath;
-        public UndertaleData Data { get => _data; set {
+        public UndertaleData Data
+        {
+            get => _data;
+            set
+            {
                 _data = value;
                 LastData = value;
-            } }
-        public string FilePath { get => _filePath; set {
+            }
+        }
+        public string FilePath
+        {
+            get => _filePath;
+            set
+            {
                 _filePath = value;
                 LastFilePath = value;
-            } }
+            }
+        }
         public static UndertaleData LastData { get; set; }
         public static string LastFilePath { get; set; }
 

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -63,10 +63,8 @@ namespace UndertaleModTool
 
         private Tab _currentTab;
 
-
         private UndertaleData _data;
         private string _filePath;
-
         public UndertaleData Data { get => _data; set {
                 _data = value;
                 LastData = value;

--- a/UndertaleModTool/Program.cs
+++ b/UndertaleModTool/Program.cs
@@ -63,7 +63,7 @@ namespace UndertaleModTool
             File.WriteAllText(Path.Combine(GetExecutableDirectory(), "crash3.txt"), (ex.Message + "\n" + ex.StackTrace));
         }
 
-        private static async Task EmergencySaveFile()
+        private static void EmergencySaveFile()
         {
             var data = MainWindow.LastData;
             if (data is null || data.UnsupportedBytecodeVersion) return;
@@ -73,14 +73,12 @@ namespace UndertaleModTool
             dlg.Filter = "GameMaker data files (.win, .unx, .ios, .droid, audiogroup*.dat)|*.win;*.unx;*.ios;*.droid;audiogroup*.dat|All files|*";
             dlg.FileName = MainWindow.LastFilePath;
             dlg.Title = "Emergency-save the current file (separate file recommended):";
-
             if (dlg.ShowDialog() != true) return;
 
-            var filename = dlg.FileName;
-
             bool SaveSucceeded = false;
-            try {
-                using (var stream = new FileStream(filename + "temp", FileMode.Create, FileAccess.Write))
+            try
+            {
+                using (var stream = new FileStream(dlg.FileName + "temp", FileMode.Create, FileAccess.Write))
                 {
                     UndertaleIO.Write(stream, data, message => {});
                     SaveSucceeded = true;
@@ -98,7 +96,7 @@ namespace UndertaleModTool
                     // It saved successfully!
                     // If we're overwriting a previously existing data file, we're going to overwrite it now.
                     // Then, we're renaming it back to the proper (non-temp) file name.
-                    File.Move(filename + "temp", filename, true);
+                    File.Move(dlg.FileName + "temp", dlg.FileName, true);
                     MessageBox.Show("Emergency save successful.");
                 }
                 else

--- a/UndertaleModTool/Program.cs
+++ b/UndertaleModTool/Program.cs
@@ -73,7 +73,7 @@ namespace UndertaleModTool
             dlg.DefaultExt = "win";
             dlg.Filter = "GameMaker data files (.win, .unx, .ios, .droid, audiogroup*.dat)|*.win;*.unx;*.ios;*.droid;audiogroup*.dat|All files|*";
             dlg.FileName = MainWindow.LastFilePath;
-            dlg.Title = "Emergency-save the current file:";
+            dlg.Title = "Emergency-save the current file (separate file recommended):";
 
             if (dlg.ShowDialog() != true) return;
 

--- a/UndertaleModTool/Program.cs
+++ b/UndertaleModTool/Program.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.CodeAnalysis;
-using NAudio.MediaFoundation;
 using Microsoft.Win32;
 using UndertaleModLib;
 

--- a/UndertaleModTool/Program.cs
+++ b/UndertaleModTool/Program.cs
@@ -12,6 +12,9 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.CodeAnalysis;
+using NAudio.MediaFoundation;
+using Microsoft.Win32;
+using UndertaleModLib;
 
 namespace UndertaleModTool
 {
@@ -40,6 +43,7 @@ namespace UndertaleModTool
             {
                 File.WriteAllText(Path.Combine(GetExecutableDirectory(), "crash.txt"), e.ToString());
                 MessageBox.Show(e.ToString());
+                EmergencySaveFile();
             }
         }
         private static void GlobalUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
@@ -58,6 +62,55 @@ namespace UndertaleModTool
             ILog log = LogManager.GetLogger(typeof(Program)); //Log4NET
             log.Error(ex.Message + "\n" + ex.StackTrace);
             File.WriteAllText(Path.Combine(GetExecutableDirectory(), "crash3.txt"), (ex.Message + "\n" + ex.StackTrace));
+        }
+
+        private static async Task EmergencySaveFile()
+        {
+            var data = MainWindow.LastData;
+            if (data is null || data.UnsupportedBytecodeVersion) return;
+
+            SaveFileDialog dlg = new SaveFileDialog();
+            dlg.DefaultExt = "win";
+            dlg.Filter = "GameMaker data files (.win, .unx, .ios, .droid, audiogroup*.dat)|*.win;*.unx;*.ios;*.droid;audiogroup*.dat|All files|*";
+            dlg.FileName = MainWindow.LastFilePath;
+            dlg.Title = "Emergency-save the current file:";
+
+            if (dlg.ShowDialog() != true) return;
+
+            var filename = dlg.FileName;
+
+            bool SaveSucceeded = false;
+            try {
+                using (var stream = new FileStream(filename + "temp", FileMode.Create, FileAccess.Write))
+                {
+                    UndertaleIO.Write(stream, data, message => {});
+                    SaveSucceeded = true;
+                }
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show("An error occurred while trying to save:\n" + e.Message, "Save error");
+            }
+            // Don't make any changes unless the save succeeds.
+            try
+            {
+                if (SaveSucceeded)
+                {
+                    // It saved successfully!
+                    // If we're overwriting a previously existing data file, we're going to overwrite it now.
+                    // Then, we're renaming it back to the proper (non-temp) file name.
+                    File.Move(filename + "temp", filename, true);
+                    MessageBox.Show("Emergency save successful.");
+                }
+                else
+                {
+                    // Leave the temporary file for possible recovery; so do nothing
+                }
+            }
+            catch (Exception exc)
+            {
+                MessageBox.Show("An error occurred while trying to save:\n" + exc.Message, "Save error");
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
When the whole tool crashes for any reason, there is now a save file dialog to save the currently opened file. It's basic (and copy-pastes a lot from MainWindow) but it's probably better than losing your work.

### Caveats
It doesn't have a progress dialog (just a single MessageBox on completion) and doesn't save profile mode data.

### Notes
<!-- Any notes or closing words -->