### PR TITLE
"GameSpecificData" folder related improvements.

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -43,7 +43,6 @@ jobs:
         cp ./README.md ./CLI-${{ matrix.os }}/
         cp ./SCRIPTS.md ./CLI-${{ matrix.os }}/
         cp ./LICENSE.txt ./CLI-${{ matrix.os }}/
-        cp -r ./UndertaleModLib/GameSpecificData/ ./CLI-${{ matrix.os }}/GameSpecificData/
         cp -r ./UndertaleModTool/Scripts/ ./CLI-${{ matrix.os }}/Scripts/
     - name: Upload ${{ matrix.os }} CLI
       uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_gui.yml
+++ b/.github/workflows/publish_gui.yml
@@ -41,7 +41,6 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
-        cp -r ./UndertaleModLib/GameSpecificData/ ./${{ matrix.os }}/GameSpecificData/
     - name: Upload ${{ matrix.os }} GUI
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publish_gui_nightly.yml
+++ b/.github/workflows/publish_gui_nightly.yml
@@ -45,7 +45,6 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
-        cp -r ./UndertaleModLib/GameSpecificData/ ./${{ matrix.os }}/GameSpecificData/
     - name: Create zip for nightly release Windows GUI
       run: |
         7z a -tzip GUI-${{ matrix.os }}-${{ matrix.configuration }}-isBundled-${{ matrix.bundled }}-isSingleFile-${{ matrix.singlefile }}.zip ./${{ matrix.os }}/* -mx0 
@@ -92,7 +91,6 @@ jobs:
         cp ./README.md ./CLI-${{ matrix.os }}/
         cp ./SCRIPTS.md ./CLI-${{ matrix.os }}/
         cp ./LICENSE.txt ./CLI-${{ matrix.os }}/
-        cp -r ./UndertaleModLib/GameSpecificData/ ./CLI-${{ matrix.os }}/GameSpecificData/
         cp -r ./UndertaleModTool/Scripts/ ./CLI-${{ matrix.os }}/Scripts/
     - name: Create zip for nightly release CLI
       run: |

--- a/.github/workflows/publish_gui_release.yml
+++ b/.github/workflows/publish_gui_release.yml
@@ -41,7 +41,6 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
-        cp -r ./UndertaleModLib/GameSpecificData/ ./${{ matrix.os }}/GameSpecificData/
     - name: Create zip for stable release Windows GUI
       run: |
         7z a -tzip GUI-${{ matrix.os }}-${{ matrix.configuration }}-isBundled-${{ matrix.bundled }}-isSingleFile-${{ matrix.singlefile }}.zip ./${{ matrix.os }}/* -mx0 
@@ -88,7 +87,6 @@ jobs:
         cp ./README.md ./CLI-${{ matrix.os }}/
         cp ./SCRIPTS.md ./CLI-${{ matrix.os }}/
         cp ./LICENSE.txt ./CLI-${{ matrix.os }}/
-        cp -r ./UndertaleModLib/GameSpecificData/ ./CLI-${{ matrix.os }}/GameSpecificData/
         cp -r ./UndertaleModTool/Scripts/ ./CLI-${{ matrix.os }}/Scripts/
     - name: Create zip for stable release CLI
       run: |

--- a/.github/workflows/publish_pr.yml
+++ b/.github/workflows/publish_pr.yml
@@ -43,7 +43,6 @@ jobs:
         cp ./README.md ./${{ matrix.os }}
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./${{ matrix.os }}
-        cp -r ./UndertaleModLib/GameSpecificData/ ./${{ matrix.os }}/GameSpecificData/
     - name: Upload ${{ matrix.os }} GUI
       uses: actions/upload-artifact@v4
       with:
@@ -87,7 +86,6 @@ jobs:
         cp ./README.md ./CLI-${{ matrix.os }}/
         cp ./SCRIPTS.md ./${{ matrix.os }}
         cp ./LICENSE.txt ./CLI-${{ matrix.os }}/
-        cp -r ./UndertaleModLib/GameSpecificData/ ./CLI-${{ matrix.os }}/GameSpecificData/
         cp -r ./UndertaleModTool/Scripts/ ./CLI-${{ matrix.os }}/Scripts/
     - name: Upload ${{ matrix.os }} CLI
       uses: actions/upload-artifact@v4

--- a/UndertaleModLib/GameSpecificData/README.txt
+++ b/UndertaleModLib/GameSpecificData/README.txt
@@ -3,3 +3,16 @@
 Games are defined in the "Definitions" sub-folder, where they are given conditions to match the game(s) they target. Any JSON files from this folder are loaded automatically, if available.
 
 GML decompiler configs are contained within the "Underanalyzer" sub-folder, referenced from the original definition files. (These are loaded on-demand.)
+
+If you want to load this data from other path (or you just don't need to work with GML code), then you can prevent automatic folder copying.
+For that, you can do one of the following:
+1) Edit the `CopyGameSpecificDataToOutDir` project property (change to "false").
+2) Override its value through "Directory.Build.props" file outside of the project (e.g. when you use "UndertaleModLib" as a git submodule).
+Create the file (if doesn't exists) in the solution root folder, and write the following:
+<Project>
+  <PropertyGroup>
+    <CopyGameSpecificDataToOutDir>false</CopyGameSpecificDataToOutDir>
+  </PropertyGroup>
+</Project>
+
+In order to change the "GameSpecificData" folder location, you should change the `GameSpecificResolver.BaseDirectory` property.

--- a/UndertaleModLib/GameSpecificData/README.txt
+++ b/UndertaleModLib/GameSpecificData/README.txt
@@ -4,7 +4,7 @@ Games are defined in the "Definitions" sub-folder, where they are given conditio
 
 GML decompiler configs are contained within the "Underanalyzer" sub-folder, referenced from the original definition files. (These are loaded on-demand.)
 
-If you want to load this data from other path (or you just don't need to work with GML code), then you can prevent automatic folder copying.
+If you want to load this data from another path (or you just don't need to work with GML code), then you can prevent automatic folder copying.
 For that, you can do one of the following:
 1) Edit the `CopyGameSpecificDataToOutDir` project property (change to "false").
 2) Override its value through "Directory.Build.props" file outside of the project (e.g. when you use "UndertaleModLib" as a git submodule).

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -24,7 +24,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Allows to disable "GameSpecificData" folder copying to the output directory using "Directory.Build.props" outside of the project
+    <!-- Allows disabling "GameSpecificData" folder copying to the output directory using "Directory.Build.props" outside of the project
          (e.g. when using this project as a git submodule) -->
     <CopyGameSpecificDataToOutDir Condition="$(CopyGameSpecificDataToOutDir) == ''">true</CopyGameSpecificDataToOutDir>
   </PropertyGroup>

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -23,6 +23,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Allows to disable "GameSpecificData" folder copying to the output directory using "Directory.Build.props" outside of the project
+         (e.g. when using this project as a git submodule) -->
+    <CopyGameSpecificDataToOutDir Condition="$(CopyGameSpecificDataToOutDir) == ''">true</CopyGameSpecificDataToOutDir>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.9.2">
       <PrivateAssets>all</PrivateAssets>
@@ -34,42 +39,13 @@
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="GameSpecificData\Definitions\deltarune.json" />
-    <None Remove="GameSpecificData\Definitions\gamemaker.json" />
-    <None Remove="GameSpecificData\Definitions\undertale.json" />
-    <None Remove="GameSpecificData\deltarune.json" />
-    <None Remove="GameSpecificData\empty.json" />
-    <None Remove="GameSpecificData\gamemaker.json" />
-    <None Remove="GameSpecificData\README.txt" />
-    <None Remove="GameSpecificData\undertale.json" />
+    <None Remove="GameSpecificData\**" />
     <None Remove="version.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="gitversion.txt" />
-    <Content Include="GameSpecificData\README.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Underanalyzer\deltarune.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Underanalyzer\template.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Underanalyzer\gamemaker.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Underanalyzer\undertale.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Definitions\deltarune.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Definitions\gamemaker.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="GameSpecificData\Definitions\undertale.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    <Content Include="GameSpecificData\**" Condition="$(CopyGameSpecificDataToOutDir)"
+             CopyToOutputDirectory="PreserveNewest" />
     <EmbeddedResource Include="gitversion.txt" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
1) Added a way to exclude the "GameSpecificData" folder from the output folder when you use "UndertaleModLib" as a library.
For example, when you want to load the data from other folder, so you don't need it being in the program folder.
See ["README.txt"](https://github.com/VladiStep/UndertaleModTool/blob/3b8a8e716f6f89667a90b5d8a31c83ac63f60d6c/UndertaleModLib/GameSpecificData/README.txt).
2) Simplify "GameSpecificData" folder copying code.
3) Remove redundant copy command for "GameSpecificData" (fixes #2185).