### PR TITLE
Add current_sprite_index variable to GameSpecificData

### DIFF
--- a/UndertaleModLib/GameSpecificData/Underanalyzer/deltarune.json
+++ b/UndertaleModLib/GameSpecificData/Underanalyzer/deltarune.json
@@ -761,6 +761,10 @@
                 {
                   "MacroType": "Match",
                   "ConditionalValue": "head_sprite"
+                },
+                {
+                  "MacroType": "Match",
+                  "ConditionalValue": "current_sprite_index"
                 }
               ]
             },

--- a/UndertaleModLib/GameSpecificData/Underanalyzer/deltarune.json
+++ b/UndertaleModLib/GameSpecificData/Underanalyzer/deltarune.json
@@ -543,7 +543,8 @@
       "tile_sprite": "Asset.Sprite",
       "commenttriangle": "Asset.Sprite",
       "target_room": "Asset.Room",
-      "base_sprite": "Asset.Sprite"
+      "base_sprite": "Asset.Sprite",
+      "current_sprite_index": "Asset.Sprite"
     },
     "FunctionArguments": {
       "snd_play": {


### PR DESCRIPTION
## Description
Minor patch, adds a sprite variable to GameSpecificData that's used about a hundred times in Chapter 4 for two NPCs.

### Caveats
N/A

### Notes
N/A