### PR TITLE
Use MaxBy instead of OrderBy when resolving Room Layer Instance IDs for performance

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -392,10 +392,11 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
                         && layer.InstancesData.InstanceIds[0] > GameObjects[^1].InstanceID)
                     {
                         // Make sure it's not a false positive
-                        uint firstLayerInstID = layer.InstancesData.InstanceIds.MinBy(x => x);
-                        uint lastInstID = GameObjects.OrderBy(x => x.InstanceID).Last().InstanceID;
+                        uint firstLayerInstID = layer.InstancesData.InstanceIds.Min();
+                        uint lastInstID = GameObjects.MaxBy(x => x.InstanceID).InstanceID;
                         if (firstLayerInstID > lastInstID)
                         {
+                            // Should this throw a warning instead?
                             Debug.WriteLine($"The first instance ID ({firstLayerInstID}) " +
                                             $"of layer (ID {layer.LayerId}) is greater than the last game object ID ({lastInstID}) ?");
                             continue;


### PR DESCRIPTION
## Description
Small Performance and code readability change in `UndertaleModLib/Models/UndertaleRoom.cs:395`.

### Caveats
Should not have any caveats.

### Notes
my first pr
