### PR TITLE
Fix CLI's `PromptLoadFile` function

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -396,7 +396,7 @@ public partial class Program : IScriptInterface
             }
             fileInfo = new FileInfo(path);
         }
-        while (fileInfo.Exists);
+        while (!fileInfo.Exists);
 
         return path;
     }


### PR DESCRIPTION
## Description
In UTMT's CLI interface, in `Program.UMTLibInherited.cs`, `PromptLoadFile` is written incorrectly, because it keeps asking for a file if that file exists, and proceeds when the file does not exist. This is because the source code said `while (fileInfo.Exists);` instead of `while (!fileInfo.Exists);`. This made the `PromptLoadFile`function not work.

### Caveats
No caveats. The CLI can now correctly prompt for files.

### Notes
None right now