### PR TITLE
Add scale transform to tiles in room

### DIFF
--- a/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
+++ b/UndertaleModTool/Controls/UndertaleRoomRenderer.xaml
@@ -235,7 +235,11 @@
                     <Rectangle Width="{Binding Width, Mode=OneTime}" Height="{Binding Height, Mode=OneTime}"
                                Opacity="{Binding Color, Mode=OneTime, Converter={StaticResource ColorToOpacityConverter}}">
                         <Rectangle.RenderTransform>
-                            <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneTime}" Y="{Binding Y, Mode=OneTime}"/>
+                            <TransformGroup>
+                                <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneWay}" Y="{Binding Y, Mode=OneWay}"/>
+                                <ScaleTransform ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"
+                                                CenterX="{Binding X, Mode=OneWay}" CenterY="{Binding Y, Mode=OneWay}"/>
+                            </TransformGroup>
                         </Rectangle.RenderTransform>
                         <Rectangle.Fill>
                             <ImageBrush

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml
@@ -1395,7 +1395,11 @@
                                    MouseDown="Rectangle_MouseDown" MouseMove="Rectangle_MouseMove" MouseUp="Rectangle_MouseUp"
                                    Opacity="{Binding Color, Mode=OneWay, Converter={StaticResource ColorToOpacityConverter}}">
                             <Rectangle.RenderTransform>
-                                <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneWay}" Y="{Binding Y, Mode=OneWay}"/>
+                                <TransformGroup>
+                                    <TranslateTransform x:Name="transform2_0" X="{Binding X, Mode=OneWay}" Y="{Binding Y, Mode=OneWay}"/>
+                                    <ScaleTransform ScaleX="{Binding ScaleX, Mode=OneWay}" ScaleY="{Binding ScaleY, Mode=OneWay}"
+                                                    CenterX="{Binding X, Mode=OneWay}" CenterY="{Binding Y, Mode=OneWay}"/>
+                                </TransformGroup>
                             </Rectangle.RenderTransform>
                             <Rectangle.Style>
                                 <Style BasedOn="{StaticResource NearestNeighbor}"/>


### PR DESCRIPTION
## Description
Legacy tiles didn't have a scale transform at all, so I added one. This should fix tile rotation problems in Undertale Yellow.

### Caveats
None

### Notes
None