### PR TITLE
Strip metadata before writing auto-generated images

### DIFF
--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -1,4 +1,4 @@
-﻿using ImageMagick;
+﻿﻿using ImageMagick;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -96,6 +96,8 @@ namespace UndertaleModLib.Util
                 returnImage.Composite(croppedImage, texPageItem.TargetX, texPageItem.TargetY, CompositeOperator.Copy);
                 croppedImage.Dispose();
             }
+
+            returnImage.Strip();
 
             return returnImage;
         }
@@ -226,6 +228,8 @@ namespace UndertaleModLib.Util
                     pixels.SetPixel(x, y, pixelBit ? white : black);
                 }
             }
+
+            image.Strip();
 
             return image;
         }


### PR DESCRIPTION
## Description
This makes sure file hashes are consistent between exports of the same sprites, which makes diffing easier

### Caveats
Untested (IIRC DubstepDude implied "someone else’s version of UTMT" fixed this, IDK if it's mine or not)

### Notes
Forgot to send this to upstream