### PR TITLE
Fix room editor crashes with grid size of one

### DIFF
--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -342,8 +342,10 @@ namespace UndertaleModTool
 
             if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
             {
-                gridWidth /= 2;
-                gridHeight /= 2;
+                if (gridWidth > 1)
+                    gridWidth /= 2;
+                if (gridHeight > 1)
+                    gridHeight /= 2;
             }
             else if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
             {
@@ -838,8 +840,10 @@ namespace UndertaleModTool
                 }
 
                 // Snap to grid
-                tgtX = ((tgtX + gridWidth / 2) / gridWidth) * gridWidth;
-                tgtY = ((tgtY + gridHeight / 2) / gridHeight) * gridHeight;
+                if (gridWidth > 0)
+                    tgtX = ((tgtX + gridWidth / 2) / gridWidth) * gridWidth;
+                if (gridHeight > 0)
+                    tgtY = ((tgtY + gridHeight / 2) / gridHeight) * gridHeight;
 
                 if (movingObj is GameObject gameObj)
                 {


### PR DESCRIPTION
## Description
The room editor would crash if your grid size was set to 1 and you held control while dragging an object. Now it shouldn't do that.

### Caveats
None that I know

### Notes
I misnamed the commit and don't feel like amending it now that it's pushed