### PR TITLE
Add missing header chunk flag, correct save location flag name, Name unknown fields in options

### DIFF
--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -67,9 +67,9 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         SteamEnabled = 0x1000,
 
         /// <summary>
-        /// When enabled, the game will write save data to %appdata%\<Game Name>, otherwise it will write to %localappdata%\<Game Name>
+        /// When enabled, the game will write save data to %appdata%\GameName, otherwise it will write to %localappdata%\GameName
         /// </summary>
-        AppDataSaveLocation = 0x2000,
+        UseAppDataSaveLocation = 0x2000,
 
         /// <summary>
         /// Whether the game supports borderless window
@@ -82,7 +82,10 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
 
         LicenseExclusions = 0x10000,
 
-        EditorRunBuildType = 0x20000,
+        /// <summary>
+        /// This flag is set when a game is launched from the Gamemaker Studio 2 IDE using the 'Run' or 'Debug' options
+        /// </summary>
+        GameRunFromGMS2IDE = 0x20000,
     }
 
     /// <summary>
@@ -170,9 +173,9 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     public byte BytecodeVersion { get; set; } = 0x10;
 
     /// <summary>
-    /// TODO: currently unknown value.
+    /// Likely padding, IsDebuggerDisabled and BytecodeVersion are written together as a 32-bit integer
     /// </summary>
-    public ushort Unknown { get; set; } = 0;
+    public ushort Padding { get; set; } = 0;
 
     /// <summary>
     /// The file name of the runner.
@@ -357,7 +360,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     {
         writer.Write(IsDebuggerDisabled ? (byte)1 : (byte)0);
         writer.Write(BytecodeVersion);
-        writer.Write(Unknown);
+        writer.Write(Padding);
         writer.WriteUndertaleString(FileName);
         writer.WriteUndertaleString(Config);
         writer.Write(LastObj);
@@ -460,7 +463,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
 
         IsDebuggerDisabled = reader.ReadByte() != 0;
         BytecodeVersion = reader.ReadByte();
-        Unknown = reader.ReadUInt16();
+        Padding = reader.ReadUInt16();
         FileName = readFileNameDelegate();
         Config = reader.ReadUndertaleString();
         LastObj = reader.ReadUInt32();
@@ -710,14 +713,14 @@ public class UndertaleOptions : UndertaleObject, IDisposable
     }
 
     /// <summary>
-    /// TODO: unknown value, needs research. Tends to be 2^31?
+    /// Shader extension flag. Always set to int.MinValue
     /// </summary>
-    public uint Unknown1 { get; set; } = 0x80000000;
+    public int ShaderExtensionFlag { get; set; } = int.MinValue;
 
     /// <summary>
-    /// TODO: another unknown value, also needs research.
+    /// Shader extension version. Always set to 2
     /// </summary>
-    public uint Unknown2 { get; set; } = 0x00000002;
+    public int ShaderExtensionVersion { get; set; } = 2;
 
     /// <summary>
     /// Option flags the data file uses.
@@ -833,8 +836,8 @@ public class UndertaleOptions : UndertaleObject, IDisposable
     {
         if (NewFormat)
         {
-            writer.Write(Unknown1);
-            writer.Write(Unknown2);
+            writer.Write(ShaderExtensionFlag);
+            writer.Write(ShaderExtensionVersion);
             writer.Write((ulong)Info);
             writer.Write(Scale);
             writer.Write(WindowColor);
@@ -897,8 +900,8 @@ public class UndertaleOptions : UndertaleObject, IDisposable
         reader.Position -= 4;
         if (NewFormat)
         {
-            Unknown1 = reader.ReadUInt32();
-            Unknown2 = reader.ReadUInt32();
+            ShaderExtensionFlag = reader.ReadInt32();
+            ShaderExtensionVersion = reader.ReadInt32();
             Info = (OptionsFlags)reader.ReadUInt64();
             Scale = reader.ReadInt32();
             WindowColor = reader.ReadUInt32();

--- a/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleGeneralInfoEditor.xaml
@@ -51,7 +51,6 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Margin="3" Foreground="DarkRed">Disable GMS debugger</TextBlock>
@@ -61,32 +60,29 @@
                 <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Bytecode version</TextBlock>
                 <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.BytecodeVersion}"/>
 
-                <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Unknown</TextBlock>
-                <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.Unknown}"/>
+                <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">FileName</TextBlock>
+                <local:UndertaleStringReference Grid.Row="2" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.FileName}"/>
 
-                <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">FileName</TextBlock>
-                <local:UndertaleStringReference Grid.Row="3" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.FileName}"/>
+                <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Config</TextBlock>
+                <local:UndertaleStringReference Grid.Row="3" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.Config}"/>
 
-                <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Config</TextBlock>
-                <local:UndertaleStringReference Grid.Row="4" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.Config}"/>
+                <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Last object ID</TextBlock>
+                <local:TextBoxDark Grid.Row="4" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LastObj}"/>
 
-                <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Last object ID</TextBlock>
-                <local:TextBoxDark Grid.Row="5" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LastObj}"/>
+                <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Last tile ID</TextBlock>
+                <local:TextBoxDark Grid.Row="5" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LastTile}"/>
 
-                <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Last tile ID</TextBlock>
-                <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LastTile}"/>
+                <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Game ID</TextBlock>
+                <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.GameID}"/>
 
-                <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Game ID</TextBlock>
-                <local:TextBoxDark Grid.Row="7" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.GameID}"/>
+                <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">DirectPlay GUID</TextBlock>
+                <local:TextBoxDark Grid.Row="7" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.DirectPlayGuid}"/>
 
-                <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">DirectPlay GUID</TextBlock>
-                <local:TextBoxDark Grid.Row="8" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.DirectPlayGuid}"/>
+                <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Name</TextBlock>
+                <local:UndertaleStringReference Grid.Row="8" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.Name}"/>
 
-                <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Name</TextBlock>
-                <local:UndertaleStringReference Grid.Row="9" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.Name}"/>
-
-                <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Version</TextBlock>
-                <Grid Grid.Row="10" Grid.Column="1">
+                <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Version</TextBlock>
+                <Grid Grid.Row="9" Grid.Column="1">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -105,8 +101,8 @@
                     <local:TextBoxDark Grid.Column="6" Margin="3" Text="{Binding GeneralInfo.Build}"/>
                 </Grid>
 
-                <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Default window size</TextBlock>
-                <Grid Grid.Row="11" Grid.Column="1">
+                <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Default window size</TextBlock>
+                <Grid Grid.Row="10" Grid.Column="1">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -117,17 +113,17 @@
                     <local:TextBoxDark Grid.Column="2" Margin="3" Text="{Binding GeneralInfo.DefaultWindowHeight}"/>
                 </Grid>
 
-                <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Flags</TextBlock>
-                <local:FlagsBox Grid.Row="12" Grid.Column="1" Margin="3" Value="{Binding GeneralInfo.Info}" />
+                <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Flags</TextBlock>
+                <local:FlagsBox Grid.Row="11" Grid.Column="1" Margin="3" Value="{Binding GeneralInfo.Info}" />
 
-                <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">License MD5</TextBlock>
-                <local:TextBoxDark Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LicenseMD5, Mode=TwoWay, Converter={StaticResource byteArrayConverter}}"/>
+                <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">License MD5</TextBlock>
+                <local:TextBoxDark Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LicenseMD5, Mode=TwoWay, Converter={StaticResource byteArrayConverter}}"/>
 
-                <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">License CRC32</TextBlock>
-                <local:TextBoxDark Grid.Row="14" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LicenseCRC32, StringFormat={}{0:X8}}"/>
+                <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">License CRC32</TextBlock>
+                <local:TextBoxDark Grid.Row="13" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.LicenseCRC32, StringFormat={}{0:X8}}"/>
 
-                <TextBlock Grid.Row="15" Grid.Column="0" Margin="3">Timestamp</TextBlock>
-                <local:TextBoxDark Grid.Row="15" Grid.Column="1" Margin="3" IsReadOnly="True"
+                <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Timestamp</TextBlock>
+                <local:TextBoxDark Grid.Row="14" Grid.Column="1" Margin="3" IsReadOnly="True"
                          Text="{Binding GeneralInfo.Timestamp, Mode=OneWay, Converter={StaticResource TimestampDateTimeConverter}}"
                          ToolTip="{Binding GeneralInfo.Timestamp, Mode=OneWay, Converter={StaticResource TimestampDateTimeConverter}, ConverterParameter=GMT}"
                          ToolTipService.InitialShowDelay="250">
@@ -141,23 +137,23 @@
                     </TextBox.Background>
                 </local:TextBoxDark>
 
-                <TextBlock Grid.Row="16" Grid.Column="0" Margin="3">Display name</TextBlock>
-                <local:UndertaleStringReference Grid.Row="16" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.DisplayName}"/>
+                <TextBlock Grid.Row="15" Grid.Column="0" Margin="3">Display name</TextBlock>
+                <local:UndertaleStringReference Grid.Row="15" Grid.Column="1" Margin="3" ObjectReference="{Binding GeneralInfo.DisplayName}"/>
 
-                <TextBlock Grid.Row="17" Grid.Column="0" Margin="3">Active targets</TextBlock>
-                <local:TextBoxDark Grid.Row="17" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.ActiveTargets}"/>
+                <TextBlock Grid.Row="16" Grid.Column="0" Margin="3">Active targets</TextBlock>
+                <local:TextBoxDark Grid.Row="16" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.ActiveTargets}"/>
 
-                <TextBlock Grid.Row="18" Grid.Column="0" Margin="3">Function classifications</TextBlock>
-                <local:FlagsBox Grid.Row="18" Grid.Column="1" Margin="3" Value="{Binding GeneralInfo.FunctionClassifications}"/>
+                <TextBlock Grid.Row="17" Grid.Column="0" Margin="3">Function classifications</TextBlock>
+                <local:FlagsBox Grid.Row="17" Grid.Column="1" Margin="3" Value="{Binding GeneralInfo.FunctionClassifications}"/>
 
-                <TextBlock Grid.Row="19" Grid.Column="0" Margin="3">Steam AppID</TextBlock>
-                <local:TextBoxDark Grid.Row="19" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.SteamAppID}"/>
+                <TextBlock Grid.Row="18" Grid.Column="0" Margin="3">Steam AppID</TextBlock>
+                <local:TextBoxDark Grid.Row="18" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.SteamAppID}"/>
 
-                <TextBlock Grid.Row="20" Grid.Column="0" Margin="3">Debugger port</TextBlock>
-                <local:TextBoxDark Grid.Row="20" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.DebuggerPort}"/>
+                <TextBlock Grid.Row="19" Grid.Column="0" Margin="3">Debugger port</TextBlock>
+                <local:TextBoxDark Grid.Row="19" Grid.Column="1" Margin="3" Text="{Binding GeneralInfo.DebuggerPort}"/>
 
-                <TextBlock Grid.Row="21" Grid.Column="0" Margin="3">Room order</TextBlock>
-                <Expander Grid.Row="21" Grid.Column="1" Margin="3" Header="List" Name="RoomListExpander">
+                <TextBlock Grid.Row="20" Grid.Column="0" Margin="3">Room order</TextBlock>
+                <Expander Grid.Row="20" Grid.Column="1" Margin="3" Header="List" Name="RoomListExpander">
                     <local:DataGridDark ItemsSource="{Binding GeneralInfo.RoomOrder}" MaxHeight="369" x:Name="RoomListGrid"
                                         AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="None" SelectionMode="Single" SelectionUnit="FullRow"
                                         ScrollViewer.CanContentScroll="True"
@@ -200,9 +196,9 @@
                     </local:DataGridDark>
                 </Expander>
 
-                <local:ButtonDark Grid.Row="22" Grid.Column="1" Margin="3" Content="Sync with room list" Click="SyncRoomList_Click"/>
+                <local:ButtonDark Grid.Row="21" Grid.Column="1" Margin="3" Content="Sync with room list" Click="SyncRoomList_Click"/>
 
-                <Grid Grid.Row="23" Grid.ColumnSpan="2" Margin="0" Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">
+                <Grid Grid.Row="22" Grid.ColumnSpan="2" Margin="0" Visibility="{Binding DataContext.IsGMS2, Mode=OneTime, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="1*"/>
                         <ColumnDefinition Width="3*"/>
@@ -249,56 +245,54 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Unknown</TextBlock>
-                <Grid Grid.Row="0" Grid.Column="1">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding Options.Unknown1}"/>
-                    <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding Options.Unknown2}"/>
-                </Grid>
+                <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Shader Extension Flag</TextBlock>
+                <local:TextBoxDark Grid.Row="1" Grid.Column="1" Margin="3" Text="{Binding Options.ShaderExtensionFlag}" />
 
-                <TextBlock Grid.Row="1" Grid.Column="0" Margin="3">Flags</TextBlock>
-                <local:FlagsBox Grid.Row="1" Grid.Column="1" Margin="3" Value="{Binding Options.Info}" />
+                <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Shader Extension Version</TextBlock>
+                <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Text="{Binding Options.ShaderExtensionVersion}" />
 
-                <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Scale</TextBlock>
-                <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Text="{Binding Options.Scale}"/>
+                <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Flags</TextBlock>
+                <local:FlagsBox Grid.Row="3" Grid.Column="1" Margin="3" Value="{Binding Options.Info}" />
 
-                <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Window color</TextBlock>
-                <local:ColorPicker Grid.Row="3" Grid.Column="1" Margin="3" Color="{Binding Options.WindowColor}"/>
+                <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Scale</TextBlock>
+                <local:TextBoxDark Grid.Row="4" Grid.Column="1" Margin="3" Text="{Binding Options.Scale}"/>
 
-                <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Color depth</TextBlock>
-                <local:TextBoxDark Grid.Row="4" Grid.Column="1" Margin="3" Text="{Binding Options.ColorDepth}"/>
+                <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Window color</TextBlock>
+                <local:ColorPicker Grid.Row="5" Grid.Column="1" Margin="3" Color="{Binding Options.WindowColor}"/>
 
-                <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Resolution</TextBlock>
-                <local:TextBoxDark Grid.Row="5" Grid.Column="1" Margin="3" Text="{Binding Options.Resolution}"/>
+                <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Color depth</TextBlock>
+                <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding Options.ColorDepth}"/>
 
-                <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Frequency</TextBlock>
-                <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding Options.Frequency}"/>
+                <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Resolution</TextBlock>
+                <local:TextBoxDark Grid.Row="7" Grid.Column="1" Margin="3" Text="{Binding Options.Resolution}"/>
 
-                <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Vertex sync</TextBlock>
-                <local:TextBoxDark Grid.Row="7" Grid.Column="1" Margin="3" Text="{Binding Options.VertexSync}"/>
+                <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Frequency</TextBlock>
+                <local:TextBoxDark Grid.Row="8" Grid.Column="1" Margin="3" Text="{Binding Options.Frequency}"/>
 
-                <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Priority</TextBlock>
-                <local:TextBoxDark Grid.Row="8" Grid.Column="1" Margin="3" Text="{Binding Options.Priority}"/>
+                <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Vertex sync</TextBlock>
+                <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" Text="{Binding Options.VertexSync}"/>
 
-                <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Back image</TextBlock>
-                <local:UndertaleObjectReference Grid.Row="9" Grid.Column="1" Margin="3" ObjectReference="{Binding Options.BackImage.Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleTexturePageItem}"/>
+                <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Priority</TextBlock>
+                <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding Options.Priority}"/>
 
-                <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Front image</TextBlock>
-                <local:UndertaleObjectReference Grid.Row="10" Grid.Column="1" Margin="3" ObjectReference="{Binding Options.FrontImage.Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleTexturePageItem}"/>
+                <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Back image</TextBlock>
+                <local:UndertaleObjectReference Grid.Row="11" Grid.Column="1" Margin="3" ObjectReference="{Binding Options.BackImage.Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleTexturePageItem}"/>
 
-                <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Load image</TextBlock>
-                <local:UndertaleObjectReference Grid.Row="11" Grid.Column="1" Margin="3" ObjectReference="{Binding Options.LoadImage.Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleTexturePageItem}"/>
+                <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Front image</TextBlock>
+                <local:UndertaleObjectReference Grid.Row="12" Grid.Column="1" Margin="3" ObjectReference="{Binding Options.FrontImage.Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleTexturePageItem}"/>
 
-                <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Load alpha</TextBlock>
-                <local:TextBoxDark Grid.Row="12" Grid.Column="1" Margin="3" Text="{Binding Options.LoadAlpha}"/>
+                <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Load image</TextBlock>
+                <local:UndertaleObjectReference Grid.Row="13" Grid.Column="1" Margin="3" ObjectReference="{Binding Options.LoadImage.Texture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ObjectType="{x:Type undertaleModels:UndertaleTexturePageItem}"/>
 
-                <TextBlock Grid.Row="13" Grid.Column="0" Margin="3">Constants</TextBlock>
-                <local:DataGridDark Grid.Row="13" Grid.Column="1" Margin="3" ItemsSource="{Binding Options.Constants}" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow">
+                <TextBlock Grid.Row="14" Grid.Column="0" Margin="3">Load alpha</TextBlock>
+                <local:TextBoxDark Grid.Row="14" Grid.Column="1" Margin="3" Text="{Binding Options.LoadAlpha}"/>
+
+                <TextBlock Grid.Row="15" Grid.Column="0" Margin="3">Constants</TextBlock>
+                <local:DataGridDark Grid.Row="15" Grid.Column="1" Margin="3" ItemsSource="{Binding Options.Constants}" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow">
                     <DataGrid.Resources>
                         <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
                         <Style TargetType="{x:Type DataGridCell}">

--- a/UndertaleModTool/Scripts/Technical Scripts/13_To_14.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/13_To_14.csx
@@ -61,8 +61,8 @@ if (!(Data.FORM.Chunks.ContainsKey("AGRP")))
     roomOrder.Clear();
     foreach(var room in rooms)
         roomOrder.Add(new UndertaleResourceById<UndertaleRoom, UndertaleChunkROOM>() { Resource = room });
-    Data.Options.Unknown1 = 2147483648;
-    Data.Options.Unknown2 = 2;
+    Data.Options.ShaderExtensionFlag = 2147483648;
+    Data.Options.ShaderExtensionVersion = 2;
     String[] order = {"GEN8", "OPTN", "EXTN", "SOND", "AGRP", "SPRT", "BGND", "PATH", "SCPT", "SHDR", "FONT", "TMLN", "OBJT", "ROOM", "DAFL", "TPAG", "CODE", "VARI", "FUNC", "STRG", "TXTR", "AUDO"};
     Dictionary<string, UndertaleChunk> newChunks = new Dictionary<string, UndertaleChunk>();
     foreach (String name in order)


### PR DESCRIPTION
## Description
The header chunk flag `LocalDataEnabled` is a misnomer, enabling it tells the engine to use the `%appdata%` directory to write save data instead of `%localappdata%`. I've proposed changing the name to `UseAppDataSaveLocation` instead with a comment to clarify its behaviour.

I've named two unknown fields in the options chunk, `ShaderExtensionFlag` and `ShaderExtensionVersion`, and added them to the GUI. I've also removed an unknown field from the GUI which is only used for padding.

I've also discovered a flag on the LTS branch of GMS2 which we don't have, which is set when launching the game via the IDE's 'run' or 'debug' buttons. Additionally the SteamEnabled flag also seems to be enabled under something called the YoYoPlayer. I'm not entirely sure what this is, but I've added it to the flag's description.

### Caveats
Any scripts referencing the old flag name `LocalDataEnabled` will need to be updated to use `UseAppDataSaveLocation` instead.