### PR TITLE
Add remaining GM 2024.14 format changes

### DIFF
--- a/UndertaleModLib/Models/UndertaleBackground.cs
+++ b/UndertaleModLib/Models/UndertaleBackground.cs
@@ -107,9 +107,10 @@ public class UndertaleBackground : UndertaleNamedResource, IDisposable
     public uint GMS2TileCount { get; set; } = 1024;
 
     /// <summary>
-    /// TODO: Functionality currently unknown. Game Maker Studio 2 only.
+    /// Exported sprite index, if the background's corresponding sprite was marked to still be exported.
+    /// Will be either 0 or -1 (depending on GM version) when the sprite is not exported, which makes this a bit ambiguous.
     /// </summary>
-    public uint GMS2UnknownAlwaysZero { get; set; } = 0;
+    public int GMS2ExportedSpriteIndex { get; set; } = 0;
 
     /// <summary>
     /// The time for each frame in microseconds. Game Maker Studio 2 only.
@@ -154,7 +155,7 @@ public class UndertaleBackground : UndertaleNamedResource, IDisposable
             writer.Write(GMS2TileColumns);
             writer.Write(GMS2ItemsPerTileCount);
             writer.Write(GMS2TileCount);
-            writer.Write(GMS2UnknownAlwaysZero);
+            writer.Write(GMS2ExportedSpriteIndex);
             writer.Write(GMS2FrameLength);
             if (GMS2TileIds.Count != GMS2TileCount * GMS2ItemsPerTileCount)
                 throw new UndertaleSerializationException("Bad tile list length, should be tile count * frame count");
@@ -186,7 +187,7 @@ public class UndertaleBackground : UndertaleNamedResource, IDisposable
             GMS2TileColumns = reader.ReadUInt32();
             GMS2ItemsPerTileCount = reader.ReadUInt32();
             GMS2TileCount = reader.ReadUInt32();
-            GMS2UnknownAlwaysZero = reader.ReadUInt32();
+            GMS2ExportedSpriteIndex = reader.ReadInt32();
             GMS2FrameLength = reader.ReadInt64();
             GMS2TileIds = new List<TileID>((int)GMS2TileCount * (int)GMS2ItemsPerTileCount);
             for (int i = 0; i < GMS2TileCount * GMS2ItemsPerTileCount; i++)

--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -23,30 +23,37 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         /// Start the game as fullscreen.
         /// </summary>
         Fullscreen = 0x0001,
+
         /// <summary>
         /// Use synchronization to avoid tearing.
         /// </summary>
         SyncVertex1 = 0x0002,
+
         /// <summary>
         /// Use synchronization to avoid tearing. TODO: difference?
         /// </summary>
         SyncVertex2 = 0x0004,
+
         /// <summary>
         /// Interpolate colours between pixels.
         /// </summary>
         Interpolate = 0x0008,
+
         /// <summary>
         /// Keep aspect ratio during scaling.
         /// </summary>
         Scale = 0x0010,
+
         /// <summary>
         /// Display mouse cursor.
         /// </summary>
         ShowCursor = 0x0020,
+
         /// <summary>
         /// Allows window to be resized.
         /// </summary>
         Sizeable = 0x0040,
+
         /// <summary>
         /// Allows fullscreen switching TODO: ???
         /// </summary>
@@ -61,6 +68,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         /// studioVersion = (infoFlags &amp; InfoFlags.StudioVersionMask) >> 9
         /// </summary>
         StudioVersionMask = 0x0E00,
+
         /// <summary>
         /// Whether Steam (or the YoYoPlayer) is enabled.
         /// </summary>
@@ -75,6 +83,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         /// Whether the game supports borderless window
         /// </summary>
         BorderlessWindow = 0x4000,
+
         /// <summary>
         /// Tells the runner to run Javascript code
         /// </summary>
@@ -85,10 +94,16 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         /// <summary>
         /// This flag is set when a game is launched from the Gamemaker Studio 2 IDE using the 'Run' or 'Debug' options
         /// </summary>
-        GameRunFromGMS2IDE = 0x20000, //0x10000
+        GameRunFromGMS2IDE = 0x20000,
 
-        // TODO
-        //TransparentBackground = 0x20000,
+        /// <summary>
+        /// For the GX.games runner, allows the browser canvas to be transparent where nothing is drawn.
+        /// </summary>
+        TransparentBackground = 0x20000,
+
+        /// <summary>
+        /// For the Windows runner, reverts the swapchain to an older/legacy swap effect.
+        /// </summary>
         WindowsD3DSwapEffectDiscard = 0x40000
     }
 
@@ -339,8 +354,6 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     public static (uint, uint, uint, uint, BranchType) TestForCommonGMSVersions(UndertaleReader reader,
                                                                     (uint, uint, uint, uint, BranchType) readVersion)
     {
-        return (2024, 14, 1, 0, BranchType.Post2022_0);
-
         (uint Major, uint Minor, uint Release, uint Build, BranchType Branch) detectedVer = readVersion;
 
         // Some GMS2+ version detection. The rest is spread around, mostly in UndertaleChunks.cs

--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -2578,7 +2578,15 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         {
             Name = reader.ReadUndertaleString();
             if (reader.undertaleData.IsVersionAtLeast(2024, 14))
+            {
                 InstanceID = reader.ReadInt32();
+
+                // Track the last ID (it's not stored elsewhere...)
+                if (InstanceID > reader.undertaleData.LastParticleSystemInstanceID)
+                {
+                    reader.undertaleData.LastParticleSystemInstanceID = InstanceID;
+                }
+            }
             _particleSys.Unserialize(reader);
             X = reader.ReadInt32();
             Y = reader.ReadInt32();
@@ -2590,7 +2598,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         
         
         /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
-        public new static uint UnserializeChildObjectCount(UndertaleReader reader)
+        public static uint UnserializeChildObjectCount(UndertaleReader reader)
         {
             reader.Position += 32;
                 
@@ -2725,7 +2733,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
         }
 
         /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
-        public new static uint UnserializeChildObjectCount(UndertaleReader reader)
+        public static uint UnserializeChildObjectCount(UndertaleReader reader)
         {
             reader.Position += 68;
                 

--- a/UndertaleModLib/Models/UndertaleSequence.cs
+++ b/UndertaleModLib/Models/UndertaleSequence.cs
@@ -1306,7 +1306,7 @@ public class UndertaleSequence : UndertaleNamedResource, INotifyPropertyChanged,
             }
 
             /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
-            public new static uint UnserializeChildObjectCount(UndertaleReader reader)
+            public static uint UnserializeChildObjectCount(UndertaleReader reader)
             {
                 reader.Position += 16;
                 

--- a/UndertaleModLib/Models/UndertaleUINode.cs
+++ b/UndertaleModLib/Models/UndertaleUINode.cs
@@ -925,7 +925,7 @@ public class UndertaleUITextItemInstance : UndertaleRoom.TextItemInstance, IUnde
     }
 
     /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>
-    public static uint UnserializeChildObjectCount(UndertaleReader reader)
+    public new static uint UnserializeChildObjectCount(UndertaleReader reader)
     {
         reader.Position += 17 * 4;
         return IUndertaleFlexInstanceProperties.UnserializeChildObjectCount(reader);

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -777,6 +777,80 @@ namespace UndertaleModLib
     {
         public override string Name => "BGND";
 
+        private bool checkedFor2024_14_1 = false;
+        private void CheckForGM2024_14_1(UndertaleReader reader)
+        {
+            checkedFor2024_14_1 = true;
+
+            if (!reader.undertaleData.IsVersionAtLeast(2024, 13) || reader.undertaleData.IsVersionAtLeast(2024, 14, 1))
+            {
+                return;
+            }
+
+            long returnTo = reader.Position;
+            long chunkStartPos = reader.AbsPosition;
+
+            // Go through each background, and check to see if it ends at the expected position. If not, this is probably 2024.14.1.
+            uint bgCount = reader.ReadUInt32();
+            for (int i = 0; i < bgCount; i++)
+            {
+                // Find background's start position, and calculate next background position (if available).
+                reader.Position = returnTo + 4 + (4 * i);
+                uint bgPtr = reader.ReadUInt32();
+                if (bgPtr == 0)
+                {
+                    // Removed asset
+                    continue;
+                }
+                uint nextBgPtr = 0;
+                int j = i;
+                while (nextBgPtr == 0 && (++j) < bgCount)
+                {
+                    // Try next pointer in list
+                    nextBgPtr = reader.ReadUInt32();
+                }
+
+                // Skip all the way to "GMS2ItemsPerTileCount" (at its pre-2024.14.1 location), which is what we actually care about.
+                reader.AbsPosition = bgPtr + (11 * 4);
+                uint itemsPerTileCount = reader.ReadUInt32();
+                uint tileCount = reader.ReadUInt32();
+
+                // Calculate the theoretical end position given the above info, and compare to the actual end position (with padding).
+                uint theoreticalEndPos = bgPtr + (15 * 4) + (itemsPerTileCount * tileCount * 4);
+                if (nextBgPtr == 0)
+                {
+                    // Align to 16 bytes, and compare against chunk end position
+                    if ((theoreticalEndPos % 16) != 0)
+                    {
+                        theoreticalEndPos += 16 - (theoreticalEndPos % 16);
+                    }
+                    uint chunkEndPos = (uint)chunkStartPos + Length;
+                    if (theoreticalEndPos != chunkEndPos)
+                    {
+                        // Probably 2024.14.1!
+                        reader.undertaleData.SetGMS2Version(2024, 14, 1);
+                        break;
+                    }
+                }
+                else
+                {
+                    // Align to 8 bytes, and compare against next background start position
+                    if ((theoreticalEndPos % 8) != 0)
+                    {
+                        theoreticalEndPos += 8 - (theoreticalEndPos % 8);
+                    }
+                    if (theoreticalEndPos != nextBgPtr)
+                    {
+                        // Probably 2024.14.1!
+                        reader.undertaleData.SetGMS2Version(2024, 14, 1);
+                        break;
+                    }
+                }
+            }
+
+            reader.Position = returnTo;
+        }
+
         internal override void SerializeChunk(UndertaleWriter writer)
         {
             Alignment = 8;
@@ -786,7 +860,22 @@ namespace UndertaleModLib
         internal override void UnserializeChunk(UndertaleReader reader)
         {
             Alignment = 8;
+
+            if (!checkedFor2024_14_1)
+            {
+                CheckForGM2024_14_1(reader);
+            }
+
             base.UnserializeChunk(reader);
+        }
+
+        internal override uint UnserializeObjectCount(UndertaleReader reader)
+        {
+            checkedFor2024_14_1 = false;
+
+            CheckForGM2024_14_1(reader);
+
+            return base.UnserializeObjectCount(reader);
         }
     }
 

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -325,6 +325,14 @@ namespace UndertaleModLib
         public bool ArrayCopyOnWrite = false;
 
         /// <summary>
+        /// The last room particle system instance ID of the data file (incrementing).
+        /// </summary>
+        /// <remarks>
+        /// The first actual usable ID is 8388608.
+        /// </remarks>
+        public int LastParticleSystemInstanceID { get; set; } = 8388607;
+
+        /// <summary>
         /// Some info for the editor to store data on.
         /// </summary>
         public readonly ToolInfo ToolInfo = new ToolInfo();

--- a/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleBackgroundEditor.xaml
@@ -63,6 +63,8 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Margin="3">Unknown Always 2</TextBlock>
@@ -74,29 +76,39 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Tile Height</TextBlock>
             <local:TextBoxDark Grid.Row="2" Grid.Column="1" Margin="3" Text="{Binding GMS2TileHeight}"/>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Output Border X</TextBlock>
-            <local:TextBoxDark Grid.Row="3" Grid.Column="1" Margin="3" Text="{Binding GMS2OutputBorderX}"/>
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="3" Text="Tile Separation X"
+                       Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2024.14.1}"/>
+            <local:TextBoxDark Grid.Row="3" Grid.Column="1" Margin="3" Text="{Binding GMS2TileSeparationX}"
+                       Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2024.14.1}"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Output Border Y</TextBlock>
-            <local:TextBoxDark Grid.Row="4" Grid.Column="1" Margin="3" Text="{Binding GMS2OutputBorderY}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Margin="3" Text="Tile Separation Y"
+                       Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2024.14.1}"/>
+            <local:TextBoxDark Grid.Row="4" Grid.Column="1" Margin="3" Text="{Binding GMS2TileSeparationY}"
+                       Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter}, ConverterParameter=2024.14.1}"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Tile Columns</TextBlock>
-            <local:TextBoxDark Grid.Row="5" Grid.Column="1" Margin="3" Text="{Binding GMS2TileColumns}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Output Border X</TextBlock>
+            <local:TextBoxDark Grid.Row="5" Grid.Column="1" Margin="3" Text="{Binding GMS2OutputBorderX}"/>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Items/frames per tile</TextBlock>
-            <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding GMS2ItemsPerTileCount}"/>
+            <TextBlock Grid.Row="6" Grid.Column="0" Margin="3">Output Border Y</TextBlock>
+            <local:TextBoxDark Grid.Row="6" Grid.Column="1" Margin="3" Text="{Binding GMS2OutputBorderY}"/>
 
-            <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Tile Count</TextBlock>
-            <local:TextBoxDark Grid.Row="7" Grid.Column="1" Margin="3" Text="{Binding GMS2TileCount}"/>
+            <TextBlock Grid.Row="7" Grid.Column="0" Margin="3">Tile Columns</TextBlock>
+            <local:TextBoxDark Grid.Row="7" Grid.Column="1" Margin="3" Text="{Binding GMS2TileColumns}"/>
 
-            <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Unknown Always Zero</TextBlock>
-            <local:TextBoxDark Grid.Row="8" Grid.Column="1" Margin="3" Text="{Binding GMS2UnknownAlwaysZero}"/>
+            <TextBlock Grid.Row="8" Grid.Column="0" Margin="3">Items/frames per tile</TextBlock>
+            <local:TextBoxDark Grid.Row="8" Grid.Column="1" Margin="3" Text="{Binding GMS2ItemsPerTileCount}"/>
 
-            <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Frame Time (microseconds)</TextBlock>
-            <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" Text="{Binding GMS2FrameLength}"/>
+            <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Tile Count</TextBlock>
+            <local:TextBoxDark Grid.Row="9" Grid.Column="1" Margin="3" Text="{Binding GMS2TileCount}"/>
 
-            <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Tile IDs</TextBlock>
-            <local:DataGridDark Grid.Row="10" Grid.Column="1" x:Name="TileIdList" ItemsSource="{Binding GMS2TileIds}" MaxHeight="279" Margin="0,0,0,3" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow" IsSynchronizedWithCurrentItem="True"
+            <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Exported Sprite Index</TextBlock>
+            <local:TextBoxDark Grid.Row="10" Grid.Column="1" Margin="3" Text="{Binding GMS2ExportedSpriteIndex}"/>
+
+            <TextBlock Grid.Row="11" Grid.Column="0" Margin="3">Frame Time (microseconds)</TextBlock>
+            <local:TextBoxDark Grid.Row="11" Grid.Column="1" Margin="3" Text="{Binding GMS2FrameLength}"/>
+
+            <TextBlock Grid.Row="12" Grid.Column="0" Margin="3">Tile IDs</TextBlock>
+            <local:DataGridDark Grid.Row="12" Grid.Column="1" x:Name="TileIdList" ItemsSource="{Binding GMS2TileIds}" MaxHeight="279" Margin="0,0,0,3" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" HorizontalGridLinesBrush="LightGray" VerticalGridLinesBrush="LightGray" HeadersVisibility="Column" SelectionMode="Single" SelectionUnit="FullRow" IsSynchronizedWithCurrentItem="True"
                                 SelectionChanged="DataGrid_SelectionChanged">
                 <DataGrid.Resources>
                     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#FF26A0DA"/>
@@ -134,7 +146,7 @@
                 </DataGrid.Columns>
             </local:DataGridDark>
 
-            <TextBlock Grid.Row="11" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
+            <TextBlock Grid.Row="13" Grid.ColumnSpan="2" Margin="3" HorizontalAlignment="Center" Foreground="DarkGray" FontStyle="Italic" TextWrapping="Wrap" TextAlignment="Center">
                 Hint: You can click on any tile region below to highlight its ID above.
             </TextBlock>
         </Grid>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml
@@ -1175,6 +1175,11 @@
 
                             <TextBlock Grid.Row="5" Grid.Column="0" Margin="3">Rotation</TextBlock>
                             <local:TextBoxDark Grid.Row="5" Grid.Column="2" Margin="3" Text="{Binding Rotation}"/>
+
+                            <TextBlock Grid.Row="6" Grid.Column="0" Margin="3" Text="Instance ID"
+                                       Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2024.14}"/>
+                            <local:TextBoxDark Grid.Row="6" Grid.Column="2" Margin="3" Text="{Binding InstanceID}"
+                                               Visibility="{Binding Mode=OneTime, Converter={StaticResource IsVersionAtLeastConverter},ConverterParameter=2024.14}"/>
                         </Grid>
                     </DataTemplate>
                 </ContentControl.Resources>

--- a/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleRoomEditor/UndertaleRoomEditor.xaml.cs
@@ -692,6 +692,7 @@ namespace UndertaleModTool
                 var newPartSysInst = new ParticleSystemInstance
                 {
                     Name = ParticleSystemInstance.GenerateRandomName(mainWindow.Data),
+                    InstanceID = ++mainWindow.Data.LastParticleSystemInstanceID,
                     ParticleSystem = partSysInst.ParticleSystem,
                     X = (int)pos.X,
                     Y = (int)pos.Y,
@@ -699,7 +700,6 @@ namespace UndertaleModTool
                     ScaleY = partSysInst.ScaleY,
                     Color = partSysInst.Color,
                     Rotation = partSysInst.Rotation
-                    // FIXME: InstanceID
                 };
 
                 newObj = newPartSysInst;

--- a/UndertaleModTool/Scripts/Technical Scripts/CopySpriteBgFont.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/CopySpriteBgFont.csx
@@ -96,7 +96,7 @@ await Task.Run(() =>
                 nativeBG.GMS2TileColumns = donorBG.GMS2TileColumns;
                 nativeBG.GMS2ItemsPerTileCount = donorBG.GMS2ItemsPerTileCount;
                 nativeBG.GMS2TileCount = donorBG.GMS2TileCount;
-                nativeBG.GMS2UnknownAlwaysZero = donorBG.GMS2UnknownAlwaysZero;
+                nativeBG.GMS2ExportedSpriteIndex = donorBG.GMS2ExportedSpriteIndex;
                 nativeBG.GMS2FrameLength = donorBG.GMS2FrameLength;
                 nativeBG.GMS2TileIds = donorBG.GMS2TileIds;
                 DumpBackground(donorBG);

--- a/UndertaleModTool/Scripts/Technical Scripts/CopySpriteBgFontInternal.csx
+++ b/UndertaleModTool/Scripts/Technical Scripts/CopySpriteBgFontInternal.csx
@@ -84,7 +84,7 @@ await Task.Run(() =>
                 nativeBG.GMS2TileColumns = donorBG.GMS2TileColumns;
                 nativeBG.GMS2ItemsPerTileCount = donorBG.GMS2ItemsPerTileCount;
                 nativeBG.GMS2TileCount = donorBG.GMS2TileCount;
-                nativeBG.GMS2UnknownAlwaysZero = donorBG.GMS2UnknownAlwaysZero;
+                nativeBG.GMS2ExportedSpriteIndex = donorBG.GMS2ExportedSpriteIndex;
                 nativeBG.GMS2FrameLength = donorBG.GMS2FrameLength;
                 nativeBG.GMS2TileIds = donorBG.GMS2TileIds;
                 DumpBackground(donorBG);


### PR DESCRIPTION
Completely changes how vector shapes are stored in UndertaleSprites

### Caveats
* No proper version detection according to the new features is present. Currently there is a hack to assume everything is built with GM 2024.14.1
* No idea how to deal with particle system instance IDs