### PR TITLE
Label individual size, margin, and origin fields

### DIFF
--- a/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
+++ b/UndertaleModTool/Editors/UndertaleSpriteEditor.xaml
@@ -62,25 +62,37 @@
         <TextBlock Grid.Row="2" Grid.Column="0" Margin="3">Size</TextBlock>
         <Grid Grid.Row="2" Grid.Column="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="3*"/>
             </Grid.ColumnDefinitions>
-            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding Width}"/>
-            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding Height}"/>
+            <TextBlock Grid.Column="0" Margin="3">Width:</TextBlock>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding Width}"/>
+            <TextBlock Grid.Column="2" Margin="3">Height:</TextBlock>
+            <local:TextBoxDark Grid.Column="3" Margin="3" Text="{Binding Height}"/>
         </Grid>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Margin Left/Right/Bottom/Top</TextBlock>
+        <TextBlock Grid.Row="3" Grid.Column="0" Margin="3">Margin</TextBlock>
         <Grid Grid.Row="3" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding MarginLeft}"/>
-            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding MarginRight}"/>
-            <local:TextBoxDark Grid.Column="2" Margin="3" Text="{Binding MarginBottom}"/>
-            <local:TextBoxDark Grid.Column="3" Margin="3" Text="{Binding MarginTop}"/>
+            <TextBlock Grid.Column="0" Margin="3">Left:</TextBlock>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding MarginLeft}"/>
+            <TextBlock Grid.Column="2" Margin="3">Right:</TextBlock>
+            <local:TextBoxDark Grid.Column="3" Margin="3" Text="{Binding MarginRight}"/>
+            <TextBlock Grid.Column="4" Margin="3">Bottom:</TextBlock>
+            <local:TextBoxDark Grid.Column="5" Margin="3" Text="{Binding MarginBottom}"/>
+            <TextBlock Grid.Column="6" Margin="3">Top:</TextBlock>
+            <local:TextBoxDark Grid.Column="7" Margin="3" Text="{Binding MarginTop}"/>
         </Grid>
 
         <TextBlock Grid.Row="4" Grid.Column="0" Margin="3">Transparent</TextBlock>
@@ -102,11 +114,15 @@
         <TextBlock Grid.Row="9" Grid.Column="0" Margin="3">Origin</TextBlock>
         <Grid Grid.Row="9" Grid.Column="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="3*"/>
             </Grid.ColumnDefinitions>
-            <local:TextBoxDark Grid.Column="0" Margin="3" Text="{Binding OriginXWrapper}"/>
-            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding OriginYWrapper}"/>
+            <TextBlock Grid.Column="0" Margin="3">X:</TextBlock>
+            <local:TextBoxDark Grid.Column="1" Margin="3" Text="{Binding OriginXWrapper}"/>
+            <TextBlock Grid.Column="2" Margin="3">Y:</TextBlock>
+            <local:TextBoxDark Grid.Column="3" Margin="3" Text="{Binding OriginYWrapper}"/>
         </Grid>
 
         <TextBlock Grid.Row="10" Grid.Column="0" Margin="3">Textures</TextBlock>


### PR DESCRIPTION
## Description
Minor change to the sprite editor to clarify the width, height, and each margin side.
<img width="1868" height="833" alt="image" src="https://github.com/user-attachments/assets/44409dd6-c538-4ae7-8cb8-ad83989e2c29" />


### Caveats
Looks worse than the current solution at extremely wide (too much empty space) and extremely narrow (cropped text, too-small fields) tool scales.
<img width="2858" height="516" alt="image" src="https://github.com/user-attachments/assets/9bc95244-e9d7-4aa8-ab13-6f978c3aaed5" />
<img width="663" height="514" alt="image" src="https://github.com/user-attachments/assets/2e097716-a404-4d84-add8-09e6ed93b925" />


### Notes
Suggested by HalfBreadChaos in the Underminers server.