### PR TITLE
Added builtin variable audio_bus_main

### DIFF
--- a/UndertaleModLib/Compiler/BuiltinList.cs
+++ b/UndertaleModLib/Compiler/BuiltinList.cs
@@ -4413,6 +4413,10 @@ public class BuiltinList : IBuiltins
         {
             GlobalNotArray["font_texture_page_size"] = new VariableInfo("font_texture_page_size", true, true);
         }
+        if (data?.IsVersionAtLeast(2022, 11) == true)
+        {
+            GlobalNotArray["audio_bus_main"] = new VariableInfo("audio_bus_main", true, true);
+        }
         GlobalNotArray["os_type"] = new VariableInfo("os_type", true, false);
         GlobalNotArray["os_device"] = new VariableInfo("os_device", true, false);
         GlobalNotArray["os_version"] = new VariableInfo("os_version", true, false);


### PR DESCRIPTION
## Description
Currently, compiling code that uses `audio_bus_main` in the appropriate GameMaker version will make it an instance variable when it should be builtin, resulting in an error in game. Undertale Yellow notably uses this variable in the code entry `gml_Object_obj_battle_flashback_final_2_controller_Step_0`.
This Pull Requests aims to add it to list of builtin variables

### Caveats
There shouldn't be any issue

### Notes
To see in which GM version the variable got added I checked `fnames` of the runtimes