### PR TITLE
Make new background layers white by default

### DIFF
--- a/UndertaleModLib/Models/UndertaleRoom.cs
+++ b/UndertaleModLib/Models/UndertaleRoom.cs
@@ -1979,7 +1979,7 @@ public class UndertaleRoom : UndertaleNamedResource, INotifyPropertyChanged, IDi
             public bool TiledHorizontally { get => _tiledHorizontally; set { _tiledHorizontally = value; OnPropertyChanged(); } }
             public bool TiledVertically { get => _tiledVertically; set { _tiledVertically = value; OnPropertyChanged(); } }
             public bool Stretch { get => _stretch; set { _stretch = value; OnPropertyChanged(); } }
-            public uint Color { get; set; } = 0xFF000000;
+            public uint Color { get; set; } = 0xFFFFFFFF;
             public float FirstFrame { get; set; }
             public float AnimationSpeed { get; set; }
             public AnimationSpeedType AnimationSpeedType { get; set; }


### PR DESCRIPTION
## Description
This makes newly created background layers white instead of black by default, which fixes a thing i've seen sometimes where people get confused that the sprites they set on their background layers show up as black in-game (since the room editor view doesn't show background layer colors), and is probably more in line with expected behavior.
(And it's also technically a UTMTCE port since it also had this.)

(It seems GameMaker's behavior in this case is still different though. There, that background layers start with color `#181818`, but get set to white whenever you add a sprite to them.)

### Caveats

### Notes