### PR TITLE
Fix Import button for newly created Textures being broken

### DIFF
--- a/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
+++ b/UndertaleModTool/Editors/UndertaleEmbeddedTextureEditor.xaml.cs
@@ -237,7 +237,7 @@ namespace UndertaleModTool
                         mainWindow.ShowWarning("WARNING: Texture page dimensions are not powers of 2. Sprite blurring is very likely in-game.", "Unexpected texture dimensions");
                     }
 
-                    var previousFormat = target.TextureData.Image.Format;
+                    var previousFormat = target.TextureData.Image?.Format;
 
                     // Import image
                     target.TextureData.Image = image;


### PR DESCRIPTION
## Description
Due to a missing single null-conditional operator, trying to import PNG files for Embedded Textures that are just created and therefore have null Image data will throw an error. This PR just adds it

### Caveats
There shouldn't be any issue

### Notes
Seems this is a new error for version 0.8.4.0