### PR TITLE
Add getters for _mainFilePath and _mainDirectory in ProjectContext

### DIFF
--- a/UndertaleModLib/Project/ProjectContextAssets.cs
+++ b/UndertaleModLib/Project/ProjectContextAssets.cs
@@ -31,7 +31,7 @@ partial class ProjectContext
         List<SerializableCode> loadedCodeAssets = new(64);
         List<ISerializableTextureProjectAsset> loadedTextureAssets = new(64);
         HashSet<string> excludeDirectorySet = [.. _mainOptions.ExcludeDirectories];
-        foreach (string directory in Directory.EnumerateDirectories(_mainDirectory))
+        foreach (string directory in Directory.EnumerateDirectories(MainDirectory))
         {
             // Skip directories that are irregular, start with ".", or are excluded based on main options
             DirectoryInfo info = new(directory);

--- a/UndertaleModLib/Project/ProjectContextImportSteps.cs
+++ b/UndertaleModLib/Project/ProjectContextImportSteps.cs
@@ -34,11 +34,11 @@ partial class ProjectContext
         {
             return;
         }
-        _projectJsonPaths ??= [Path.GetFullPath(_mainFilePath)];
+        _projectJsonPaths ??= [Path.GetFullPath(MainFilePath)];
         foreach (string subProjectRelativePath in _mainOptions.SubProjects)
         {
-            string subProjectPath = Path.Join(_mainDirectory, subProjectRelativePath);
-            Paths.VerifyWithinDirectory(_mainDirectory, subProjectPath);
+            string subProjectPath = Path.Join(MainDirectory, subProjectRelativePath);
+            Paths.VerifyWithinDirectory(MainDirectory, subProjectPath);
             if (!_projectJsonPaths.Add(Path.GetFullPath(subProjectPath)))
             {
                 throw new ProjectException("Infinite sub-project recursion detected");
@@ -59,8 +59,8 @@ partial class ProjectContext
         foreach (ProjectMainOptions.PathList.PathPair pair in _mainOptions.ExternalFiles)
         {
             // Make sure external file or directory exists
-            string sourcePath = Path.Join(_mainDirectory, pair.Source);
-            Paths.VerifyWithinDirectory(_mainDirectory, sourcePath);
+            string sourcePath = Path.Join(MainDirectory, pair.Source);
+            Paths.VerifyWithinDirectory(MainDirectory, sourcePath);
             bool isDirectory;
             try
             {
@@ -165,8 +165,8 @@ partial class ProjectContext
         foreach (ProjectMainOptions.Patch patch in _mainOptions.Patches)
         {
             // Get path to patch file
-            string fullPatchPath = Path.Join(_mainDirectory, patch.PatchPath);
-            Paths.VerifyWithinDirectory(_mainDirectory, fullPatchPath);
+            string fullPatchPath = Path.Join(MainDirectory, patch.PatchPath);
+            Paths.VerifyWithinDirectory(MainDirectory, fullPatchPath);
 
             // Try finding valid base/output file paths
             if (!TryFindFileFromPathList(patch.DataFilePath, out string baseFilePath, out string outputFilePath))

--- a/UndertaleModLib/Project/ProjectContextScripts.cs
+++ b/UndertaleModLib/Project/ProjectContextScripts.cs
@@ -59,8 +59,8 @@ partial class ProjectContext
         foreach (string relativePath in relativePathList)
         {
             // Get path to script file
-            string path = Path.GetFullPath(Path.Join(_mainDirectory, relativePath));
-            Paths.VerifyWithinDirectory(_mainDirectory, path);
+            string path = Path.GetFullPath(Path.Join(MainDirectory, relativePath));
+            Paths.VerifyWithinDirectory(MainDirectory, path);
 
             // Load script contents
             string scriptText;


### PR DESCRIPTION
## Description
Adding getters for `_mainFilePath` and `_mainDirectory` allows access to them from inside project import scripts via the `Project` global.

### Caveats
As far as I know, adding getters for these properties shouldn't have any adverse effects.