### PR TITLE
use Extent instead of Composite for padding

### DIFF
--- a/UndertaleModLib/Util/TextureWorker.cs
+++ b/UndertaleModLib/Util/TextureWorker.cs
@@ -95,6 +95,7 @@ namespace UndertaleModLib.Util
             if (includePadding)
             {
                 // Based on a benchmark, Extent is faster than creating a new image and using Composite
+                image.Compose = CompositeOperator.Copy;
                 image.Extent(new MagickGeometry(-texPageItem.TargetX, -texPageItem.TargetY, (uint)exportWidth, (uint)exportHeight), MagickColors.Transparent);
             }
 


### PR DESCRIPTION
## Description
An optimization to TextureWorker which improves the speed of adding padding to images

### Caveats
This is not intensively tested, though from my (minimal) testing, it looks alright.

### Notes
Everywhere I look, Extent is said to be faster.
https://stackoverflow.com/questions/54270807/how-to-add-padding-to-an-image-using-magickimage-in-net-core
