### PR TITLE
Update Magick.NET package version to 14.10.3

### DIFF
--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.10.2" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.10.3" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Updated Magick.NET-Q8-AnyCPU from 14.10.2 to 14.10.3.
This update addresses a lot of high-severity bugs.
### Caveats
No breaking changes to the public API were identified in this minor version bump, so backward compatibility is maintained.

### Notes
<img width="973" height="132" alt="image" src="https://github.com/user-attachments/assets/8047178a-7209-4e5d-9d8d-6ffe3ca9e844" />

There just were 300+ warnings when i tried to build UndertaleModLib
All unit tests passed successfully on the local environment after the update.