### PR TITLE
Remove empty object events to prevent segfault

### DIFF
--- a/UndertaleModLib/Models/UndertaleGameObject.cs
+++ b/UndertaleModLib/Models/UndertaleGameObject.cs
@@ -209,6 +209,7 @@ public class UndertaleGameObject : UndertaleNamedResource, IProjectAsset, INotif
         {
             v.Serialize(writer);
         }
+        FixEvents();
         writer.WriteUndertaleObject(Events);
     }
 
@@ -257,6 +258,24 @@ public class UndertaleGameObject : UndertaleNamedResource, IProjectAsset, INotif
             PhysicsVertices.InternalAdd(v);
         }
         Events = reader.ReadUndertaleObject<UndertalePointerList<UndertalePointerList<Event>>>();
+    }
+
+    /// <summary>
+    /// It is possible to create a new event in the UndertaleModTool GUI that has no actions.
+    /// Events with zero actions will lead to a segfault in the runner when loading chunk OBJT,
+    /// because it assumes there is at least one action per event.
+    /// This has been proven on Undertale 1.01, maybe modern runners are not affected.
+    ///
+    /// This method removes these empty events.
+    /// </summary>
+    private void FixEvents() {
+        foreach (UndertalePointerList<Event> events in Events) {
+            for (int i = events.Count - 1; i >= 0; i--) {
+                if (events[i].Actions.Count == 0) {
+                    events.RemoveAt(i);
+                }
+            }
+        }
     }
 
     /// <inheritdoc cref="UndertaleObject.UnserializeChildObjectCount(UndertaleReader)"/>


### PR DESCRIPTION
## Description
It is possible to create a new event in the UndertaleModTool GUI that has no actions.
Events with zero actions will lead to a segfault in the runner when loading chunk OBJT, because it assumes there is at least one action per event.

I encountered this bug on Undertale 1.01 Linux, maybe modern runners are not affected.

How to reproduce:
* Open Undertale in UndertaleModTool
* Go to any game object
* Create a new event but do not add any actions (code entries) to it.
* Save data file
* Run game
* `Process Chunk: OBJT   730320`
* `fish: Job 1, '~/.sg/Undertale/runner' terminated by signal SIGSEGV (Address boundary error)`
* Unprofit

I added a small method to remove those empty events; fixing this bug.

### Caveats
This code removes the empty events when building the data file.
If it's not desired to change anything about the UndertaleData while serializing, then this new methods needs to be called _before_ writing.