### PR TITLE
Optimize UnescapeText method using StringBuilder

### DIFF
--- a/UndertaleModLib/Models/UndertaleString.cs
+++ b/UndertaleModLib/Models/UndertaleString.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace UndertaleModLib.Models;
 
@@ -117,7 +117,37 @@ public class UndertaleString : UndertaleResource, ISearchable, IDisposable, Unde
     /// <returns>A string which features the <b>text</b> <c>\n</c>, <c>\r</c>, <c>"</c> and <c>\</c> being properly unescaped.</returns>
     public static string UnescapeText(string text)
     {
-        // TODO: optimize this? seems like a very whacky thing to do... (could use a stringbuilder or something)
-        return text.Replace("\\r", "\r").Replace("\\n", "\n").Replace("\\\"", "\"").Replace("\\\\", "\\");
+        var result = new System.Text.StringBuilder(text.Length);
+        for (int i = 0; i < text.Length; i++)
+        {
+            char ch = text[i];
+            if (ch != '\\' || i + 1 >= text.Length)
+            {
+                result.Append(ch);
+                continue;
+            }
+
+            char next = text[++i];
+            switch (next)
+            {
+                case 'r':
+                    result.Append('\r');
+                    break;
+                case 'n':
+                    result.Append('\n');
+                    break;
+                case '"':
+                    result.Append('"');
+                    break;
+                case '\\':
+                    result.Append('\\');
+                    break;
+                default:
+                    result.Append('\\');
+                    result.Append(next);
+                    break;
+            }
+        }
+        return result.ToString();
     }
 }


### PR DESCRIPTION
Refactor UnescapeText method to use StringBuilder for optimization.

## Description
This refactors `UndertaleString.UnescapeText` to parse escape sequences in a single pass with `StringBuilder` instead of applying multiple chained `string.Replace` calls.

The previous implementation could re-process characters produced by an earlier replacement. For example, an escaped literal backslash followed by `n` (`"\\n"` in assembler text) could be transformed into a real newline because `Replace("\\n", "\n")` ran before `Replace("\\\\", "\\")`.

The new implementation handles only the escape sequences emitted by `UndertaleString.ToString(true)`:

- `\r` -> carriage return
- `\n` -> newline
- `\"` -> double quote
- `\\` -> literal backslash

Unknown escape-like sequences are preserved as-is instead of dropping the backslash. This keeps strings such as Windows paths (`C:\Users\Name`) or unsupported escape-like text (`\t`, `\x`, `\0`, `\U`) from being silently changed.

## Caveats
This intentionally does not add support for additional GML/C-style escape sequences such as `\t`, `\xNN`, octal escapes, or Unicode escapes. The method is used by the VM assembler text path and is kept as the inverse of `UndertaleString.ToString(true)`, rather than a full GML string literal parser.

## Notes
Needs tests ig
