### PR TITLE
Panicking ByName/IndexOf/IndexByName, separate Try- methods for null/-1

### DIFF
--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -495,7 +495,7 @@ public partial class Program : IScriptInterface
     }
 
     /// <inheritdoc/>
-    public string GetDisassemblyText(string codeName  GetDisassemblyText(Data.Code.ByName(codeName));
+    public string GetDisassemblyText(string codeName) => GetDisassemblyText(Data.Code.ByName(codeName));
 
     /// <inheritdoc/>
     public string GetDisassemblyText(UndertaleCode code)

--- a/UndertaleModCli/Program.UMTLibInherited.cs
+++ b/UndertaleModCli/Program.UMTLibInherited.cs
@@ -484,9 +484,9 @@ public partial class Program : IScriptInterface
         GlobalDecompileContext decompileContext = context is null ? new(Data) : context;
         try
         {
-            return code != null
-                ? new DecompileContext(decompileContext, code, settings ?? Data.ToolInfo.DecompilerSettings).DecompileToString()
-                : "";
+            settings ??= Data.ToolInfo.DecompilerSettings;
+            DecompileContext ctx = new DecompileContext(decompileContext, code, settings);
+            return ctx.DecompileToString();
         }
         catch (Exception e)
         {
@@ -495,10 +495,7 @@ public partial class Program : IScriptInterface
     }
 
     /// <inheritdoc/>
-    public string GetDisassemblyText(string codeName)
-    {
-        return GetDisassemblyText(Data.Code.ByName(codeName));
-    }
+    public string GetDisassemblyText(string codeName  GetDisassemblyText(Data.Code.ByName(codeName));
 
     /// <inheritdoc/>
     public string GetDisassemblyText(UndertaleCode code)
@@ -508,7 +505,7 @@ public partial class Program : IScriptInterface
 
         try
         {
-            return code != null ? code.Disassemble(Data.Variables, Data.CodeLocals?.For(code), Data.CodeLocals is null) : "";
+            return code.Disassemble(Data.Variables, Data.CodeLocals?.For(code), Data.CodeLocals is null);
         }
         catch (Exception e)
         {

--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -821,14 +821,6 @@ public partial class Program : IScriptInterface
     private void DumpCodeEntry(string codeEntry)
     {
         UndertaleCode code = Data.Code.ByName(codeEntry);
-
-
-        if (code == null)
-        {
-            Console.Error.WriteLine($"Data file does not contain a code entry named {codeEntry}!");
-            return;
-        }
-
         string directory = Path.Join(Output.FullName, "CodeEntries");
 
         Directory.CreateDirectory(directory);
@@ -1021,7 +1013,7 @@ public partial class Program : IScriptInterface
                     if (Data.IsVersionAtLeast(2, 3))
                     {
                         // GameMaker 2.3+ uses the object name for the collision subtype
-                        int objectIndex = Data.GameObjects.IndexOfName(collisionSubtype);
+                        int objectIndex = Data.GameObjects.TryIndexByName(collisionSubtype);
                         if (objectIndex >= 0)
                         {
                             // Object already exists; use its ID as a subtype
@@ -1078,7 +1070,7 @@ public partial class Program : IScriptInterface
             if (manualLink)
             {
                 // Create new object if necessary
-                UndertaleGameObject obj = Data.GameObjects.ByName(objectName);
+                UndertaleGameObject obj = Data.GameObjects.TryByName(objectName);
                 if (obj is null)
                 {
                     obj = new()
@@ -1122,16 +1114,8 @@ public partial class Program : IScriptInterface
     private void ReplaceTextureWithFile(string textureEntry, FileInfo fileToReplace)
     {
         UndertaleEmbeddedTexture texture = Data.EmbeddedTextures.ByName(textureEntry);
-
-        if (texture == null)
-        {
-            Console.Error.WriteLine($"Data file does not contain an embedded texture named {textureEntry}!");
-            return;
-        }
-
         if (Verbose)
             Console.WriteLine("Replacing " + textureEntry);
-
         texture.TextureData.Image = GMImage.FromPng(File.ReadAllBytes(fileToReplace.FullName));
     }
 

--- a/UndertaleModLib/Compiler/CodeImportGroup.cs
+++ b/UndertaleModLib/Compiler/CodeImportGroup.cs
@@ -188,7 +188,7 @@ public sealed class CodeImportGroup
             return false;
         }
         ReadOnlySpan<char> otherObjectName = codeEntryName.AsSpan(collisionSeparatorIndex + EventCollisionSeparator.Length);
-        int otherObjectIndex = Data.GameObjects.IndexOfName(otherObjectName);
+        int otherObjectIndex = Data.GameObjects.TryIndexByName(otherObjectName);
         if (otherObjectIndex < 0)
         {
             return false;
@@ -205,7 +205,7 @@ public sealed class CodeImportGroup
     private UndertaleCode FindOrCreateCodeEntry(string codeEntryName)
     {
         // Try to find existing
-        if (Data.Code.ByName(codeEntryName) is UndertaleCode existing)
+        if (Data.Code.TryByName(codeEntryName) is UndertaleCode existing)
         {
             if (existing.ParentEntry is not null)
             {
@@ -239,7 +239,12 @@ public sealed class CodeImportGroup
             MainThreadAction(() =>
             {
                 ReadOnlySpan<char> scriptName = codeEntryName.AsSpan(EventScriptPrefix.Length);
-                if (Data.Scripts.ByName(scriptName) is not UndertaleScript existingScript)
+                if (Data.Scripts.TryByName(scriptName) is UndertaleScript existingScript)
+                {
+                    // Attach to existing script asset (in case of corruption)
+                    existingScript.Code = newEntry;
+                }
+                else
                 {
                     // Create script, as one doesn't already exist
                     Data.Scripts.Add(new()
@@ -247,11 +252,6 @@ public sealed class CodeImportGroup
                         Name = Data.Strings.MakeString(scriptName.ToString()),
                         Code = newEntry
                     });
-                }
-                else
-                {
-                    // Attach to existing script asset (in case of corruption)
-                    existingScript.Code = newEntry;
                 }
             });
         }
@@ -293,7 +293,7 @@ public sealed class CodeImportGroup
             if (containsCollisionSeparator && TryParseCollisionEvent(codeEntryName, collisionSeparatorIndex, out ReadOnlySpan<char> collisionObjectName, out uint collisionSubtype))
             {
                 // Create new object if necessary.
-                UndertaleGameObject collisionObj = Data.GameObjects.ByName(collisionObjectName);
+                UndertaleGameObject collisionObj = Data.GameObjects.TryByName(collisionObjectName);
                 if (collisionObj is null)
                 {
                     string collisionObjectNameStr = collisionObjectName.ToString();
@@ -355,7 +355,7 @@ public sealed class CodeImportGroup
 
             // Create new object if necessary.
             ReadOnlySpan<char> objectName = codeEntryName.AsSpan(new Range(EventObjectPrefix.Length, secondLastUnderscore));
-            UndertaleGameObject obj = Data.GameObjects.ByName(objectName);
+            UndertaleGameObject obj = Data.GameObjects.TryByName(objectName);
             if (obj is null)
             {
                 string objectNameStr = objectName.ToString();

--- a/UndertaleModLib/Decompiler/Assembler.cs
+++ b/UndertaleModLib/Decompiler/Assembler.cs
@@ -260,7 +260,7 @@ public static partial class Assembler
                             line = line["[function]".Length..];
                             instr.ValueFunction = data.Functions.ByName(line);
                         }
-                        else if (data.Functions.ByName(line) is UndertaleFunction f)
+                        else if (data.Functions.TryByName(line) is UndertaleFunction f)
                         {
                             // Function reference (old-style syntax)
                             instr.ValueFunction = f;
@@ -321,9 +321,7 @@ public static partial class Assembler
 
                 // Find function being referenced
                 string funcName = match.Groups[1].Value;
-                UndertaleFunction func = data.Functions.ByName(funcName) ?? 
-                    throw new Exception($"Could not find function with name \"{funcName}\"");
-                instr.ValueFunction = func;
+                instr.ValueFunction = data.Functions.ByName(funcName);
 
                 // Parse argument count
                 instr.ArgumentsCount = ushort.Parse(match.Groups[2].Value);
@@ -349,9 +347,7 @@ public static partial class Assembler
                         else
                         {
                             // Or alternatively parse function!
-                            UndertaleFunction extFunc = data.Functions.ByName(line) ?? 
-                                throw new Exception($"Could not find function specified by extended pushref instruction: \"{line}\"");
-                            instr.ValueFunction = extFunc;
+                            instr.ValueFunction = data.Functions.ByName(line);
                         }
                     }
                 }
@@ -380,7 +376,7 @@ public static partial class Assembler
     private static int ParseResourceName(string line, UndertaleData data)
     {
         // TODO: have the option of building lookup maps instead of performing this linear search...
-        int id = data.IndexOfByName(line);
+        int id = data.IndexByName(line);
         if (id < 0)
         {
             throw new FormatException($"Unable to parse \"{line}\" as a number or resource name");
@@ -425,8 +421,7 @@ public static partial class Assembler
                 line = line[2..].Trim();
                 int space = line.IndexOf(' ', StringComparison.InvariantCulture);
                 string codeName = line[..space];
-                UndertaleCode code = data.Code.ByName(codeName) ?? 
-                    throw new Exception($"Failed to find code entry with name \"{codeName}\"");
+                UndertaleCode code = data.Code.ByName(codeName);
 
                 // Parse additional info (local/argument count), using a regular expression
                 string info = line[(space + 1)..];

--- a/UndertaleModLib/Decompiler/GlobalDecompileContext.cs
+++ b/UndertaleModLib/Decompiler/GlobalDecompileContext.cs
@@ -141,7 +141,7 @@ public class GlobalDecompileContext : IGameContext
         {
             if (script?.Name?.Content is string name && !name.StartsWith(subFunctionPrefix, StringComparison.Ordinal) &&
                 !data.GlobalFunctions.FunctionNameExists(name) &&
-                data.Functions.ByName(name) is UndertaleFunction function)
+                data.Functions.TryByName(name) is UndertaleFunction function)
             {
                 // Regular script asset (pre and post 2.3)
                 data.GlobalFunctions.DefineFunction(name, function);
@@ -151,7 +151,7 @@ public class GlobalDecompileContext : IGameContext
                 // If code name starts with "gml_Script_", and there's no parent code entry,
                 // then this is probably a GML-defined extension function.
                 if (code.Name?.Content is string codeName && codeName.StartsWith(subFunctionPrefix, StringComparison.Ordinal) &&
-                    data.Functions.ByName(codeName) is UndertaleFunction extFunction)
+                    data.Functions.TryByName(codeName) is UndertaleFunction extFunction)
                 {
                     data.GlobalFunctions.DefineFunction(codeName[subFunctionPrefix.Length..], extFunction);
                 }
@@ -172,7 +172,7 @@ public class GlobalDecompileContext : IGameContext
                     foreach (UndertaleExtensionFunction extensionFunc in extensionFile.Functions)
                     {
                         string functionName = extensionFunc.Name.Content;
-                        if (data.Functions.ByName(functionName) is UndertaleFunction foundFunction)
+                        if (data.Functions.TryByName(functionName) is UndertaleFunction foundFunction)
                         {
                             data.GlobalFunctions.DefineFunction(functionName, foundFunction);
                         }

--- a/UndertaleModLib/Models/UndertaleCode.cs
+++ b/UndertaleModLib/Models/UndertaleCode.cs
@@ -1229,7 +1229,7 @@ public class UndertaleInstruction : UndertaleObject, IGMInstruction
             return null;
         }
         string variableName = data.Strings[stringId].Content;
-        return data.Variables.ByName(variableName) ?? new UndertaleVariable() { Name = new UndertaleString(variableName) };
+        return data.Variables.TryByName(variableName) ?? new UndertaleVariable() { Name = new UndertaleString(variableName) };
     }
 
     IGMFunction IGMInstruction.TryFindFunction(IGameContext context)
@@ -1261,7 +1261,7 @@ public class UndertaleInstruction : UndertaleObject, IGMInstruction
             return null;
         }
         string functionName = data.Strings[stringId].Content;
-        return data.Functions.ByName(functionName) ?? new UndertaleFunction() { Name = new UndertaleString(functionName) };
+        return data.Functions.TryByName(functionName) ?? new UndertaleFunction() { Name = new UndertaleString(functionName) };
     }
     
     /// <summary>

--- a/UndertaleModLib/Project/ProjectContextAssets.cs
+++ b/UndertaleModLib/Project/ProjectContextAssets.cs
@@ -251,7 +251,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.Sprites.ByName(spriteNameOrNull) ??
+        return Data.Sprites.TryByName(spriteNameOrNull) ??
             throw new ProjectException($"Failed to find sprite \"{spriteNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -266,7 +266,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.Backgrounds.ByName(backgroundNameOrNull) ??
+        return Data.Backgrounds.TryByName(backgroundNameOrNull) ??
             throw new ProjectException($"Failed to find background \"{backgroundNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -281,7 +281,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.Fonts.ByName(fontNameOrNull) ??
+        return Data.Fonts.TryByName(fontNameOrNull) ??
             throw new ProjectException($"Failed to find font \"{fontNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -296,7 +296,7 @@ partial class ProjectContext
             throw new ProjectException($"No font name specified in property of \"{forAsset.DataName}\"");
         }
 
-        int index = Data.Fonts.IndexOfName(fontNameOrNull);
+        int index = Data.Fonts.TryIndexByName(fontNameOrNull);
         if (index < 0)
         {
             // Fallback option: parse integer and use that
@@ -322,7 +322,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.GameObjects.ByName(gameObjectNameOrNull) ??
+        return Data.GameObjects.TryByName(gameObjectNameOrNull) ??
             throw new ProjectException($"Failed to find object \"{gameObjectNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -337,7 +337,7 @@ partial class ProjectContext
             throw new ProjectException($"No object name specified in property of \"{forAsset.DataName}\"");
         }
 
-        int index = Data.GameObjects.IndexOfName(gameObjectNameOrNull);
+        int index = Data.GameObjects.TryIndexByName(gameObjectNameOrNull);
         if (index < 0)
         {
             // Fallback option: parse integer and use that
@@ -363,7 +363,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.Code.ByName(codeEntryNameOrNull) ??
+        return Data.Code.TryByName(codeEntryNameOrNull) ??
             throw new ProjectException($"Failed to find code entry \"{codeEntryNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -378,7 +378,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.Sequences.ByName(sequenceNameOrNull) ??
+        return Data.Sequences.TryByName(sequenceNameOrNull) ??
             throw new ProjectException($"Failed to find sequence \"{sequenceNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -393,7 +393,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.ParticleSystems.ByName(particleSystemNameOrNull) ??
+        return Data.ParticleSystems.TryByName(particleSystemNameOrNull) ??
             throw new ProjectException($"Failed to find particle system \"{particleSystemNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -408,7 +408,7 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.Sounds.ByName(soundNameOrNull) ??
+        return Data.Sounds.TryByName(soundNameOrNull) ??
             throw new ProjectException($"Failed to find sound \"{soundNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 
@@ -423,7 +423,9 @@ partial class ProjectContext
             return null;
         }
 
-        return Data.AnimationCurves.ByName(animCurveNameOrNull) ??
+        // TODO: All of these TryByName calls can be cleaned up with the new throwing ByName, but that will lose the `forAsset.DataName`.
+        // Either remove this comment and keep or replace these with ByName without ??
+        return Data.AnimationCurves.TryByName(animCurveNameOrNull) ??
             throw new ProjectException($"Failed to find animation curve \"{animCurveNameOrNull}\" for \"{forAsset.DataName}\"");
     }
 

--- a/UndertaleModLib/Project/SerializableAssets/SerializableAnimationCurve.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableAnimationCurve.cs
@@ -115,7 +115,7 @@ internal sealed class SerializableAnimationCurve : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.AnimationCurves.ByName(DataName) is UndertaleAnimationCurve existing)
+        if (projectContext.Data.AnimationCurves.TryByName(DataName) is UndertaleAnimationCurve existing)
         {
             // Animation curve found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableBackground.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableBackground.cs
@@ -141,7 +141,7 @@ internal sealed class SerializableBackground : ISerializableTextureProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Backgrounds.ByName(DataName) is UndertaleBackground existing)
+        if (projectContext.Data.Backgrounds.TryByName(DataName) is UndertaleBackground existing)
         {
             // Background found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableCode.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableCode.cs
@@ -75,7 +75,7 @@ internal sealed class SerializableCode : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Code.ByName(DataName) is UndertaleCode existing)
+        if (projectContext.Data.Code.TryByName(DataName) is UndertaleCode existing)
         {
             // Code found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableFont.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableFont.cs
@@ -200,7 +200,7 @@ internal sealed class SerializableFont : ISerializableTextureProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Fonts.ByName(DataName) is UndertaleFont existing)
+        if (projectContext.Data.Fonts.TryByName(DataName) is UndertaleFont existing)
         {
             // Font found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableGameObject.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableGameObject.cs
@@ -215,7 +215,7 @@ internal sealed class SerializableGameObject : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.GameObjects.ByName(DataName) is UndertaleGameObject existing)
+        if (projectContext.Data.GameObjects.TryByName(DataName) is UndertaleGameObject existing)
         {
             // Object found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializablePath.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializablePath.cs
@@ -86,7 +86,7 @@ internal sealed class SerializablePath : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Paths.ByName(DataName) is UndertalePath existing)
+        if (projectContext.Data.Paths.TryByName(DataName) is UndertalePath existing)
         {
             // Path found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableRoom.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableRoom.cs
@@ -913,7 +913,7 @@ internal sealed class SerializableRoom : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Rooms.ByName(DataName) is UndertaleRoom existing)
+        if (projectContext.Data.Rooms.TryByName(DataName) is UndertaleRoom existing)
         {
             // Room found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableScript.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableScript.cs
@@ -54,7 +54,7 @@ internal sealed class SerializableScript : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Scripts.ByName(DataName) is UndertaleScript existing)
+        if (projectContext.Data.Scripts.TryByName(DataName) is UndertaleScript existing)
         {
             // Script found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableSequence.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableSequence.cs
@@ -479,7 +479,7 @@ internal sealed class SerializableSequence : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Sequences.ByName(DataName) is UndertaleSequence existing)
+        if (projectContext.Data.Sequences.TryByName(DataName) is UndertaleSequence existing)
         {
             // Sequence found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableShader.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableShader.cs
@@ -121,7 +121,7 @@ internal sealed class SerializableShader : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Shaders.ByName(DataName) is UndertaleShader existing)
+        if (projectContext.Data.Shaders.TryByName(DataName) is UndertaleShader existing)
         {
             // Shader found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableSound.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableSound.cs
@@ -160,7 +160,7 @@ internal sealed class SerializableSound : ISerializableProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Sounds.ByName(DataName) is UndertaleSound existing)
+        if (projectContext.Data.Sounds.TryByName(DataName) is UndertaleSound existing)
         {
             // Sound found
             _dataAsset = existing;

--- a/UndertaleModLib/Project/SerializableAssets/SerializableSprite.cs
+++ b/UndertaleModLib/Project/SerializableAssets/SerializableSprite.cs
@@ -294,7 +294,7 @@ internal sealed class SerializableSprite : ISerializableTextureProjectAsset
     /// <inheritdoc/>
     public void PreImport(ProjectContext projectContext)
     {
-        if (projectContext.Data.Sprites.ByName(DataName) is UndertaleSprite existing)
+        if (projectContext.Data.Sprites.TryByName(DataName) is UndertaleSprite existing)
         {
             // Sprite found
             _dataAsset = existing;

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -45,7 +45,7 @@ namespace UndertaleModLib
                 // Prevent recursion
                 if (resourceTypeName == "Item")
                     return;
-                
+
                 var property = GetType().GetProperty(resourceTypeName);
                 if (property is null)
                     throw new MissingMemberException($"\"UndertaleData\" doesn't contain a property named \"{resourceTypeName}\".");
@@ -60,6 +60,7 @@ namespace UndertaleModLib
         /// <param name="resourceType">The resource type to get.</param>
         /// <exception cref="NotSupportedException"> if the type is not an <see cref="UndertaleNamedResource"/>.</exception>
         /// <exception cref="MissingMemberException"> if the data file does not contain a property of that type.</exception>
+        // this thing should get nuked lowkey
         public IList this[Type resourceType]
         {
             get
@@ -71,8 +72,10 @@ namespace UndertaleModLib
                 if (!typeof(UndertaleResource).IsAssignableFrom(resourceType))
                     throw new NotSupportedException($"\"{resourceType.FullName}\" is not an UndertaleResource.");
 
-                var property = GetType().GetProperties().Where(x => x.PropertyType.Name == "IList`1")
-                                                        .FirstOrDefault(x => x.PropertyType.GetGenericArguments()[0] == resourceType);
+                var property = GetType()
+                    .GetProperties()
+                    .Where(x => x.PropertyType.Name == "IList`1")
+                    .FirstOrDefault(x => x.PropertyType.GetGenericArguments()[0] == resourceType);
                 if (property is null)
                     throw new MissingMemberException($"\"UndertaleData\" doesn't contain a resource list of type \"{resourceType.FullName}\".");
 
@@ -83,8 +86,10 @@ namespace UndertaleModLib
                 if (!typeof(UndertaleResource).IsAssignableFrom(resourceType))
                     throw new NotSupportedException($"\"{resourceType.FullName}\" is not an UndertaleResource.");
 
-                var property = GetType().GetProperties().Where(x => x.PropertyType.Name == "IList`1")
-                                                        .FirstOrDefault(x => x.PropertyType.GetGenericArguments()[0] == resourceType);
+                var property = GetType()
+                    .GetProperties()
+                    .Where(x => x.PropertyType.Name == "IList`1")
+                    .FirstOrDefault(x => x.PropertyType.GetGenericArguments()[0] == resourceType);
                 if (property is null)
                     throw new MissingMemberException($"\"UndertaleData\" doesn't contain a resource list of type \"{resourceType.FullName}\".");
 
@@ -181,8 +186,6 @@ namespace UndertaleModLib
         /// The rooms of the data file.
         /// </summary>
         public IList<UndertaleRoom> Rooms => FORM.ROOM?.List;
-        //[Obsolete("Unused")]
-        // DataFile
 
         /// <summary>
         /// The texture page items from the data file.
@@ -302,7 +305,6 @@ namespace UndertaleModLib
         /// </summary>
         public IList<UndertaleParticleSystemEmitter> ParticleSystemEmitters => FORM.PSEM?.List;
 
-
         /// <summary>
         /// Whether this is an unsupported bytecode version.
         /// </summary>
@@ -366,137 +368,166 @@ namespace UndertaleModLib
         /// </summary>
         public UndertaleData()
         {
-            AllListProperties = GetType().GetProperties()
-                                .Where(x => x.PropertyType.IsGenericType
-                                            && x.PropertyType.GetGenericTypeDefinition() == typeof(IList<>))
-                                .ToArray();
+            AllListProperties = GetType()
+                .GetProperties()
+                .Where(x =>
+                    x.PropertyType.IsGenericType
+                    && x.PropertyType.GetGenericTypeDefinition() == typeof(IList<>)
+                )
+                .ToArray();
         }
 
         /// <summary>
-        /// Get a resource from the data file by name.
+        /// Tries to find any named resource/asset in the data file.
         /// </summary>
         /// <remarks>
-        /// This does a linear search, and will thus be slow if used many times. It's recommended to build lookup maps if many searches are required.
+        /// This does a linear search, and will thus be slow if used many times.
+        /// It's recommended to build lookup maps if many searches are required.
         /// </remarks>
         /// <param name="name">The name of the desired resource.</param>
         /// <param name="ignoreCase">Whether to ignore casing while searching.</param>
-        /// <returns>The <see cref="UndertaleNamedResource"/>.</returns>
+        /// <returns>The found <see cref="UndertaleNamedResource"/> or <see langword="null"/>.</returns>
+        public UndertaleNamedResource TryByName(string name, bool ignoreCase = false)
+        {
+            return Sounds?.TryByName(name, ignoreCase)
+                ?? Sprites?.TryByName(name, ignoreCase)
+                ?? Backgrounds?.TryByName(name, ignoreCase)
+                ?? Paths?.TryByName(name, ignoreCase)
+                ?? Scripts?.TryByName(name, ignoreCase)
+                ?? Fonts?.TryByName(name, ignoreCase)
+                ?? GameObjects?.TryByName(name, ignoreCase)
+                ?? Rooms?.TryByName(name, ignoreCase)
+                ?? Extensions?.TryByName(name, ignoreCase)
+                ?? Shaders?.TryByName(name, ignoreCase)
+                ?? Timelines?.TryByName(name, ignoreCase)
+                ?? AnimationCurves?.TryByName(name, ignoreCase)
+                ?? Sequences?.TryByName(name, ignoreCase)
+                ?? AudioGroups?.TryByName(name, ignoreCase)
+                ?? (UndertaleNamedResource)null;
+        }
+
+        /// <summary>
+        /// Finds any named resource/asset in the data file.
+        /// </summary>
+        /// <remarks>
+        /// This does a linear search, and will thus be slow if used many times.
+        /// It's recommended to build lookup maps if many searches are required.
+        /// </remarks>
+        /// <param name="name">The name of the desired resource.</param>
+        /// <param name="ignoreCase">Whether to ignore casing while searching.</param>
+        /// <returns>The found <see cref="UndertaleNamedResource"/>.</returns>
+        /// <exception cref="InvalidOperationException">if there is no resource with the given name.</exception>
         public UndertaleNamedResource ByName(string name, bool ignoreCase = false)
         {
-            return 
-                Sounds.ByName(name, ignoreCase) ??
-                Sprites.ByName(name, ignoreCase) ??
-                Backgrounds.ByName(name, ignoreCase) ??
-                Paths.ByName(name, ignoreCase) ??
-                Scripts.ByName(name, ignoreCase) ??
-                Fonts.ByName(name, ignoreCase) ??
-                GameObjects.ByName(name, ignoreCase) ??
-                Rooms.ByName(name, ignoreCase) ??
-                Extensions.ByName(name, ignoreCase) ??
-                Shaders.ByName(name, ignoreCase) ??
-                Timelines.ByName(name, ignoreCase) ??
-                AnimationCurves?.ByName(name, ignoreCase) ??
-                Sequences?.ByName(name, ignoreCase) ??
-                AudioGroups?.ByName(name, ignoreCase) ??
-                (UndertaleNamedResource)null;
+            UndertaleNamedResource found = TryByName(name, ignoreCase);
+            if (found is null)
+                throw new InvalidOperationException($"Could not find resource with name {name}");
+            return found;
         }
 
         /// <summary>
         /// Returns the zero-based index of the first occurrence of the specified <see cref="UndertaleResource"/>.
         /// </summary>
         /// <remarks>
-        /// This does a linear search, and will thus be slow if used many times. It's recommended to build lookup maps if many searches are required.
+        /// This does a linear search, and will thus be slow if used many times.
+        /// It's recommended to build lookup maps if many searches are required.
         /// </remarks>
         /// <param name="obj">The object to get the index of.</param>
-        /// <param name="panicIfInvalid">Whether to throw if <paramref name="obj"/> is not a valid object.</param>
-        /// <returns>The zero-based index position of the <paramref name="obj"/> parameter if it is found, or -1 if it is not found.</returns>
-        /// <exception cref="InvalidOperationException"><paramref name="panicIfInvalid"/> is <see langword="true"/>
-        /// and <paramref name="obj"/> could not be found.</exception>
-        public int IndexOf(UndertaleResource obj, bool panicIfInvalid = true)
+        /// <returns>The zero-based index position of the <paramref name="obj"/> parameter, or -1 if the resource is not registered.</returns>
+        public int TryIndexOf(UndertaleResource obj)
         {
             Type objType = obj.GetType();
-            PropertyInfo objListPropInfo = AllListProperties.FirstOrDefault(x => x.PropertyType.GetGenericArguments()[0] == objType);
+            PropertyInfo objListPropInfo = AllListProperties.FirstOrDefault(x =>
+                x.PropertyType.GetGenericArguments()[0] == objType
+            );
             if (objListPropInfo is not null)
             {
                 if (objListPropInfo.GetValue(this) is IList list)
                     return list.IndexOf(obj);
             }
-
-            if (panicIfInvalid)
-                throw new InvalidOperationException();
             return -1;
         }
 
+        /// <summary>
+        /// Returns the zero-based index of the first occurrence of the specified <see cref="UndertaleResource"/>.
+        /// </summary>
+        /// <remarks>
+        /// This does a linear search, and will thus be slow if used many times.
+        /// It's recommended to build lookup maps if many searches are required.
+        /// </remarks>
+        /// <param name="obj">The object to get the index of.</param>
+        /// <returns>The zero-based index position of the <paramref name="obj"/>.</returns>
+        /// <exception cref="InvalidOperationException">if the resource is not registered.</exception>
+        public int IndexOf(UndertaleResource obj)
+        {
+            int found = TryIndexOf(obj);
+            if (found < 0)
+                throw new InvalidOperationException($"Resource {obj} is not registered in the data file");
+            return found;
+        }
 
         /// <summary>
         /// Returns the zero-based index of the first occurrence of the specified <see cref="UndertaleNamedResource"/>.
         /// </summary>
         /// <remarks>
-        /// This does a linear search, and will thus be slow if used many times. It's recommended to build lookup maps if many searches are required.
+        /// This does a linear search, and will thus be slow if used many times.
+        /// It's recommended to build lookup maps if many searches are required.
         /// </remarks>
         /// <param name="name">The name of the desired resource.</param>
         /// <param name="ignoreCase">Whether to ignore casing while searching.</param>
         /// <returns>The zero-based index position of the <see cref="UndertaleNamedResource"/> if it is found, or -1 if it is not found.</returns>
-        public int IndexOfByName(string name, bool ignoreCase = false)
+        public int TryIndexByName(string name, bool ignoreCase = false)
         {
-            int res = Sounds.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Sprites.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Backgrounds.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Paths.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Scripts.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Fonts.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = GameObjects.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Rooms.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Extensions.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Shaders.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-            res = Timelines.IndexOfName(name, ignoreCase);
-            if (res >= 0) return res;
-
-            if (AnimationCurves is not null)
-            {
-                res = AnimationCurves.IndexOfName(name, ignoreCase);
-                if (res >= 0) return res;
-            }
-            if (Sequences is not null)
-            {
-                res = Sequences.IndexOfName(name, ignoreCase);
-                if (res >= 0) return res;
-            }
-            if (AudioGroups is not null)
-            {
-                res = AudioGroups.IndexOfName(name, ignoreCase);
-                if (res >= 0) return res;
-            }
-
+            int res = -1;
+            res = Sounds.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Sprites.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Backgrounds.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Paths.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Scripts.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Fonts.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = GameObjects.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Rooms.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Extensions.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Shaders.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = Timelines.TryIndexByName(name, ignoreCase); if (res >= 0) return res;
+            res = AnimationCurves?.TryIndexByName(name, ignoreCase) ?? -1; if (res >= 0) return res;
+            res = Sequences?.TryIndexByName(name, ignoreCase) ?? -1; if (res >= 0) return res;
+            res = AudioGroups?.TryIndexByName(name, ignoreCase) ?? -1; if (res >= 0) return res;
             return -1;
+        }
+
+        /// <summary>
+        /// Returns the zero-based index of the first occurrence of the specified <see cref="UndertaleNamedResource"/>.
+        /// </summary>
+        /// <remarks>
+        /// This does a linear search, and will thus be slow if used many times.
+        /// It's recommended to build lookup maps if many searches are required.
+        /// </remarks>
+        /// <param name="name">The name of the desired resource.</param>
+        /// <param name="ignoreCase">Whether to ignore casing while searching.</param>
+        /// <returns>The zero-based index position of the <see cref="UndertaleNamedResource"/>.</returns>
+        /// <exception cref="InvalidOperationException">if there is no resource with the given name.</exception>
+        public int IndexByName(string name, bool ignoreCase = false)
+        {
+            int found = TryIndexByName(name, ignoreCase);
+            if (found < 0)
+                throw new InvalidOperationException($"Could not find index of resource with name {name}");
+            return found;
         }
 
         /// <summary>
         /// Reports whether the data file was built by GameMaker Studio 2.
         /// </summary>
         /// <returns><see langword="true"/> if yes, <see langword="false"/> if not.</returns>
-        public bool IsGameMaker2()
-        {
-            return IsVersionAtLeast(2);
-        }
-
+        public bool IsGameMaker2() => IsVersionAtLeast(2);
 
         // Old Versions: https://store.yoyogames.com/downloads/gm-studio/release-notes-studio-old.html
         // https://web.archive.org/web/20150304025626/https://store.yoyogames.com/downloads/gm-studio/release-notes-studio.html
         // Early Access: https://web.archive.org/web/20181002232646/http://store.yoyogames.com:80/downloads/gm-studio-ea/release-notes-studio.html
         private bool TestGMS1Version(uint stableBuild, uint betaBuild, bool allowGMS2 = false)
         {
-            return (allowGMS2 || !IsGameMaker2()) && (IsVersionAtLeast(1, 0, 0, stableBuild) || (IsVersionAtLeast(1, 0, 0, betaBuild) && !IsVersionAtLeast(1, 0, 0, 1000)));
+            if (allowGMS2 && IsGameMaker2()) return true;
+            return IsVersionAtLeast(1, 0, 0, stableBuild) || (IsVersionAtLeast(1, 0, 0, betaBuild) && !IsVersionAtLeast(1, 0, 0, 1000));
         }
 
         /// <summary>
@@ -518,19 +549,19 @@ namespace UndertaleModLib
             GeneralInfo.Build = build;
 
             if (isLTS is not null)
-            {
                 SetLTS((bool)isLTS);
-            }
         }
 
         /// <summary>
-        /// Sets the branch type in GeneralInfo to the appropriate LTS or non-LTS version based on 
+        /// Sets the branch type in GeneralInfo to the appropriate LTS or non-LTS version based on
         /// </summary>
         /// <param name="isLTS">If included, alter the data branch between LTS and non-LTS.</param>
         public void SetLTS(bool isLTS)
         {
             // Insert additional logic as needed for new branches using IsVersionAtLeast
-            GeneralInfo.Branch = isLTS ? UndertaleGeneralInfo.BranchType.LTS2022_0 : UndertaleGeneralInfo.BranchType.Post2022_0;
+            GeneralInfo.Branch = isLTS
+                ? UndertaleGeneralInfo.BranchType.LTS2022_0
+                : UndertaleGeneralInfo.BranchType.Post2022_0;
         }
 
         /// <summary>
@@ -670,6 +701,7 @@ namespace UndertaleModLib
             data.FORM.Chunks["AUDO"] = new UndertaleChunkAUDO();
             foreach (UndertaleChunk chunk in data.FORM.Chunks.Values)
                 data.FORM.ChunksTypeDict[chunk.GetType()] = chunk;
+
             data.FORM.GEN8.Object = new UndertaleGeneralInfo();
             data.FORM.OPTN.Object = new UndertaleOptions();
             data.FORM.LANG.Object = new UndertaleLanguage();
@@ -677,12 +709,12 @@ namespace UndertaleModLib
             data.GeneralInfo.Config = data.Strings.MakeString("Default");
             data.GeneralInfo.Name = data.Strings.MakeString("NewGame");
             data.GeneralInfo.DisplayName = data.Strings.MakeString("New UndertaleModTool Game");
-            data.GeneralInfo.GameID = (uint)new Random().Next();
-            data.GeneralInfo.Timestamp = (uint)new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds();
-            data.Options.Constants.Add(new UndertaleOptions.Constant() { Name = data.Strings.MakeString("@@SleepMargin"), Value = data.Strings.MakeString(1.ToString()) });
-            data.Options.Constants.Add(new UndertaleOptions.Constant() { Name = data.Strings.MakeString("@@DrawColour"), Value = data.Strings.MakeString(0xFFFFFFFF.ToString()) });
-            data.Rooms.Add(new UndertaleRoom() { Name = data.Strings.MakeString("room0"), Caption = data.Strings.MakeString("") });
-            data.BuiltinList = new BuiltinList(data);
+            data.GeneralInfo.GameID = (uint) new Random().Next();
+            data.GeneralInfo.Timestamp = (uint) new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds();
+            data.Options.Constants.Add(new() { Name = data.Strings.MakeString("@@SleepMargin"), Value = data.Strings.MakeString(1.ToString()) });
+            data.Options.Constants.Add(new() { Name = data.Strings.MakeString("@@DrawColour"), Value = data.Strings.MakeString(0xFFFFFFFF.ToString()) } );
+            data.Rooms.Add(new() { Name = data.Strings.MakeString("room0"), Caption = data.Strings.MakeString("") });
+            data.BuiltinList = new(data);
             Decompiler.GameSpecificResolver.Initialize(data);
             return data;
         }
@@ -694,8 +726,9 @@ namespace UndertaleModLib
 
             Type disposableType = typeof(IDisposable);
             PropertyInfo[] dataProperties = GetType().GetProperties();
-            var dataDisposableProps = dataProperties.Except(AllListProperties)
-                                                    .Where(x => disposableType.IsAssignableFrom(x.PropertyType));
+            var dataDisposableProps = dataProperties
+                .Except(AllListProperties)
+                .Where(x => disposableType.IsAssignableFrom(x.PropertyType));
 
             // Dispose disposable properties
             foreach (PropertyInfo disposableProp in dataDisposableProps)
@@ -747,7 +780,7 @@ namespace UndertaleModLib
         public IDecompileSettings DecompilerSettings = new DecompileSettings();
 
         /// <summary>
-        /// Function that returns the prefix to be used when 
+        /// Function that returns the prefix to be used when
         /// resolving instance ID references in the compiler and decompiler.
         /// </summary>
         public Func<string> InstanceIdPrefix = () => "inst_";

--- a/UndertaleModLib/UndertaleDataExtensionMethods.cs
+++ b/UndertaleModLib/UndertaleDataExtensionMethods.cs
@@ -11,99 +11,99 @@ namespace UndertaleModLib;
 public static class UndertaleDataExtensionMethods
 {
     /// <summary>
-    /// An extension method, that returns the element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s
-    /// that has a specified <paramref name="name"/>.
+    /// Returns the element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
+    /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
+    /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
+    /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
+    /// <returns>The element that has the specified name, or <see langword="null"/> if none is found.</returns>
+    public static T TryByName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
+    {
+        return TryByName(list, name.AsSpan(), ignoreCase);
+    }
+
+    /// <summary>
+    /// Returns the element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
+    /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
+    /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
+    /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
+    /// <returns>The element that has the specified name, or <see langword="null"/> if none is found.</returns>
+    public static T TryByName<T>(this IList<T> list, ReadOnlySpan<char> name, bool ignoreCase = false) where T : UndertaleNamedResource
+    {
+        StringComparison comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        foreach (T item in list)
+        {
+            if (item is null)
+            {
+                continue;
+            }
+            if (item.Name.Content.AsSpan().Equals(name, comparisonType))
+            {
+                return item;
+            }
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Returns the element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
     /// </summary>
     /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
     /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
     /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
     /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
     /// <returns>The element that has the specified name.</returns>
+    /// <exception cref="InvalidOperationException">if there is no element with the specified name.</exception>
     public static T ByName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
     {
-        StringComparison comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-        foreach (T item in list)
-        {
-            if (item is null)
-            {
-                continue;
-            }
-            if (item.Name.Content.Equals(name, comparisonType))
-            {
-                return item;
-            }
-        }
-
-        return default;
+        return ByName(list, name.AsSpan(), ignoreCase);
     }
 
     /// <summary>
-    /// An extension method, that returns the index of an element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s
-    /// that has a specified <paramref name="name"/>.
-    /// </summary>
-    /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
-    /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
-    /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
-    /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
-    /// <returns>The index of the element that has the specified name, or -1 if none is found.</returns>
-    public static int IndexOfName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
-    {
-        StringComparison comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-        for (int i = 0; i < list.Count; i++)
-        {
-            if (list[i] is not T item)
-            {
-                continue;
-            }
-            if (item.Name.Content.Equals(name, comparisonType))
-            {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    /// <summary>
-    /// An extension method, that returns the element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s
-    /// that has a specified <paramref name="name"/>.
+    /// Returns the element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
     /// </summary>
     /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
     /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
     /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
     /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
     /// <returns>The element that has the specified name.</returns>
+    /// <exception cref="InvalidOperationException">if there is no element with the specified name.</exception>
     public static T ByName<T>(this IList<T> list, ReadOnlySpan<char> name, bool ignoreCase = false) where T : UndertaleNamedResource
     {
-        StringComparison comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-        foreach (T item in list)
-        {
-            if (item is null)
-            {
-                continue;
-            }
-            if (item.Name.Content.AsSpan().Equals(name, comparisonType))
-            {
-                return item;
-            }
+        T found = TryByName(list, name, ignoreCase);
+        if (found is null) {
+            throw new InvalidOperationException($"Could not find {typeof(T)} with name {name}");
         }
-
-        return default;
+        return found;
     }
 
     /// <summary>
-    /// An extension method, that returns the index of an element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s
-    /// that has a specified <paramref name="name"/>.
+    /// Returns the index of an element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
     /// </summary>
     /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
     /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
     /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
     /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
     /// <returns>The index of the element that has the specified name, or -1 if none is found.</returns>
-    public static int IndexOfName<T>(this IList<T> list, ReadOnlySpan<char> name, bool ignoreCase = false) where T : UndertaleNamedResource
+    public static int TryIndexByName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
+    {
+        return TryIndexByName(list, name.AsSpan(), ignoreCase);
+    }
+
+    /// <summary>
+    /// Returns the index of an element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
+    /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
+    /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
+    /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
+    /// <returns>The index of the element that has the specified name, or -1 if none is found.</returns>
+    public static int TryIndexByName<T>(this IList<T> list, ReadOnlySpan<char> name, bool ignoreCase = false) where T : UndertaleNamedResource
     {
         StringComparison comparisonType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
@@ -120,6 +120,23 @@ public static class UndertaleDataExtensionMethods
         }
 
         return -1;
+    }
+
+    /// <summary>
+    /// Returns the index of an element in a <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s with the specified <paramref name="name"/>.
+    /// </summary>
+    /// <param name="list">The <see cref="IList{T}"/> of <see cref="UndertaleNamedResource"/>s to search in.</param>
+    /// <param name="name">The name of the <see cref="UndertaleNamedResource"/> to find.</param>
+    /// <param name="ignoreCase">Whether casing should be ignored for searching.</param>
+    /// <typeparam name="T">A type of <see cref="UndertaleNamedResource"/>.</typeparam>
+    /// <returns>The index of the element that has the specified name.</returns>
+    /// <exception cref="InvalidOperationException">if there is no element with the specified name.</exception>
+    public static int IndexByName<T>(this IList<T> list, string name, bool ignoreCase = false) where T : UndertaleNamedResource
+    {
+        int found = TryIndexByName(list, name, ignoreCase);
+        if (found < 0)
+            throw new InvalidOperationException($"Could not find index of {typeof(T)} with name {name}");
+        return found;
     }
 
     public static UndertaleCodeLocals For(this IList<UndertaleCodeLocals> list, UndertaleCode code)
@@ -205,7 +222,7 @@ public static class UndertaleDataExtensionMethods
 
     public static UndertaleFunction EnsureDefined(this IList<UndertaleFunction> list, string name, IList<UndertaleString> strg)
     {
-        UndertaleFunction func = list.ByName(name);
+        UndertaleFunction func = list.TryByName(name);
         if (func is null)
         {
             return list.Define(name, strg);

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3105,7 +3105,7 @@ result in loss of work.");
         public void UpdateObjectLabel(object obj)
         {
             // Try to get index
-            int foundIndex = obj is UndertaleResource res ? Data.IndexOf(res, false) : -1;
+            int foundIndex = obj is UndertaleResource res ? Data.TryIndexOf(res) : -1;
 
 			// Determine ID
 			string idString;

--- a/UndertaleModTool/Scripts/UTDR Scripts/Debug.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/Debug.csx
@@ -13,53 +13,26 @@ string displayName = Data.GeneralInfo.DisplayName.Content;
 if (internalName == "NXTALE" || internalName.StartsWith("UNDERTALE"))
 {
     // UNDERTALE
-    if (Data.Scripts.ByName("SCR_GAMESTART", true)?.Code is UndertaleCode SCR_GAMESTART)
-    {
-        importGroup.QueueFindReplace(SCR_GAMESTART, "global.debug = ", $"global.debug = {(enable ? "1" : "0")}; //");
-        importGroup.Import();
-        ChangeSelection(SCR_GAMESTART);
-    }
-    else
-    {
-        ScriptError("Failed to find SCR_GAMESTART.");
-        return;
-    }
+    UndertaleCode scr_gamestart = Data.Scripts.ByName("SCR_GAMESTART", true).Code;
+    importGroup.QueueFindReplace(scr_gamestart, "global.debug = ", $"global.debug = {(enable ? "1" : "0")}; //");
+    importGroup.Import();
+    ChangeSelection(scr_gamestart);
 }
 else if (!Data.IsVersionAtLeast(2, 3) && (displayName == "SURVEY_PROGRAM" || displayName == "DELTARUNE Chapter 1"))
 {
     // DELTARUNE Chapter 1, before 1&2 demo
-    if (Data.Scripts.ByName("scr_debug")?.Code is UndertaleCode scr_debug)
-    {
-        importGroup.QueueReplace(scr_debug, $"global.debug = {(enable ? "1" : "0")}; return global.debug;");
-        importGroup.Import();
-        ChangeSelection(scr_debug);
-    }
-    else
-    {
-        ScriptError("Failed to find scr_debug.");
-        return;
-    }
+    UndertaleCode scr_debug = Data.Scripts.ByName("scr_debug").Code;
+    importGroup.QueueReplace(scr_debug, $"global.debug = {(enable ? "1" : "0")}; return global.debug;");
+    importGroup.Import();
+    ChangeSelection(scr_debug);
 }
 else if (displayName == "DELTARUNE Chapter 1&2")
 {
     // DELATRUNE (1&2 demo prior to LTS)
-    if (Data.Scripts.ByName("SCR_GAMESTART", true)?.Code is not UndertaleCode SCR_GAMESTART)
-    {
-        ScriptError("Failed to find SCR_GAMESTART.");
-        return;
-    }
-    if (Data.Code.ByName("gml_Object_obj_debugcontroller_ch1_Create_0") is not UndertaleCode debugControllerCode)
-    {
-        ScriptError("Failed to find obj_debugcontroller_ch1 create event.");
-        return;
-    }
-    if (Data.Code.ByName("gml_Object_obj_debugProfiler_Create_0") is not UndertaleCode debugProfilerCode)
-    {
-        ScriptError("Failed to find obj_debugProfiler create event.");
-        return;
-    }
-
-    importGroup.QueueFindReplace(SCR_GAMESTART, "global.debug = ", $"global.debug = {(enable ? "1" : "0")}; //");
+    UndertaleCode scr_gamestart = Data.Scripts.ByName("SCR_GAMESTART", true).Code;
+    UndertaleCode debugControllerCode = Data.Code.ByName("gml_Object_obj_debugcontroller_ch1_Create_0");
+    UndertaleCode debugProfilerCode = Data.Code.ByName("gml_Object_obj_debugProfiler_Create_0");
+    importGroup.QueueFindReplace(scr_gamestart, "global.debug = ", $"global.debug = {(enable ? "1" : "0")}; //");
     importGroup.QueueFindReplace(debugControllerCode, "debug = ", $"debug = {(enable ? "true" : "false")}; //");
     if (debugProfilerCode.Instructions.Count == 0 && enable)
     {
@@ -71,33 +44,24 @@ else if (displayName == "DELTARUNE Chapter 1&2")
         importGroup.QueueReplace(debugProfilerCode, "");
     }
     importGroup.Import();
-    ChangeSelection(SCR_GAMESTART);
+    ChangeSelection(scr_gamestart);
 }
-else if (displayName.ToUpper().Contains("DELTARUNE"))
+else if (displayName.ToUpperInvariant().Contains("DELTARUNE"))
 {
     if (Data.GameObjects.ByName("obj_event_manager") is null)
     {
         // DELTARUNE (1&2 LTS demo)
         if (displayName == "DELTARUNE Chapter 1")
         {
-            if (Data.Code.ByName("gml_Object_obj_debugcontroller_Create_0") is not UndertaleCode debugControllerCode)
-            {
-                ScriptError("Failed to find obj_debugcontroller create event.");
-                return;
-            }
-
+            UndertaleCode debugControllerCode = Data.Code.ByName("gml_Object_obj_debugcontroller_Create_0");
             importGroup.QueueFindReplace(debugControllerCode, "debug = ", $"debug = {(enable ? "true" : "false")}; //");
             importGroup.Import();
             ChangeSelection(debugControllerCode);
         }
         else if (displayName == "DELTARUNE Chapter 2")
         {
-            if (Data.Scripts.ByName("scr_debug")?.Code is not UndertaleCode scr_debug)
-            {
-                ScriptError("Failed to find scr_debug.");
-                return;
-            }
 
+            UndertaleCode scr_debug = Data.Scripts.ByName("scr_debug").Code;
             importGroup.QueueReplace(scr_debug, $"function scr_debug() {{ return {(enable ? "1" : "0")}; }}");
             importGroup.Import();
             ChangeSelection(scr_debug);
@@ -111,12 +75,7 @@ else if (displayName.ToUpper().Contains("DELTARUNE"))
     else
     {
         // DELTARUNE (full release, handles all chapters)
-        if (Data.Code.ByName("gml_Object_obj_initializer2_Create_0") is not UndertaleCode initializerCode)
-        {
-            ScriptError("Failed to find obj_initializer2 create event.");
-            return;
-        }
-
+        UndertaleCode initializerCode = Data.Code.ByName("gml_Object_obj_initializer2_Create_0");
         if (enable && displayName == "DELTARUNE Chapter 3")
         {
             // Chapter 3 needs extra globals defined for debug to function correctly
@@ -137,8 +96,8 @@ else if (displayName.ToUpper().Contains("DELTARUNE"))
             importGroup.QueueFindReplace(initializerCode, "global.debug = ", $"global.debug = {(enable ? "1" : "0")}; //");
         }
 
-        if (Data.Code.ByName("gml_GlobalScript_scr_flag_get") is UndertaleCode flagGetCode &&
-            Data.Code.ByName("gml_Script_scr_flag_name_get") is not null)
+        if (Data.Code.TryByName("gml_GlobalScript_scr_flag_get") is UndertaleCode flagGetCode &&
+            Data.Code.TryByName("gml_Script_scr_flag_name_get") is not null)
         {
             // Fix for chapters not including flag names
             importGroup.QueueFindReplace(flagGetCode,

--- a/UndertaleModTool/Scripts/UTDR Scripts/DisableDogcheck.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/DisableDogcheck.csx
@@ -25,7 +25,7 @@ UndertaleModLib.Compiler.CodeImportGroup importGroup = new(Data)
 };
 
 // Removes the invoking of the dog check script and the actual check itself from "gml_Script_scr_load".
-UndertaleCode scr_load = Data.Scripts.ByName("scr_load", true)?.Code;
+UndertaleCode scr_load = Data.Scripts.ByName("scr_load", true).Code;
 if (Data.GeneralInfo.Name.Content == "NXTALE" || Data.GeneralInfo.Name.Content.StartsWith("UNDERTALE")) 
 {
     importGroup.QueueFindReplace(scr_load, 

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleBattlegroupSelector.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleBattlegroupSelector.csx
@@ -19,10 +19,9 @@ if (!name.StartsWith("undertale") && name != "nxtale") {
     return;
 }
 
-var selector = Data.GameObjects.ByName("obj_battlegroup_input");
-
-if(selector == null) {
-    selector = new UndertaleGameObject() { Name = Data.Strings.MakeString("obj_battlegroup_input") };
+UndertaleGameObject selector = Data.GameObjects.TryByName("obj_battlegroup_input");
+if (selector is null) {
+    selector = new() { Name = Data.Strings.MakeString("obj_battlegroup_input") };
     Data.GameObjects.Add(selector);
 }
 

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleBetterVaporiser.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleBetterVaporiser.csx
@@ -152,13 +152,6 @@ else // Undertale Switch/Probs other consoles (GMS2)
 //
 
 var obj_whtpxlgrav = Data.GameObjects.ByName("obj_whtpxlgrav");
-
-if (obj_whtpxlgrav == null)
-{
-    ScriptError("This script only works with Undertale!", "Not Undertale");
-    return;
-}
-
 importGroup.QueueReplace(obj_whtpxlgrav.EventHandlerFor(EventType.Create, Data), @"
 image_speed = 0
 delay = 0

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleBorderEnabler.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleBorderEnabler.csx
@@ -85,7 +85,7 @@ foreach (var path in Directory.EnumerateFiles(bordersPath))
 // Create texture fragments and assign them to existing (but empty) backgrounds
 Action<string, UndertaleEmbeddedTexture, ushort, ushort, ushort, ushort> AssignBorderBackground = (name, tex, x, y, width, height) => 
 {
-    var bg = Data.Backgrounds.ByName(name);
+    var bg = Data.Backgrounds.TryByName(name);
     if (bg is null) 
     {
         // The anime border does not exist on PC yet ;)

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleChangeHomeBattlegroup.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleChangeHomeBattlegroup.csx
@@ -20,12 +20,6 @@ else if (Data?.GeneralInfo?.DisplayName?.Content.ToLower() == "deltarune chapter
 
 
 UndertaleCode code = Data.Code.ByName("gml_Object_obj_mainchara_KeyPress_36");
-if (code == null)
-{
-    ScriptError("Cannot apply, \"gml_Object_obj_mainchara_KeyPress_36\" does not exist!");
-    return;
-}
-
 GlobalDecompileContext globalDecompileContext = new(Data);
 Underanalyzer.Decompiler.IDecompileSettings decompilerSettings = new Underanalyzer.Decompiler.DecompileSettings();
 UndertaleModLib.Compiler.CodeImportGroup importGroup = new(Data)

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleDialogSimulator.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleDialogSimulator.csx
@@ -47,15 +47,13 @@ bool isDeltarune = false;
 if (Data.GeneralInfo.Name.ToString() == "\"DELTARUNE\"")
     isDeltarune = true;
 
-string newRoomName = "room_dialoguer";    
-var roomCheck = Data.Rooms.ByName(newRoomName);
-if (roomCheck != null)
+string newRoomName = "room_dialoguer";
+if (Data.Rooms.TryByName(newRoomName) is not null)
 {
     ScriptError(newRoomName + " already exists.");
     return;
 }
-var objCheck = Data.GameObjects.ByName("obj_dialog_sim");
-if (objCheck != null)
+if (Data.GameObjects.TryByName("obj_dialog_sim") is not null)
 {
     ScriptError("Object 'obj_dialog_sim' already exists.");
     return;
@@ -164,10 +162,10 @@ public void HandleAddingNewRoom()
     newRoom.Width = (uint)(isDeltarune ? 640 : 320);
     newRoom.Height = (uint)(isDeltarune ? 480 : 240);
 
-    if (Data.GameObjects.ByName("obj_mainchara") != null && (!isDeltarune))
-        newRoom.Views[0].ObjectId = Data.GameObjects.ByName("obj_mainchara");
+    if (Data.GameObjects.TryByName("obj_mainchara") is UndertaleGameObject obj_mainchara && !isDeltarune)
+        newRoom.Views[0].ObjectId = obj_mainchara;
     UndertaleRoom.Layer newInstancesLayer = new UndertaleRoom.Layer();
-    if (!(GMS1_mode))
+    if (!GMS1_mode)
     {
         newInstancesLayer.LayerName = Data.Strings.MakeString(newRoomName + "_GameObjects_Layer");
         newInstancesLayer.LayerId = last_layer_id++;
@@ -180,12 +178,12 @@ public void HandleAddingNewRoom()
         newRoom.SetupRoom();
     }
 
-    if (Data.GameObjects.ByName("obj_mainchara") != null)
+    if (Data.GameObjects.TryByName("obj_mainchara") is UndertaleGameObject obj_mainchara)
     {
         UndertaleRoom.GameObject newPlayerObj = new UndertaleRoom.GameObject();
         newPlayerObj.X = 160;
         newPlayerObj.Y = 120;
-        newPlayerObj.ObjectDefinition = Data.GameObjects.ByName("obj_mainchara");
+        newPlayerObj.ObjectDefinition = obj_mainchara;
         newPlayerObj.InstanceID = Data.GeneralInfo.LastObj++;
         UndertaleRoom.GameObject obj = newPlayerObj;
         newRoom.GameObjects.Add(obj);
@@ -196,12 +194,12 @@ public void HandleAddingNewRoom()
         }
     }
 
-    if (Data.GameObjects.ByName("obj_overworldcontroller") != null)
+    if (Data.GameObjects.TryByName("obj_overworldcontroller") is UndertaleGameObject obj_overworldcontroller)
     {
         UndertaleRoom.GameObject newControllerObj = new UndertaleRoom.GameObject();
         newControllerObj.X = 0;
         newControllerObj.Y = 0;
-        newControllerObj.ObjectDefinition = Data.GameObjects.ByName("obj_overworldcontroller");
+        newControllerObj.ObjectDefinition = obj_overworldcontroller;
         newControllerObj.InstanceID = Data.GeneralInfo.LastObj++;
         UndertaleRoom.GameObject obj = newControllerObj;
         newRoom.GameObjects.Add(obj);
@@ -212,12 +210,12 @@ public void HandleAddingNewRoom()
         }
     }
 
-    if (Data.GameObjects.ByName("obj_dialog_sim") != null)
+    if (Data.GameObjects.TryByName("obj_dialog_sim") is UndertaleGameObject obj_dialog_sim)
     {
         UndertaleRoom.GameObject newPlayerObj = new UndertaleRoom.GameObject();
         newPlayerObj.X = 160;
         newPlayerObj.Y = 120;
-        newPlayerObj.ObjectDefinition = Data.GameObjects.ByName("obj_dialog_sim");
+        newPlayerObj.ObjectDefinition = obj_dialog_sim;
         newPlayerObj.InstanceID = Data.GeneralInfo.LastObj++;
         UndertaleRoom.GameObject obj = newPlayerObj;
         newRoom.GameObjects.Add(obj);
@@ -228,12 +226,12 @@ public void HandleAddingNewRoom()
         }
     }
 
-    if (Data.GameObjects.ByName("obj_darkcontroller") != null && !GMS1_mode)
+    if (Data.GameObjects.TryByName("obj_darkcontroller") is UndertaleGameObject obj_darkcontroller && !GMS1_mode)
     {
         UndertaleRoom.GameObject newControllerObj = new UndertaleRoom.GameObject();
         newControllerObj.X = 0;
         newControllerObj.Y = 0;
-        newControllerObj.ObjectDefinition = Data.GameObjects.ByName("obj_darkcontroller");
+        newControllerObj.ObjectDefinition = obj_darkcontroller;
         newControllerObj.InstanceID = Data.GeneralInfo.LastObj++;
         UndertaleRoom.GameObject obj = newControllerObj;
         newRoom.GameObjects.Add(obj);

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleSafeBlaster.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleSafeBlaster.csx
@@ -6,9 +6,8 @@ EnsureDataLoaded();
 ScriptMessage("Adds a Gaster Blaster (+ generator) that isn't tied to Sans.\nOnly useful for modders.\nCreated by BenjaminUrquhart for Cairns.");
 
 // Blaster
-var obj_safeblaster = Data.GameObjects.ByName("obj_safeblaster");
-
-if (obj_safeblaster == null)
+var obj_safeblaster = Data.GameObjects.TryByName("obj_safeblaster");
+if (obj_safeblaster is null)
 {
     obj_safeblaster = new UndertaleGameObject()
     {
@@ -211,9 +210,8 @@ importGroup.QueueReplace(obj_safeblaster.EventHandlerFor(EventType.Destroy, Data
 
 
 // Generator
-var obj_safebl_gen = Data.GameObjects.ByName("obj_safebl_gen");
-
-if (obj_safebl_gen == null)
+var obj_safebl_gen = Data.GameObjects.TryByName("obj_safebl_gen");
+if (obj_safebl_gen is null)
 {
     obj_safebl_gen = new UndertaleGameObject()
     {

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleSwitchAndXboxOnPC.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleSwitchAndXboxOnPC.csx
@@ -19,7 +19,7 @@ UndertaleModLib.Compiler.CodeImportGroup importGroup = new(Data)
     MainThreadAction = MainThreadAction
 };
 
-bool isXbox = Data.Rooms.ByName("room_xbox_engagement") is not null;
+bool isXbox = Data.Rooms.TryByName("room_xbox_engagement") is not null;
 
 if (isXbox)
 {

--- a/UndertaleModTool/Scripts/Utility Scripts/FancyRoomSelect.csx
+++ b/UndertaleModTool/Scripts/Utility Scripts/FancyRoomSelect.csx
@@ -5,7 +5,7 @@
 
 EnsureDataLoaded();
 
-var obj = Data.GameObjects.ByName("obj_roomselector");
+var obj = Data.GameObjects.TryByName("obj_roomselector");
 if (obj is null) 
 {
     obj = new UndertaleGameObject() { Name = Data.Strings.MakeString("obj_roomselector"), Persistent = true };

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -17,6 +17,7 @@
         <NeutralLanguage>en</NeutralLanguage>
         <ResourceLanguages>en</ResourceLanguages>
         <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
         <!-- Suppress all missing XML comment warnings -->
         <NoWarn>1591</NoWarn>
         <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
The UndertaleData methods and extensions `ByName()`, `IndexOf` and `IndexOfByName` (now called `IndexByName`) now throw an exception when the element could not be found. The old behavior of returning `null`/`-1` is still available via `TryByName`, `TryIndexOf` and `TryIndexByName`.

### Caveats
This is a breaking change.

### Notes
i fixed all the csx scripts (hopefully)