### PR TITLE
New IDEVersion struct in GeneralInfo for convenience

### DIFF
--- a/UndertaleModLib/Models/UndertaleGeneralInfo.cs
+++ b/UndertaleModLib/Models/UndertaleGeneralInfo.cs
@@ -182,7 +182,89 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         Steam = 0x2000000000000000UL,
         UNUSED5 = 2310346608841064448UL,
         Shaders = 0x4000000000000000UL,
-        VertexBuffers = 9223372036854775808UL
+        VertexBuffers = 0x8000000000000000UL
+    }
+
+    /// <summary>
+    /// The GameMaker IDE Version this game was made in.
+    /// </summary>
+    /// <remarks>
+    /// UTMT also uses this to track the data file format for games made in 
+    /// GMS2 since the version stored in GEN8 is no longer being updated.
+    /// </remarks>
+    public struct IDEVersion: UndertaleObject
+    {
+        /// <summary>
+        /// The most significant version part.
+        /// 
+        /// This can be 1, 2 or a year after 2021.
+        /// </summary>
+        /// <remarks>
+        /// If greater than 1, serialization produces "2.0.0.0" due to the flag no longer updating in data.win
+        /// </remarks>
+        public uint Major;
+
+        /// <summary>
+        /// The second-most significant version part.
+        /// </summary>
+        public uint Minor;
+
+        /// <summary>
+        /// The third-most significant version part.
+        /// </summary>
+        public uint Release;
+
+        /// <summary>
+        /// The fourth-most (least) significant version part.
+        /// </summary>
+        public uint Build;
+
+        /// <summary>
+        /// The GameMaker release branch of the data file. May be set to <see cref="BranchType.Post2022_0"/> when features exempted from LTS are detected.
+        /// </summary>
+        public BranchType Branch;
+
+        public IDEVersion(uint major, uint minor = 0, uint release = 0, uint build = 0, BranchType branch = BranchType.Pre2022_0)
+        {
+            Major = major;
+            Minor = minor;
+            Release = release;
+            Build = build;
+            Branch = branch;
+        }
+
+        public IDEVersion()
+        {
+            Major = 1;
+            Build = 1337;
+        }
+
+        public void Serialize(UndertaleWriter writer)
+        {
+            writer.Write(Major);
+            writer.Write(Minor);
+            writer.Write(Release);
+            writer.Write(Build);
+        }
+
+        public void Unserialize(UndertaleReader reader)
+        {
+            Major = reader.ReadUInt32();
+            Minor = reader.ReadUInt32();
+            Release = reader.ReadUInt32();
+            Build = reader.ReadUInt32();
+        }
+    }
+
+    /// <summary>
+    /// Different GameMaker release branches. LTS has some but not all features of equivalent newer versions.
+    /// </summary>
+    // TODO: implement LTS 2026
+    public enum BranchType
+    {
+        Pre2022_0,
+        LTS2022_0,
+        Post2022_0
     }
 
     /// <summary>
@@ -191,13 +273,18 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     public bool IsDebuggerDisabled { get; set; } = true;
 
     /// <summary>
-    /// The bytecode version of the data file.
+    /// The bytecode version of the data file, (theoretically) indicating the data file format version.
     /// </summary>
+    /// <remarks>
+    /// It's theoretical because this is stuck on 17 since GMS2 and this library uses 
+    /// the IDE version (via version checks) for those modern versions instead.
+    /// </remarks>
     public byte BytecodeVersion { get; set; } = 0x10;
 
     /// <summary>
     /// Likely padding, IsDebuggerDisabled and BytecodeVersion are written together as a 32-bit integer
     /// </summary>
+    // TODO: this can probably be removed
     public ushort Padding { get; set; } = 0;
 
     /// <summary>
@@ -211,17 +298,17 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     public UndertaleString Config { get; set; }
 
     /// <summary>
-    /// The last object id of the data file.
+    /// The last object ID of the data file.
     /// </summary>
     public uint LastObj { get; set; } = 100000;
 
     /// <summary>
-    /// The last tile id of the data file.
+    /// The last tile ID of the data file.
     /// </summary>
     public uint LastTile { get; set; } = 10000000;
 
     /// <summary>
-    /// The game id of the data file.
+    /// The game ID of the data file.
     /// </summary>
     public uint GameID { get; set; } = 13371337;
 
@@ -237,40 +324,35 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     public UndertaleString Name { get; set; }
 
     /// <summary>
-    /// Different GameMaker release branches. LTS has some but not all features of equivalent newer versions.
+    /// The GameMaker IDE Version this game was made in.
     /// </summary>
-    public enum BranchType
-    {
-        Pre2022_0,
-        LTS2022_0,
-        Post2022_0
-    }
-
-    /// <summary>
-    /// The GameMaker release branch of the data file. May be set to <see cref="BranchType.Post2022_0"/> when features exempted from LTS are detected.
-    /// </summary>
-    public BranchType Branch = BranchType.Pre2022_0;
+    public IDEVersion Version;
 
     /// <summary>
     /// The major version of the data file.
     /// If greater than 1, serialization produces "2.0.0.0" due to the flag no longer updating in data.win
     /// </summary>
-    public uint Major { get; set; } = 1;
+    public uint Major { get => Version.Major; set { Version.Major = value; } }
 
     /// <summary>
     /// The minor version of the data file.
     /// </summary>
-    public uint Minor { get; set; } = 0;
+    public uint Minor { get => Version.Minor; set { Version.Minor = value; } }
 
     /// <summary>
     /// The Release version of the data file.
     /// </summary>
-    public uint Release { get; set; } = 0;
+    public uint Release { get => Version.Release; set { Version.Release = value; } }
 
     /// <summary>
     /// The build version of the data file.
     /// </summary>
-    public uint Build { get; set; } = 1337;
+    public uint Build { get => Version.Build; set { Version.Build = value; } }
+
+    /// <summary>
+    /// The GameMaker release branch of the data file. May be set to <see cref="BranchType.Post2022_0"/> when features exempted from LTS are detected.
+    /// </summary>
+    public BranchType Branch { get => Version.Branch; set { Version.Branch = value; } }
 
     /// <summary>
     /// The default window width of the game.
@@ -306,7 +388,6 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     /// The name that gets displayed in the window.
     /// </summary>
     public UndertaleString DisplayName { get; set; }
-
 
     public ulong ActiveTargets { get; set; } = 0;
 
@@ -355,24 +436,23 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     /// </summary>
     public bool InfoTimestampOffset { get; set; } = true;
 
-    public static (uint, uint, uint, uint, BranchType) TestForCommonGMSVersions(UndertaleReader reader,
-                                                                    (uint, uint, uint, uint, BranchType) readVersion)
+    public static IDEVersion TestForCommonGMSVersions(UndertaleReader reader, IDEVersion readVersion)
     {
-        (uint Major, uint Minor, uint Release, uint Build, BranchType Branch) detectedVer = readVersion;
+        IDEVersion detectedVer = readVersion;
 
         // Some GMS2+ version detection. The rest is spread around, mostly in UndertaleChunks.cs
         if (reader.AllChunkNames.Contains("UILR"))      // 2024.13, not present on LTS
-            detectedVer = (2024, 13, 0, 0, BranchType.Post2022_0);
+            detectedVer = new(2024, 13, 0, 0, BranchType.Post2022_0);
         else if (reader.AllChunkNames.Contains("PSEM")) // 2023.2, not present on LTS
-            detectedVer = (2023, 2, 0, 0, BranchType.Post2022_0);
+            detectedVer = new(2023, 2, 0, 0, BranchType.Post2022_0);
         else if (reader.AllChunkNames.Contains("FEAT")) // 2022.8
-            detectedVer = (2022, 8, 0, 0, BranchType.Pre2022_0);
+            detectedVer = new(2022, 8, 0, 0, BranchType.Pre2022_0);
         else if (reader.AllChunkNames.Contains("FEDS")) // 2.3.6
-            detectedVer = (2, 3, 6, 0, BranchType.Pre2022_0);
+            detectedVer = new(2, 3, 6, 0, BranchType.Pre2022_0);
         else if (reader.AllChunkNames.Contains("SEQN")) // 2.3
-            detectedVer = (2, 3, 0, 0, BranchType.Pre2022_0);
+            detectedVer = new(2, 3, 0, 0, BranchType.Pre2022_0);
         else if (reader.AllChunkNames.Contains("TGIN")) // 2.2.1
-            detectedVer = (2, 2, 1, 0, BranchType.Pre2022_0);
+            detectedVer = new(2, 2, 1, 0, BranchType.Pre2022_0);
 
         return detectedVer;
     }
@@ -391,28 +471,18 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         writer.Write(GameID);
         writer.Write(DirectPlayGuid.ToByteArray());
         writer.WriteUndertaleString(Name);
-        if (Major == 1)
-        {
-            writer.Write(Major);
-            writer.Write(Minor);
-            writer.Write(Release);
-            writer.Write(Build);
-        }
-        else
-        {
-            // The version number here is no longer updated,
-            // but it's still useful for the tool
-            writer.Write((uint)2);
-            writer.Write((uint)0);
-            writer.Write((uint)0);
-            writer.Write((uint)0);
-        }
+
+        // The version number here is no longer updated,
+        // but it's still useful for the tool
+        IDEVersion ver = Major < 2 ? Version : new(2);
+        writer.WriteUndertaleObject(ver);
+
         writer.Write(DefaultWindowWidth);
         writer.Write(DefaultWindowHeight);
         writer.Write((uint)Info);
         writer.Write(LicenseCRC32);
         if (LicenseMD5.Length != 16)
-            throw new IOException("LicenseMD5 has invalid length");
+            throw new InvalidOperationException("LicenseMD5 has invalid length");
         writer.Write(LicenseMD5);
         writer.Write(Timestamp);
         writer.WriteUndertaleString(DisplayName);
@@ -455,7 +525,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
             }
             writer.Write(GMS2FPS);
             if (GMS2GameGUID.Length != 16)
-                throw new IOException("GMS2GameGUID has invalid length");
+                throw new InvalidOperationException("GMS2GameGUID has invalid length");
             writer.Write(GMS2AllowStatistics);
             writer.Write(GMS2GameGUID);
         }
@@ -464,7 +534,7 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
     /// <inheritdoc />
     public void Unserialize(UndertaleReader reader)
     {
-        Func<UndertaleString> readFileNameDelegate;
+        Func<UndertaleString> readFileNameDelegate = reader.ReadUndertaleString;
         if (reader.ReadOnlyGEN8)
             readFileNameDelegate = () =>
             {
@@ -481,8 +551,6 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
 
                 return res;
             };
-        else
-            readFileNameDelegate = reader.ReadUndertaleString;
 
         IsDebuggerDisabled = reader.ReadByte() != 0;
         BytecodeVersion = reader.ReadByte();
@@ -495,21 +563,14 @@ public class UndertaleGeneralInfo : UndertaleObject, IDisposable
         byte[] guidData = reader.ReadBytes(16);
         DirectPlayGuid = new Guid(guidData);
         Name = reader.ReadUndertaleString();
-        Major = reader.ReadUInt32();
-        Minor = reader.ReadUInt32();
-        Release = reader.ReadUInt32();
-        Build = reader.ReadUInt32();
+        Version = reader.ReadUndertaleObject<IDEVersion>();
 
         if (reader.ReadOnlyGEN8)
             return;
 
         // TestForCommonGMSVersions is run during the object counting phase, so the previous general info is always accurate.
         var prevGenInfo = reader.undertaleData.GeneralInfo;
-        Major = prevGenInfo.Major;
-        Minor = prevGenInfo.Minor;
-        Release = prevGenInfo.Release;
-        Build = prevGenInfo.Build;
-        Branch = prevGenInfo.Branch;
+        Version = prevGenInfo.Version;
 
         DefaultWindowWidth = reader.ReadUInt32();
         DefaultWindowHeight = reader.ReadUInt32();

--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -4,6 +4,7 @@ using System.IO;
 using UndertaleModLib.Models;
 using UndertaleModLib.Util;
 using static UndertaleModLib.Models.UndertaleRoom;
+using static UndertaleModLib.Models.UndertaleGeneralInfo;
 
 namespace UndertaleModLib
 {
@@ -214,15 +215,8 @@ namespace UndertaleModLib
             reader.Bytecode14OrLower = Object.BytecodeVersion <= 14;
 
             reader.Position += 42;
-
-            Object.Major = reader.ReadUInt32();
-            Object.Minor = reader.ReadUInt32();
-            Object.Release = reader.ReadUInt32();
-            Object.Build = reader.ReadUInt32();
-
-            var readVer = (Object.Major, Object.Minor, Object.Release, Object.Build, Object.Branch);
-            var detectedVer = UndertaleGeneralInfo.TestForCommonGMSVersions(reader, readVer);
-            (Object.Major, Object.Minor, Object.Release, Object.Build, Object.Branch) = detectedVer;
+            Object.Version = reader.ReadUndertaleObject<IDEVersion>();
+            Object.Version = UndertaleGeneralInfo.TestForCommonGMSVersions(reader, Object.Version);
         }
     }
 

--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -8,6 +8,7 @@ using Underanalyzer.Decompiler;
 using Underanalyzer.Decompiler.GameSpecific;
 using UndertaleModLib.Compiler;
 using UndertaleModLib.Models;
+using static UndertaleModLib.Models.UndertaleGeneralInfo;
 
 namespace UndertaleModLib
 {
@@ -502,6 +503,17 @@ namespace UndertaleModLib
         /// <summary>
         /// Sets the GMS2+ version flag in GeneralInfo.
         /// </summary>
+        public void SetGMS2Version(IDEVersion ver) {
+            bool? isLTS = null;
+            if (ver.Branch == BranchType.LTS2022_0) isLTS = true;
+            if (ver.Branch == BranchType.Post2022_0) isLTS = false;
+            SetGMS2Version(ver.Major, ver.Minor, ver.Release, ver.Build, isLTS);
+        }
+
+
+        /// <summary>
+        /// Sets the GMS2+ version flag in GeneralInfo.
+        /// </summary>
         /// <param name="major">The major version.</param>
         /// <param name="minor">The minor version.</param>
         /// <param name="release">The release version.</param>
@@ -536,6 +548,11 @@ namespace UndertaleModLib
         /// <summary>
         /// Reports whether the version of the data file is the same or higher than a specified version.
         /// </summary>
+        public bool IsVersionAtLeast(IDEVersion ver) => IsVersionAtLeast(ver.Major, ver.Minor, ver.Release, ver.Build);
+
+        /// <summary>
+        /// Reports whether the version of the data file is the same or higher than a specified version.
+        /// </summary>
         /// <param name="major">The major version.</param>
         /// <param name="minor">The minor version.</param>
         /// <param name="release">The release version.</param>
@@ -563,6 +580,12 @@ namespace UndertaleModLib
 
             return true; // The version is exactly what supplied.
         }
+
+        /// <summary>
+        /// Reports whether the version of the data file is the same or higher than a specified version, and off the LTS branch that lacks some features.
+        /// </summary>
+        /// <returns>Whether the version of the data file is the same or higher than a specified version. Always false for LTS.</returns>
+        public bool IsNonLTSVersionAtLeast(IDEVersion ver) => IsNonLTSVersionAtLeast(ver.Major, ver.Minor, ver.Release, ver.Build);
 
         /// <summary>
         /// Reports whether the version of the data file is the same or higher than a specified version, and off the LTS branch that lacks some features.


### PR DESCRIPTION
## Description
Made a new struct called IDEVersion that contains major, minor, release, build and LTS branch. UndertaleGeneralInfo now stores this in a new field called Version. You can still use GeneralInfo.Major to access GeneralInfo.Version.Major etc using a properties. This ensures this change does not break existing code (and is more convenient anyway).

The reason I implemented this is because I think this could be useful when handling GameMaker versions without needing to create a whole UndertaleGeneralInfo or making your own struct/tuple for the 5 different version parts.

### Caveats
no

### Notes
if you don't like the name IDEVersion I can change it to something else lol