### PR TITLE
Fix debug crashes in Chapter 5

### DIFF
--- a/UndertaleModTool/Scripts/UTDR Scripts/Debug.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/Debug.csx
@@ -135,15 +135,8 @@ else if (displayName.ToUpper().Contains("DELTARUNE"))
         else if (enable && displayName == "DELTARUNE Chapter 5")
         {
             // Chapter 5 references rooms that don't exist which causes crashes in debug mode
-            if (Data.Code.ByName("gml_GlobalScript_scr_save") is UndertaleCode saveCode)
-            {
-                importGroup.QueueFindReplace(saveCode, "room == rm_blank", "room == room_empty");
-            }
-
-            if (Data.Code.ByName("gml_GlobalScript_scr_get_room_by_id") is UndertaleCode roomByIdCode)
-            {
-                importGroup.QueueFindReplace(roomByIdCode, "scr_room(rm_blank, 50094)", "scr_room(room_empty, 50094)");
-            }
+            importGroup.QueueFindReplace("gml_GlobalScript_scr_save", "room == rm_blank", "room == room_empty");
+            importGroup.QueueFindReplace("gml_GlobalScript_scr_get_room_by_id", "scr_room(rm_blank, 50094)", "scr_room(room_empty, 50094)");
 
             importGroup.QueueFindReplace(initializerCode, "global.debug = ", "global.debug = 1; //");
         }

--- a/UndertaleModTool/Scripts/UTDR Scripts/Debug.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/Debug.csx
@@ -132,6 +132,21 @@ else if (displayName.ToUpper().Contains("DELTARUNE"))
                 importGroup.QueueFindReplace(initializerCode, "global.debug = ", "global.debug = 1; //");
             }
         }
+        else if (enable && displayName == "DELTARUNE Chapter 5")
+        {
+            // Chapter 5 references rooms that don't exist which causes crashes in debug mode
+            if (Data.Code.ByName("gml_GlobalScript_scr_save") is UndertaleCode saveCode)
+            {
+                importGroup.QueueFindReplace(saveCode, "room == rm_blank", "room == room_empty");
+            }
+
+            if (Data.Code.ByName("gml_GlobalScript_scr_get_room_by_id") is UndertaleCode roomByIdCode)
+            {
+                importGroup.QueueFindReplace(roomByIdCode, "scr_room(rm_blank, 50094)", "scr_room(room_empty, 50094)");
+            }
+
+            importGroup.QueueFindReplace(initializerCode, "global.debug = ", "global.debug = 1; //");
+        }
         else
         {
             importGroup.QueueFindReplace(initializerCode, "global.debug = ", $"global.debug = {(enable ? "1" : "0")}; //");


### PR DESCRIPTION
## Description
Patches some code in chapter 5 that causes crashes when trying to save the game in debug mode, or loading into the game from the debug start menu

### Caveats
As far as I know, there are no caveats. However, the data returned from `scr_get_room_list` will return 2 different room ids, and both will use `room_blank` as it's room.

### Notes
Maybe removing `rm_blank` from `scr_get_room_list` entirely instead of just changing it to a different existing room would be better? The solution I have works FWIW.