### PR TITLE
Add function parameter definition for scr_84_add_menu_item

### DIFF
--- a/UndertaleModLib/GameSpecificData/Underanalyzer/deltarune.json
+++ b/UndertaleModLib/GameSpecificData/Underanalyzer/deltarune.json
@@ -1067,7 +1067,19 @@
       "gml_Script_sunkus_kb_check_released": [ "Constant.VirtualKey" ],
       "gml_Script_sunkus_kb_check_direct": [ "Constant.VirtualKey" ],
       "gml_Script_sunkus_kb_clear": [ "Constant.VirtualKey" ],
-      "gml_Script_sunkus_kb_check_pressed_with_repeat": [ "Constant.VirtualKey" ]
+      "gml_Script_sunkus_kb_check_pressed_with_repeat": [ "Constant.VirtualKey" ],
+      "scr_84_add_menu_item": [
+        null,
+        {
+          "MacroType": "Union",
+          "Macros": [
+            { "MacroType": "Match", "ConditionalValue": "[room]", "ConditionalType": "String" },
+            { "MacroType": "Match", "ConditionalValue": "[roomdark]", "ConditionalType": "String" }
+          ]
+        },
+        "Asset.Room",
+        null
+      ]
     },
     "FunctionReturn": {
       "scr_getbuttonsprite": {


### PR DESCRIPTION
## Description
Adds a definition to the deltarune decompiler config to make `scr_84_add_menu_item` decompile the third parameter as a room asset when the second parameter is set to `[room]` or `[roomdark]`. This fixes the [obscure debug menu from the Chapter 1 Switch port](https://tcrf.net/Proto:Deltarune/Chapter_1_Demo_(2018)#8-4_Debug_Menu) decompiling with raw room IDs in its menu options.

### Caveats
They seem to have changed how the 8-4 menu works in chapter 3 onwards which would probably break this detection. This doesn't really matter unless a newer version of the menu manages to crop up in the future though.

### Notes
Before:
<img width="515" height="195" alt="image" src="https://github.com/user-attachments/assets/84143836-379a-4d3c-9d1f-faeea6b74451" />
After:
<img width="623" height="196" alt="image" src="https://github.com/user-attachments/assets/86311934-2fed-4b0b-af40-2a63492cd5a9" />

The check for `[room]` or `[roomdark]` ensures that the other menu options that give items or the like are unchanged.