### PR TITLE
Add template strings

### DIFF
--- a/UndertaleModLib/Decompiler/GlobalDecompileContext.cs
+++ b/UndertaleModLib/Decompiler/GlobalDecompileContext.cs
@@ -52,6 +52,7 @@ public class GlobalDecompileContext : IGameContext
     public bool UsingNewArrayOwners => Data?.IsVersionAtLeast(2, 3, 2) ?? false;
     public bool UsingOptimizedFunctionDeclarations => Data?.IsVersionAtLeast(2024, 14) ?? false;
     public bool UsingNewChainedFunctionArgumentOrder => Data?.IsVersionAtLeast(2024, 14, 4) ?? false;
+    public bool UsingTemplateStrings => Data?.IsVersionAtLeast(2024, 14) ?? false;
     public GameSpecificRegistry GameSpecificRegistry => Data?.GameSpecificRegistry;
     public IBuiltins Builtins { get; private set; } = null;
     public ICodeBuilder CodeBuilder { get; private set; } = null;

--- a/UndertaleModLib/Decompiler/GlobalDecompileContext.cs
+++ b/UndertaleModLib/Decompiler/GlobalDecompileContext.cs
@@ -52,7 +52,8 @@ public class GlobalDecompileContext : IGameContext
     public bool UsingNewArrayOwners => Data?.IsVersionAtLeast(2, 3, 2) ?? false;
     public bool UsingOptimizedFunctionDeclarations => Data?.IsVersionAtLeast(2024, 14) ?? false;
     public bool UsingNewChainedFunctionArgumentOrder => Data?.IsVersionAtLeast(2024, 14, 4) ?? false;
-    public bool UsingTemplateStrings => Data?.IsVersionAtLeast(2024, 14) ?? false;
+    public bool UsingTemplateStrings => Data?.IsNonLTSVersionAtLeast(2023, 4) ?? false;
+    public bool UsingModernTemplateStrings => Data?.IsVersionAtLeast(2024, 14) ?? false;
     public GameSpecificRegistry GameSpecificRegistry => Data?.GameSpecificRegistry;
     public IBuiltins Builtins { get; private set; } = null;
     public ICodeBuilder CodeBuilder { get; private set; } = null;

--- a/UndertaleModTool/Resources/GML.xshd
+++ b/UndertaleModTool/Resources/GML.xshd
@@ -5,7 +5,8 @@
     <Color name="TemplateStringField" foreground="#C0C0C0" />
     <Color name="Identifier" foreground="#B2B1FF" />
     <Color name="AltIdentifier" foreground="#FFF899" />
-    <Color name="Function" foreground="#B2B1FF" />
+	<Color name="Function" foreground="#B2B1FF" />
+	<Color name="InternalFunction" foreground="#B2B1FF" />
     <Color name="Number" foreground="#FF6464" />
 
     <!-- This is the main ruleset. -->
@@ -109,14 +110,19 @@
             \bargument1[0-5]\b
         </Rule>
 
-        <!-- Function calls -->
-        <Rule color="Function">
-            [_a-zA-Z@][_a-zA-Z0-9@]*(?=\()
-        </Rule>
+		<!-- Function calls -->
+		<Rule color="Function">
+			[_a-zA-Z][_a-zA-Z0-9]*(?=\()
+		</Rule>
+
+		<!-- Internal function calls -->
+		<Rule color="InternalFunction">
+			@+[_a-zA-Z][_a-zA-Z0-9]*@+(?=\()
+		</Rule>
 
         <!-- Normal identifiers -->
         <Rule color="Identifier">
-            [_a-zA-Z@][_a-zA-Z0-9@]*
+            [_a-zA-Z][_a-zA-Z0-9]*
         </Rule>
     </RuleSet>
 </SyntaxDefinition>

--- a/UndertaleModTool/Resources/GML.xshd
+++ b/UndertaleModTool/Resources/GML.xshd
@@ -2,6 +2,7 @@
         xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
     <Color name="Comment" foreground="#5B995B" />
     <Color name="String" foreground="Yellow" />
+    <Color name="TemplateStringField" foreground="#C0C0C0" />
     <Color name="Identifier" foreground="#B2B1FF" />
     <Color name="AltIdentifier" foreground="#FFF899" />
     <Color name="Function" foreground="#B2B1FF" />
@@ -27,6 +28,17 @@
             <RuleSet>
                 <!-- nested span for escape sequences -->
                 <Span begin="\\" end="." />
+            </RuleSet>
+        </Span>
+
+        <Span color="String">
+            <Begin>\$"</Begin>
+            <End>"</End>
+            <RuleSet>
+                <!-- nested span for escape sequences -->
+                <Span begin="\\" end="." />
+                <!-- use main ruleset for template string fields -->
+				<Span begin="{" end="}" color="TemplateStringField" ruleSet="" />
             </RuleSet>
         </Span>
 
@@ -99,12 +111,12 @@
 
         <!-- Function calls -->
         <Rule color="Function">
-            [_a-zA-Z][_a-zA-Z0-9]*(?=\()
+            [_a-zA-Z@][_a-zA-Z0-9@]*(?=\()
         </Rule>
 
         <!-- Normal identifiers -->
         <Rule color="Identifier">
-            [_a-zA-Z][_a-zA-Z0-9]*
+            [_a-zA-Z@][_a-zA-Z0-9@]*
         </Rule>
     </RuleSet>
 </SyntaxDefinition>

--- a/UndertaleModTool/Resources/VMASM.xshd
+++ b/UndertaleModTool/Resources/VMASM.xshd
@@ -6,7 +6,8 @@
     <Color name="AltIdentifier" foreground="#FFF899" />
     <Color name="BranchOpcode" foreground="#80A8FF" />
     <Color name="Opcode" foreground="#DADADA" />
-    <Color name="Function" foreground="#FFB871" fontWeight="bold" />
+	<Color name="Function" foreground="#FFB871" fontWeight="bold" />
+	<Color name="InternalFunction" foreground="#FFB871" fontWeight="bold" />
     <Color name="Number" foreground="#FF6464" />
     <Color name="Label" foreground="#FF8D0A" />
 
@@ -72,10 +73,15 @@
             \bargument1[0-5]\b
         </Rule>
 
-        <!-- Function calls -->
-        <Rule color="Function">
-            [_a-zA-Z@][_a-zA-Z0-9@]*(?=\()
-        </Rule>
+		<!-- Function calls -->
+		<Rule color="Function">
+			[_a-zA-Z@][_a-zA-Z0-9@]*(?=\()
+		</Rule>
+
+		<!-- Internal function calls -->
+		<Rule color="InternalFunction">
+			@+[_a-zA-Z][_a-zA-Z0-9]*@+(?=\()
+		</Rule>
 
         <!-- Opcodes -->
         <Rule color="BranchOpcode">

--- a/UndertaleModTool/Resources/VMASM.xshd
+++ b/UndertaleModTool/Resources/VMASM.xshd
@@ -74,7 +74,7 @@
 
         <!-- Function calls -->
         <Rule color="Function">
-            [_a-zA-Z][_a-zA-Z0-9]*(?=\()
+            [_a-zA-Z@][_a-zA-Z0-9@]*(?=\()
         </Rule>
 
         <!-- Opcodes -->

--- a/UndertaleModTool/Settings.cs
+++ b/UndertaleModTool/Settings.cs
@@ -203,6 +203,7 @@ namespace UndertaleModTool
         public bool CleanupDefaultArgumentValues { get => _innerSettings.CleanupDefaultArgumentValues; set => _innerSettings.CleanupDefaultArgumentValues = value; }
         public bool CleanupBuiltinArrayVariables { get => _innerSettings.CleanupBuiltinArrayVariables; set => _innerSettings.CleanupBuiltinArrayVariables = value; }
         public bool CleanupLocalVarDeclarations { get => _innerSettings.CleanupLocalVarDeclarations; set => _innerSettings.CleanupLocalVarDeclarations = value; }
+        public bool CleanupTemplateStrings { get => _innerSettings.CleanupTemplateStrings; set => _innerSettings.CleanupTemplateStrings = value; }
         public bool CreateEnumDeclarations { get => _innerSettings.CreateEnumDeclarations; set => _innerSettings.CreateEnumDeclarations = value; }
         public string UnknownEnumName { get => _innerSettings.UnknownEnumName; set => _innerSettings.UnknownEnumName = value; }
         public string UnknownEnumValuePattern { get => _innerSettings.UnknownEnumValuePattern; set => _innerSettings.UnknownEnumValuePattern = value; }

--- a/UndertaleModTool/Windows/GMLSettingsWindow.xaml
+++ b/UndertaleModTool/Windows/GMLSettingsWindow.xaml
@@ -168,6 +168,9 @@
                     <CheckBox Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="3" Content="Scope local variable declarations" 
                               ToolTip="If enabled, local variable declarations will be placed according to their scopes, which are detected based on usage in the code." 
                               IsChecked="{Binding DecompilerSettings.CleanupLocalVarDeclarations}"/>
+                    <CheckBox Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="3" Content="Template strings" 
+                              ToolTip="If enabled, the decompiler will make an attempt to rewrite calls to @@string@@ as template strings." 
+                              IsChecked="{Binding DecompilerSettings.CleanupTemplateStrings}"/>
                 </Grid>
             </Grid>
             <Separator Margin="10,0,10,0"/>

--- a/UndertaleModTool/Windows/GMLSettingsWindow.xaml
+++ b/UndertaleModTool/Windows/GMLSettingsWindow.xaml
@@ -169,7 +169,7 @@
                               ToolTip="If enabled, local variable declarations will be placed according to their scopes, which are detected based on usage in the code." 
                               IsChecked="{Binding DecompilerSettings.CleanupLocalVarDeclarations}"/>
                     <CheckBox Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Margin="3" Content="Template strings" 
-                              ToolTip="If enabled, the decompiler will make an attempt to rewrite calls to @@string@@ as template strings." 
+                              ToolTip="If enabled, the decompiler will attempt to rewrite string()/@@string@@() as template strings." 
                               IsChecked="{Binding DecompilerSettings.CleanupTemplateStrings}"/>
                 </Grid>
             </Grid>


### PR DESCRIPTION
## Description
This complements https://github.com/UnderminersTeam/Underanalyzer/pull/28.

This changes UTMT and UTModLib to reflect the additions to the Underanalyzer interfaces. Additionally, some syntax highlighting for template strings was added (doesn't support nested braces, this is seemingly an AvalonEdit limitation), along with a checkbox for the new feature flag.

### Caveats
As stated on the Underanalyzer PR.