### PR TITLE
Add local options to save source and destination in project

### DIFF
--- a/UndertaleModCli/Program.cs
+++ b/UndertaleModCli/Program.cs
@@ -20,7 +20,6 @@ using UndertaleModLib.Models;
 using UndertaleModLib.Project;
 using UndertaleModLib.Scripting;
 using UndertaleModLib.Util;
-using static UndertaleModLib.UndertaleReader;
 
 namespace UndertaleModCli;
 
@@ -266,8 +265,8 @@ public partial class Program : IScriptInterface
         {
             Description = "Path to the UndertaleModTool project.json file"
         };
-        Option<FileInfo> projectBuildSourceOption = new("-s", "--source") { Description = "Source data file", Required = true };
-        Option<FileInfo> projectBuildDestinationOption = new("-d", "--destination") { Description = "Destination data file", Required = true };
+        Option<FileInfo> projectBuildSourceOption = new("-s", "--source") { Description = "Source data file" };
+        Option<FileInfo> projectBuildDestinationOption = new("-d", "--destination") { Description = "Destination data file" };
 
         Command projectBuildCommand = new("build", "Build a project")
         {
@@ -334,13 +333,12 @@ public partial class Program : IScriptInterface
     {
         if (datafile == null) throw new ArgumentNullException(nameof(datafile));
 
-        Console.WriteLine($"Trying to load file: '{datafile.FullName}'");
+        if (verbose)
+            Console.WriteLine($"Trying to load file: '{datafile.FullName}'");
+
         this.Verbose = verbose;
         this.Data = ReadDataFile(datafile, verbose ? WarningHandler : null, verbose ? MessageHandler : null);
         this.Output = output ?? new DirectoryInfo(datafile.DirectoryName);
-
-        if (this.Verbose)
-            Console.WriteLine("Output directory has been set to " + this.Output.FullName);
     }
 
     /// <summary>
@@ -446,7 +444,7 @@ public partial class Program : IScriptInterface
 
         // If parameter to save file was given, save the data file
         if (options.Output != null)
-            program.SaveDataFile(options.Output.FullName);
+            program.SaveDataFile(options.Output.FullName, options.Verbose ? MessageHandler : DummyHandler);
 
         return EXIT_SUCCESS;
     }
@@ -628,7 +626,7 @@ public partial class Program : IScriptInterface
 
         // If parameter to save file was given, save the data file
         if (options.Output != null)
-            program.SaveDataFile(options.Output.FullName);
+            program.SaveDataFile(options.Output.FullName, options.Verbose ? MessageHandler : DummyHandler);
 
         return EXIT_SUCCESS;
     }
@@ -638,8 +636,6 @@ public partial class Program : IScriptInterface
         try
         {
             ArgumentNullException.ThrowIfNull(options.ProjectFile);
-            ArgumentNullException.ThrowIfNull(options.Source);
-            ArgumentNullException.ThrowIfNull(options.Destination);
         }
         catch (Exception e)
         {
@@ -647,33 +643,45 @@ public partial class Program : IScriptInterface
             return EXIT_FAILURE;
         }
 
-        // Load source
-        Program program;
-        try
-        {
-            program = new Program(options.Source, options.Verbose);
-        }
-        catch (FileNotFoundException e)
-        {
-            Console.Error.WriteLine(e.Message);
-            return EXIT_FAILURE;
-        }
-
-        program.FilePath = options.Destination.FullName;
-
-        // Load project
         ProjectContext newProjectContext;
         try
         {
-            if (program.Verbose)
+            if (options.Verbose)
                 Console.WriteLine($"Loading project file '{options.ProjectFile.FullName}'");
 
-            newProjectContext = ProjectContext.CreateWithDataFilePaths(options.Source.FullName, options.Destination.FullName, options.ProjectFile.FullName);
+            newProjectContext = ProjectContext.CreateWithLocalOptions(options.ProjectFile.FullName);
 
-            if (program.Verbose)
-                Console.WriteLine($"Importing project into source data file");
+            string loadFilePath = newProjectContext.LoadDataPath;
+            string saveFilePath = newProjectContext.SaveDataPath;
+
+            if (options.Source is not null)
+                loadFilePath = options.Source.FullName;
+            if (options.Destination is not null)
+                saveFilePath = options.Destination.FullName;
+
+            if (loadFilePath is null || saveFilePath is null)
+            {
+                Console.Error.WriteLine($"Source and destination not found in local options and not set in arguments.");
+                return EXIT_FAILURE;
+            }
+
+            if (options.Verbose)
+                Console.WriteLine($"Source: {loadFilePath}\nDestination: {saveFilePath}");
+
+            Program program;
+            program = new Program(new(loadFilePath), options.Verbose);
+            program.FilePath = saveFilePath;
+
+            newProjectContext.SetDataFilePaths(loadFilePath, saveFilePath);
 
             newProjectContext.Import(program.Data);
+
+            program.Project = newProjectContext;
+
+            if (options.Verbose)
+                Console.WriteLine($"Saving to destination data file");
+
+            program.SaveDataFile(saveFilePath, options.Verbose ? MessageHandler : DummyHandler);
         }
         catch (ProjectException e)
         {
@@ -682,17 +690,9 @@ public partial class Program : IScriptInterface
         }
         catch (Exception e)
         {
-            Console.Error.WriteLine($"Error occurred when loading project:\n{e}");
+            Console.Error.WriteLine(e.Message);
             return EXIT_FAILURE;
         }
-
-        program.Project = newProjectContext;
-
-        // Save destination data file
-        if (program.Verbose)
-            Console.WriteLine($"Saving to destination data file");
-
-        program.SaveDataFile(options.Destination.FullName);
 
         return EXIT_SUCCESS;
     }
@@ -753,7 +753,7 @@ public partial class Program : IScriptInterface
                 case ConsoleKey.NumPad3:
                 case ConsoleKey.D3:
                     {
-                        SaveDataFile(FilePath);
+                        SaveDataFile(FilePath, this.Verbose ? MessageHandler : DummyHandler);
                         break;
                     }
 
@@ -763,7 +763,7 @@ public partial class Program : IScriptInterface
                     {
                         Console.Write("Where to save? ");
                         string path = RemoveQuotes(Console.ReadLine());
-                        SaveDataFile(path);
+                        SaveDataFile(path, this.Verbose ? MessageHandler : DummyHandler);
                         break;
                     }
 
@@ -1239,8 +1239,9 @@ public partial class Program : IScriptInterface
     /// Saves the currently loaded <see cref="Data"/> to an output path.
     /// </summary>
     /// <param name="outputPath">The path where to save the data.</param>
+    /// <param name="messageHandler">Handler for messages</param>
     /// <exception cref="IOException">If saving fails</exception>
-    private void SaveDataFile(string outputPath)
+    private void SaveDataFile(string outputPath, UndertaleWriter.MessageHandlerDelegate messageHandler = null)
     {
         if (Verbose)
             Console.WriteLine($"Saving new data file to '{outputPath}'");
@@ -1249,7 +1250,7 @@ public partial class Program : IScriptInterface
             // Save data.win to temp file
             using (FileStream fs = new(outputPath + "temp", FileMode.Create, FileAccess.Write))
             {
-                UndertaleIO.Write(fs, Data, MessageHandler);
+                UndertaleIO.Write(fs, Data, messageHandler);
             }
 
             // If we're executing this, the saving was successful. So we can replace the new temp file
@@ -1276,7 +1277,7 @@ public partial class Program : IScriptInterface
     /// <param name="messageHandler">Handler for messages</param>
     /// <returns></returns>
     /// <exception cref="FileNotFoundException">If the data file cannot be found</exception>
-    private static UndertaleData ReadDataFile(FileInfo datafile, WarningHandlerDelegate warningHandler = null, MessageHandlerDelegate messageHandler = null)
+    private static UndertaleData ReadDataFile(FileInfo datafile, UndertaleReader.WarningHandlerDelegate warningHandler = null, UndertaleReader.MessageHandlerDelegate messageHandler = null)
     {
         try
         {

--- a/UndertaleModLib/Project/ProjectContext.cs
+++ b/UndertaleModLib/Project/ProjectContext.cs
@@ -188,6 +188,37 @@ public sealed partial class ProjectContext
         };
     }
 
+    public static void LoadProjectLocalOptions(string mainFilePath, out string loadFilePath, out string saveFilePath)
+    {
+        string mainDirectory = Path.GetFullPath(Path.GetDirectoryName(mainFilePath));
+        string localFilePath = Path.Join(mainDirectory, "project-local.json");
+
+        ProjectLocalOptions localOptions;
+
+        if (File.Exists(localFilePath))
+        {
+            try
+            {
+                using (FileStream fs = new(localFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    localOptions = JsonSerializer.Deserialize<ProjectLocalOptions>(fs, JsonOptions);
+                }
+
+                loadFilePath = localOptions.DataFilePath.Source;
+                saveFilePath = localOptions.DataFilePath.Destination;
+            }
+            catch (Exception e)
+            {
+                throw new ProjectException($"Failed to load project local options at \"{Path.GetFileName(localFilePath)}\": {e.Message}", e);
+            }
+        }
+        else
+        {
+            loadFilePath = null;
+            saveFilePath = null;
+        }
+    }
+
     /// <summary>
     /// Initializes a project context for a new project based on its main file path, and a name to give to it.
     /// </summary>
@@ -235,8 +266,21 @@ public sealed partial class ProjectContext
         {
             Name = newProjectName
         };
-        using FileStream fs = new(mainFilePath, FileMode.CreateNew);
-        JsonSerializer.Serialize(fs, _mainOptions, JsonOptions);
+        using (FileStream fs = new(mainFilePath, FileMode.CreateNew))
+        {
+            JsonSerializer.Serialize(fs, _mainOptions, JsonOptions);
+        }
+
+        // Create new local options and save it
+        string localFilePath = Path.Join(MainDirectory, "project-local.json");
+        ProjectLocalOptions localOptions = new()
+        {
+            DataFilePath = new(LoadDataPath, SaveDataPath)
+        };
+        using (FileStream fs = new(localFilePath, FileMode.CreateNew))
+        {
+            JsonSerializer.Serialize(fs, localOptions, JsonOptions);
+        }
     }
 
     /// <summary>

--- a/UndertaleModLib/Project/ProjectContext.cs
+++ b/UndertaleModLib/Project/ProjectContext.cs
@@ -40,12 +40,12 @@ public sealed partial class ProjectContext
     /// <summary>
     /// Current directory associated with loading data for this project. Must always be set.
     /// </summary>
-    public string LoadDirectory { get; }
+    public string LoadDirectory { get; private set; }
 
     /// <summary>
     /// Current directory associated with saving data for this project. Must always be set.
     /// </summary>
-    public string SaveDirectory { get; }
+    public string SaveDirectory { get; private set; }
 
     /// <summary>
     /// Current data file path associated with this project, for loading only, or <see langword="null"/> if none is assigned.
@@ -148,6 +148,17 @@ public sealed partial class ProjectContext
     private HashSet<string> _streamedSoundFilenames = null;
 
     /// <summary>
+    /// Initializes a project context based on its existing main file path.
+    /// </summary>
+    /// <param name="mainFilePath">Main file path for the project.</param>
+    private ProjectContext(string mainFilePath)
+    {
+        Data = null;
+        MainFilePath = mainFilePath;
+        MainDirectory = Path.GetFullPath(Path.GetDirectoryName(MainFilePath));
+    }
+
+    /// <summary>
     /// Initializes a project context based on its existing main file path, as well as load/save directories.
     /// </summary>
     /// <param name="loadDirectory">Path of the directory for game data to be loaded from.</param>
@@ -188,10 +199,21 @@ public sealed partial class ProjectContext
         };
     }
 
-    public static void LoadProjectLocalOptions(string mainFilePath, out string loadFilePath, out string saveFilePath)
+    /// <summary>
+    /// Initializes a project context based on its existing main file path and reads the local options file to determine the load/save data file paths.
+    /// <para>If <see cref="LoadDirectory"/> and <see cref="SaveDirectory"/> are null, use <see cref="SetDataFilePaths"/> before performing any other operations.</para>
+    /// </summary>
+    /// <param name="mainFilePath">Main file path for the project.</param>
+    public static ProjectContext CreateWithLocalOptions(string mainFilePath)
     {
-        string mainDirectory = Path.GetFullPath(Path.GetDirectoryName(mainFilePath));
-        string localFilePath = Path.Join(mainDirectory, "project-local.json");
+        var projectContext = new ProjectContext(mainFilePath);
+        projectContext.LoadLocalOptions();
+        return projectContext;
+    }
+
+    private void LoadLocalOptions()
+    {
+        string localFilePath = Path.Join(MainDirectory, "project-local.json");
 
         ProjectLocalOptions localOptions;
 
@@ -204,18 +226,15 @@ public sealed partial class ProjectContext
                     localOptions = JsonSerializer.Deserialize<ProjectLocalOptions>(fs, JsonOptions);
                 }
 
-                loadFilePath = localOptions.DataFilePath.Source;
-                saveFilePath = localOptions.DataFilePath.Destination;
+                LoadDataPath = Path.GetFullPath(localOptions.DataFilePath.Source);
+                SaveDataPath = Path.GetFullPath(localOptions.DataFilePath.Destination);
+                LoadDirectory = Path.GetDirectoryName(LoadDataPath);
+                SaveDirectory = Path.GetDirectoryName(SaveDataPath);
             }
             catch (Exception e)
             {
                 throw new ProjectException($"Failed to load project local options at \"{Path.GetFileName(localFilePath)}\": {e.Message}", e);
             }
-        }
-        else
-        {
-            loadFilePath = null;
-            saveFilePath = null;
         }
     }
 
@@ -283,6 +302,20 @@ public sealed partial class ProjectContext
         }
     }
 
+
+    /// <summary>
+    /// Sets data paths for the project. Must be called if it failed to find them in the local options file before performing any other operations.
+    /// </summary>
+    /// <param name="loadPath">Path of the data file for game data to be loaded from.</param>
+    /// <param name="savePath">Path of the data file for game data to be saved to.</param>
+    public void SetDataFilePaths(string loadPath, string savePath)
+    {
+        LoadDataPath = Path.GetFullPath(loadPath);
+        SaveDataPath = Path.GetFullPath(savePath);
+        LoadDirectory = Path.GetDirectoryName(LoadDataPath);
+        SaveDirectory = Path.GetDirectoryName(SaveDataPath);
+    }
+
     /// <summary>
     /// Imports all of the data of the project.
     /// </summary>
@@ -304,6 +337,12 @@ public sealed partial class ProjectContext
         if (_mainOptions is not null)
         {
             throw new InvalidOperationException("Project has already been imported");
+        }
+
+        // Ensure load and save directories are set
+        if (LoadDirectory is null || SaveDirectory is null)
+        {
+            throw new InvalidOperationException("Project has no save and/or load directories set");
         }
 
         // Set main thread action, if supplied
@@ -517,7 +556,7 @@ public sealed partial class ProjectContext
                     }
                     catch (Exception e)
                     {
-                        _codeSources[code] = 
+                        _codeSources[code] =
                             $"""
                             /*
                             Decompiler failed on project export.

--- a/UndertaleModLib/Project/ProjectLocalOptions.cs
+++ b/UndertaleModLib/Project/ProjectLocalOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UndertaleModLib.Project;
+
+/// <summary>
+/// Represents the local options file for a project.
+/// </summary>
+internal sealed class ProjectLocalOptions
+{
+    /// <summary>
+    /// Path to the load and save data file paths for this project.
+    /// </summary>
+    public ProjectMainOptions.PathList.PathPair DataFilePath { get; set; }
+}

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3947,29 +3947,51 @@ result in loss of work.");
                 return;
             }
 
-            // If necessary, ask for a source data file
-            string dataFilePathToLoad = null;
-            if (Data is null || FilePath is null)
+            // Check project-local.json
+            string mainFilePath = openProjectDialog.FileName;
+            string loadFilePath = null;
+            string saveFilePath = null;
+
+            try
             {
-                OpenFileDialog sourceDialog = new()
-                {
-                    DefaultExt = "win",
-                    Filter = DataFileFilter,
-                    Title = "Choose source data file"
-                };
-                if (sourceDialog.ShowDialog(this) != true)
-                {
-                    return;
-                }
-                dataFilePathToLoad = sourceDialog.FileName;
+                ProjectContext.LoadProjectLocalOptions(mainFilePath, out loadFilePath, out saveFilePath);
+            }
+            catch (ProjectException ex)
+            {
+                this.ShowError(ex.Message, "Failed to load project");
+                return;
             }
 
-            // Ask for save file directory
-            string saveFilePath = ChooseProjectSaveFile(dataFilePathToLoad ?? FilePath);
+            string dataFilePathToLoad = loadFilePath;
+
+            // If necessary, ask for a source data file
+            if (loadFilePath is null)
+            {
+                if (Data is null || FilePath is null)
+                {
+                    OpenFileDialog sourceDialog = new()
+                    {
+                        DefaultExt = "win",
+                        Filter = DataFileFilter,
+                        Title = "Choose source data file"
+                    };
+                    if (sourceDialog.ShowDialog(this) != true)
+                    {
+                        return;
+                    }
+                    dataFilePathToLoad = sourceDialog.FileName;
+                }
+            }
+
+            // If necessary, ask for a destination data file
             if (saveFilePath is null)
             {
-                // Save file prompt failed or was cancelled
-                return;
+                saveFilePath = ChooseProjectSaveFile(dataFilePathToLoad ?? FilePath);
+                if (saveFilePath is null)
+                {
+                    // Save file prompt failed or was cancelled
+                    return;
+                }
             }
 
             // Load data file if needed
@@ -3982,10 +4004,11 @@ result in loss of work.");
                 {
                     return;
                 }
+
+                loadFilePath = FilePath;
             }
 
             // Change main file path to the save data file path
-            string loadFilePath = FilePath;
             FilePath = saveFilePath;
 
             // Attempt loading project from the specific JSON
@@ -3995,7 +4018,7 @@ result in loss of work.");
             {
                 try
                 {
-                    newProjectContext = ProjectContext.CreateWithDataFilePaths(loadFilePath, saveFilePath, openProjectDialog.FileName);
+                    newProjectContext = ProjectContext.CreateWithDataFilePaths(loadFilePath, saveFilePath, mainFilePath);
                     newProjectContext.Import(Data, null, (f) => Dispatcher.Invoke(f));
                 }
                 catch (ProjectException ex)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -3947,14 +3947,13 @@ result in loss of work.");
                 return;
             }
 
-            // Check project-local.json
+            // Set up project
             string mainFilePath = openProjectDialog.FileName;
-            string loadFilePath = null;
-            string saveFilePath = null;
 
+            ProjectContext newProjectContext = null;
             try
             {
-                ProjectContext.LoadProjectLocalOptions(mainFilePath, out loadFilePath, out saveFilePath);
+                newProjectContext = ProjectContext.CreateWithLocalOptions(mainFilePath);
             }
             catch (ProjectException ex)
             {
@@ -3962,13 +3961,22 @@ result in loss of work.");
                 return;
             }
 
+            string loadFilePath = newProjectContext.LoadDataPath;
+            string saveFilePath = newProjectContext.SaveDataPath;
+
             string dataFilePathToLoad = loadFilePath;
 
-            // If necessary, ask for a source data file
+            // If there's no source data file defined
             if (loadFilePath is null)
             {
-                if (Data is null || FilePath is null)
+                if (Data is not null && FilePath is not null)
                 {
+                    // Use currently loaded data file as source data file
+                    loadFilePath = FilePath;
+                }
+                else
+                {
+                    // If there's no loaded data file, ask for a source data file
                     OpenFileDialog sourceDialog = new()
                     {
                         DefaultExt = "win",
@@ -3983,7 +3991,7 @@ result in loss of work.");
                 }
             }
 
-            // If necessary, ask for a destination data file
+            // If there's no destination data file defined
             if (saveFilePath is null)
             {
                 saveFilePath = ChooseProjectSaveFile(dataFilePathToLoad ?? FilePath);
@@ -4011,14 +4019,15 @@ result in loss of work.");
             // Change main file path to the save data file path
             FilePath = saveFilePath;
 
+            // Set project data file paths
+            newProjectContext.SetDataFilePaths(loadFilePath, saveFilePath);
+
             // Attempt loading project from the specific JSON
-            ProjectContext newProjectContext = null;
             IsEnabled = false;
             await Task.Run(() =>
             {
                 try
                 {
-                    newProjectContext = ProjectContext.CreateWithDataFilePaths(loadFilePath, saveFilePath, mainFilePath);
                     newProjectContext.Import(Data, null, (f) => Dispatcher.Invoke(f));
                 }
                 catch (ProjectException ex)


### PR DESCRIPTION
## Description
Adds a new project-local.json file to the project directory. It stores the source and destination files used by the project, making it so you don't need to specify them every time you load a project. This file and its options should not be committed to version control, since it contains your own local paths.

### Caveats
I'm not sure if the structure I did in the code is correct, it feels a bit shoehorned in. Also the new local options class uses PathPair from the main one, so that should probably be moved as well.

### Notes
I'm not sure if this should create a .gitignore since we don't initialize git anyway.