### PR TITLE
add Name.Regex option to GameSpecificResolver

### DIFF
--- a/UndertaleModLib/Decompiler/GameSpecificResolver.cs
+++ b/UndertaleModLib/Decompiler/GameSpecificResolver.cs
@@ -31,6 +31,23 @@ public class GameSpecificResolver
             return ConditionResult.Accept;
         },
 
+        ["Name.Regex"] = (UndertaleData data, string value) =>
+        {
+            string name = data?.GeneralInfo?.Name?.Content;
+            if (name is null)
+            {
+                return ConditionResult.Ignore;
+            }
+
+            Match m = Regex.Match(name, value, RegexOptions.CultureInvariant);
+            if (m.Success)
+            {
+                return ConditionResult.Accept;
+            }
+
+            return ConditionResult.Ignore;
+        },
+
         ["DisplayName.Regex"] = (UndertaleData data, string value) =>
         {
             string displayName = data?.GeneralInfo?.DisplayName?.Content;

--- a/UndertaleModLib/GameSpecificData/Definitions/deltarune.json
+++ b/UndertaleModLib/GameSpecificData/Definitions/deltarune.json
@@ -8,6 +8,10 @@
     {
       "ConditionKind": "DisplayName.Regex",
       "Value": "(?i)^deltarune"
+    },
+    {
+      "ConditionKind": "Name.Regex",
+      "Value": "(?i)^deltarune"
     }
   ],
   "UnderanalyzerFilename": "deltarune.json"


### PR DESCRIPTION
## Description
This adds a `Name.Regex` condition to GameSpecificResolver to allow for GameSpecificData Underanalyzer fixes to be applied to games with a null or otherwise unhelpful DisplayName (e.g. certain console versions of DELTARUNE Chapter 4)

### Caveats
None...?
