### PR TITLE
Mark UndertaleData as DynamicallyAccessedMembers

### DIFF
--- a/UndertaleModLib/UndertaleData.cs
+++ b/UndertaleModLib/UndertaleData.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Underanalyzer.Decompiler;
@@ -19,6 +20,7 @@ namespace UndertaleModLib
     /// It includes all the data within it accessible by either the <see cref="FORM"/>-Chunk attribute,
     /// but also via already organized attributes such as <see cref="Backgrounds"/> or <see cref="GameObjects"/>.
     /// TODO: add more documentation about how a data file works at one point.</remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
     public class UndertaleData : IDisposable
     {
         /// <summary>


### PR DESCRIPTION
I'm using UndertaleModLib in a project that __requires__ trimming enabled (*ahem*[web tool](https://github.com/ngyikp/UndertaleModTool-Web)) and getting trim warnings from various parts of the library. One of them is on UndertaleData as it does a self-reflection for its own properties, so annotate it with DynamicallyAccessedMembers.

Trim warnings:
```
UndertaleModTool/UndertaleModLib/UndertaleData.cs(369,13): Trim analysis warning IL2075: UndertaleModLib.UndertaleData.UndertaleData(): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperties()'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
UndertaleModTool/UndertaleModLib/UndertaleData.cs(696,13): Trim analysis warning IL2075: UndertaleModLib.UndertaleData.Dispose(): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperties()'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
UndertaleModTool/UndertaleModLib/UndertaleData.cs(37,17): Trim analysis warning IL2075: UndertaleModLib.UndertaleData.Item.get: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
UndertaleModTool/UndertaleModLib/UndertaleData.cs(74,17): Trim analysis warning IL2075: UndertaleModLib.UndertaleData.Item.get: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperties()'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
UndertaleModTool/UndertaleModLib/UndertaleData.cs(49,17): Trim analysis warning IL2075: UndertaleModLib.UndertaleData.Item.set: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
UndertaleModTool/UndertaleModLib/UndertaleData.cs(86,17): Trim analysis warning IL2075: UndertaleModLib.UndertaleData.Item.set: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperties()'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```