### PR TITLE
Add bundled script to enable the Dog Shrine on PC & PS

### DIFF
--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -82,6 +82,7 @@ These are scripts developed primarily for use in Undertale/Deltarune.
 - `UndertaleDebugMsg.csx`: Displays the contents of `global.msg` on-screen while debug mode is enabled in Undertale.
 - `UndertaleDebugToggler.csx`: Makes it possible to switch debug mode on and off using F1 in Undertale.
 - `UndertaleDialogSimulator.csx`: Adds a dialogue editor to Undertale.
+- `UndertaleEnableDogShrine.csx`: Enables the Dog Shrine on the PC and PlayStation (when run on PC using a compatible runner) releases of Undertale
 - `UndertaleFixAlphysLabCrashAndroid.csx`: Fixes a crash at Alphys's lab on Android devices in Undertale.
 - `UndertaleGoToRoom.csx`: Adds a debug hotkey to go to a room ID, in Undertale.
 - `UndertaleRunButton.csx`: Removes the debug check from the Backspace hotkey speed boost in Undertale.

--- a/UndertaleModTool/Scripts/UTDR Scripts/UndertaleEnableDogShrine.csx
+++ b/UndertaleModTool/Scripts/UTDR Scripts/UndertaleEnableDogShrine.csx
@@ -1,0 +1,32 @@
+EnsureDataLoaded();
+
+string name = Data.GeneralInfo?.Name?.Content.ToLower();
+if (!name.StartsWith("undertale"))
+{
+    if (name == "nxtale")
+    {
+        ScriptError("This script does not work for the Nintendo Switch or Xbox One version of Undertale.", "Unsupported Version");
+    }
+    else
+    {
+        ScriptError("This script only works for Undertale.", "Unsupported Game");
+    }
+    return;
+}
+
+UndertaleModLib.Compiler.CodeImportGroup importGroup = new(Data)
+{
+    MainThreadAction = MainThreadAction
+};
+
+// Enable the entrance to the Dog Shrine
+importGroup.QueueFindReplace("gml_Object_obj_kitchenchecker_Create_0", "global.osflavor == 4", "true");
+importGroup.QueueFindReplace("gml_Object_obj_kitchenchecker_Alarm_2", "global.osflavor == 4 && ", "");
+
+// Enable the donation box trash in Waterfall
+importGroup.QueueFindReplace("gml_Object_obj_npc_room_Create_0", "global.osflavor != 4 || ", "");
+
+// Disable dogcheck
+importGroup.QueueFindReplace("gml_Object_obj_dogshrine_Step_0", "global.osflavor != 4", "false");
+
+importGroup.Import();


### PR DESCRIPTION
## Description
<!-- A clear, in-depth description of what the changes are. Reference existing issues and add screenshots if necessary! -->

This PR adds a simple CSX script that enables the Dog Shrine on the PC and PlayStation (when run with a compatible runner on PC) releases of Undertale.

### Caveats
<!-- Any caveats, side effects or regressions of this PR -->

There isn't any that I'm aware of.

### Notes
<!-- Any notes or closing words -->

Many thanks to the authors of the `UndertaleSwitchAndXboxOnPC.csx` script, which served as a great reference; and the [UndertaleVersionSwitcher](https://github.com/Jacky720/UndertaleVersionSwitcher) project, which enabled me to experiment with the PS versions of the game.

This is my first time contributing to the project, so if there's anything I've missed, please be sure to let me know. Thanks!