### PR TITLE
Fixes and improvements for "Find all references" feature

### DIFF
--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/FindReferencesTypesDialog.xaml.cs
@@ -86,18 +86,12 @@ namespace UndertaleModTool.Windows
                 return;
             }
 
-            GameVersion ver;
-            if (data.GeneralInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
-                ver = (2022, 0, 0);
-            else
-                ver = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
-            var sourceTypes = UndertaleResourceReferenceMap.GetReferenceableTypes(ver);
+            GameVersion version = new(data.GeneralInfo);
+            bool isYYC = data.Code is null; // There is `UndertaleData.IsYYC()`, but it also checks for general info
+            var sourceTypes = UndertaleResourceReferenceMap.GetReferenceableTypes(version, isYYC);
 
             foreach (var typePair in sourceTypes)
             {
-                if (data.Code is null && UndertaleResourceReferenceMap.CodeTypes.Contains(typePair.Key))
-                    continue;
-
                 TypesList.Items.Add(new CheckBox()
                 {
                     DataContext = typePair.Key,

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -7,41 +7,55 @@ using UndertaleModLib.Models;
 
 namespace UndertaleModTool.Windows
 {
-    public record GameVersion(uint Major, uint Minor, uint Release) : IComparable<GameVersion>
+    public readonly record struct GameVersion((uint Major, uint Minor, uint Release)? GameMakerVersion = null,
+                                              byte? BytecodeVersion = null)
+        : IComparable<GameVersion>
     {
-        public GameVersion(UndertaleGeneralInfo gameInfo) : this(gameInfo.Major, gameInfo.Minor, gameInfo.Release)
+        public GameVersion() : this(null, null)
+        {
+            throw new InvalidOperationException("At least one version (GameMaker or bytecode) must be specified.");
+        }
+        public GameVersion(byte bytecodeVersion) : this(null, bytecodeVersion)
+        {
+        }
+        public GameVersion(UndertaleGeneralInfo gameInfo)
+            : this((gameInfo.Major, gameInfo.Minor, gameInfo.Release), gameInfo.BytecodeVersion)
         {
             if (gameInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
-            {
-                Major = 2022;
-                Minor = 0;
-                Release = 0;
-            } 
+                GameMakerVersion = (2022, 0, 0);
         }
+
+        public bool HasGMVersion => GameMakerVersion.HasValue;
+        public bool HasBytecodeVersion => BytecodeVersion.HasValue;
 
         public static implicit operator GameVersion((uint, uint, uint) verTuple)
         {
-            return new(verTuple.Item1, verTuple.Item2, verTuple.Item3);
+            return new(verTuple);
         }
 
         public int CompareTo(GameVersion other)
         {
-            int cmp = Major.CompareTo(other.Major);
-            if (cmp != 0)
-                return cmp;
+            bool compareGMVer = HasGMVersion && other.HasGMVersion;
+            bool compareBytecodeVer = HasBytecodeVersion && other.HasBytecodeVersion;
 
-            cmp = Minor.CompareTo(other.Minor);
-            if (cmp != 0)
-                return cmp;
+            if (!compareGMVer && !compareBytecodeVer)
+                throw new InvalidOperationException("No common version to compare (GameMaker or bytecode)");
 
-            return Release.CompareTo(other.Release);
+            if (compareGMVer)
+            {
+                int gmCompare = GameMakerVersion.Value.CompareTo(other.GameMakerVersion.Value);
+                if (gmCompare != 0 || !compareBytecodeVer)
+                    return gmCompare;
+            }
+
+            return BytecodeVersion.Value.CompareTo(other.BytecodeVersion.Value);
         }
     }
 
     public class TypesForVersion
     {
         public GameVersion Version { get; set; }
-        public GameVersion BeforeVersion { get; set; } = new(uint.MaxValue, uint.MaxValue, uint.MaxValue);
+        public GameVersion BeforeVersion { get; set; } = new((uint.MaxValue, uint.MaxValue, uint.MaxValue), byte.MaxValue);
         public (Type, string)[] Types { get; set; }
     }
 
@@ -217,7 +231,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         // Bytecode version 14
-                        Version = (14, uint.MaxValue, uint.MaxValue),
+                        Version = new(14),
                         Types = new[]
                         {
                             (typeof(UndertaleAudioGroup), "Audio groups")
@@ -226,7 +240,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         // Bytecode version 15
-                        Version = (15, uint.MaxValue, uint.MaxValue),
+                        Version = new(15),
                         BeforeVersion = (2024, 8, 0),
                         Types = new[]
                         {
@@ -236,7 +250,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         // Bytecode version 16
-                        Version = (16, uint.MaxValue, uint.MaxValue),
+                        Version = new(16),
                         Types = new[]
                         {
                             (typeof(UndertaleLanguage), "Languages"),
@@ -354,7 +368,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion()
                     {
                         // Bytecode version 16
-                        Version = (16, uint.MaxValue, uint.MaxValue),
+                        Version = new(16),
                         Types = new[]
                         {
                             (typeof(UndertaleRoom.GameObject), "Room object instances (creation or pre create code)")
@@ -383,7 +397,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion()
                     {
                         // Bytecode version 14
-                        Version = (14, uint.MaxValue, uint.MaxValue),
+                        Version = new(14),
                         Types = new[]
                         {
                             (typeof(UndertaleSound), "Sounds")
@@ -478,7 +492,7 @@ namespace UndertaleModTool.Windows
             { typeof(UndertaleFunction), ("Functions", (1, 0, 0)) },
             { typeof(UndertaleVariable), ("Variables", (1, 0, 0)) },
             { typeof(UndertaleEmbeddedAudio), ("Embedded audio", (1, 0, 0)) },
-            { typeof(UndertaleAudioGroup), ("Audio groups", (14, uint.MaxValue, uint.MaxValue)) }, // Bytecode version 14
+            { typeof(UndertaleAudioGroup), ("Audio groups", new(14)) }, // Bytecode version 14
             { typeof(UndertaleParticleSystem), ("Particle systems", (2023, 2, 0)) },
             { typeof(UndertaleParticleSystemEmitter), ("Particle system emitters", (2023, 2, 0)) }
         };
@@ -500,22 +514,12 @@ namespace UndertaleModTool.Windows
                 return null;
 
             GameVersion version = new(data.GeneralInfo);
-            byte bytecodeVersion = data.GeneralInfo.BytecodeVersion;
 
             IEnumerable<(Type, string)> outTypes = Enumerable.Empty<(Type, string)>();
             foreach (var typeForVer in typesForVer)
             {
-                bool isAtLeast = false;
-                if (typeForVer.Version.Minor == uint.MaxValue)
-                    isAtLeast = typeForVer.Version.Major <= bytecodeVersion;
-                else
-                    isAtLeast = typeForVer.Version.CompareTo(version) <= 0;
-
-                bool isAboveMost = false;
-                if (typeForVer.BeforeVersion.Minor == uint.MaxValue)
-                    isAboveMost = typeForVer.BeforeVersion.Major <= bytecodeVersion;
-                else
-                    isAboveMost = typeForVer.BeforeVersion.CompareTo(version) <= 0;
+                bool isAtLeast = typeForVer.Version.CompareTo(version) <= 0;
+                bool isAboveMost = typeForVer.BeforeVersion.CompareTo(version) <= 0;
 
                 if (isAtLeast && !isAboveMost)
                     outTypes = typeForVer.Types.UnionBy(outTypes, x => x.Item1);

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -9,6 +9,16 @@ namespace UndertaleModTool.Windows
 {
     public record GameVersion(uint Major, uint Minor, uint Release) : IComparable<GameVersion>
     {
+        public GameVersion(UndertaleGeneralInfo gameInfo) : this(gameInfo.Major, gameInfo.Minor, gameInfo.Release)
+        {
+            if (gameInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
+            {
+                Major = 2022;
+                Minor = 0;
+                Release = 0;
+            } 
+        }
+
         public static implicit operator GameVersion((uint, uint, uint) verTuple)
         {
             return new(verTuple.Item1, verTuple.Item2, verTuple.Item3);
@@ -489,11 +499,7 @@ namespace UndertaleModTool.Windows
             if (!typeMap.TryGetValue(type, out TypesForVersion[] typesForVer))
                 return null;
 
-            GameVersion version;
-            if (data.GeneralInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
-                version = (2022, 0, 0);
-            else
-                version = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
+            GameVersion version = new(data.GeneralInfo);
             byte bytecodeVersion = data.GeneralInfo.BytecodeVersion;
 
             IEnumerable<(Type, string)> outTypes = Enumerable.Empty<(Type, string)>();

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -500,7 +500,7 @@ namespace UndertaleModTool.Windows
             { typeof(UndertaleParticleSystemEmitter), ("Particle system emitters", (2023, 2, 0)) }
         };
         private static Dictionary<Type, string> referenceableTypes;
-        private static GameVersion currVersion;
+        private static (GameVersion Version, bool IsYYC) currVerState;
         
         public static readonly HashSet<Type> CodeTypes = new()
         {
@@ -538,7 +538,8 @@ namespace UndertaleModTool.Windows
 
         public static Dictionary<Type, string> GetReferenceableTypes(GameVersion version, bool isYYC)
         {
-            if (version == currVersion && currVersion != default)
+            if (version == currVerState.Version && currVerState != default
+                && isYYC == currVerState.IsYYC)
                 return referenceableTypes;
 
             // Filter out code-related types, because YYC game = no code in "data.win"
@@ -550,7 +551,7 @@ namespace UndertaleModTool.Windows
 
             referenceableTypes = typesOrigSrc.Where(x => x.Value.Item2.CompareTo(version) <= 0)
                                              .ToDictionary(x => x.Key, x => x.Value.Item1);
-            currVersion = version;
+            currVerState = (version, isYYC);
 
             if (referenceableTypes.Count == 0)
                 return referenceableTypes;

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -15,17 +15,17 @@ namespace UndertaleModTool.Windows
         }
 
         public int CompareTo(GameVersion other)
-		{
-			int cmp = Major.CompareTo(other.Major);
-			if (cmp != 0)
+        {
+            int cmp = Major.CompareTo(other.Major);
+            if (cmp != 0)
                 return cmp;
 
-			cmp = Minor.CompareTo(other.Minor);
-			if (cmp != 0)
+            cmp = Minor.CompareTo(other.Minor);
+            if (cmp != 0)
                 return cmp;
 
-			return Release.CompareTo(other.Release);
-		}
+            return Release.CompareTo(other.Release);
+        }
     }
 
     public class TypesForVersion
@@ -188,7 +188,6 @@ namespace UndertaleModTool.Windows
                             (typeof(UndertaleVariable), "Variables"),
                             (typeof(UndertaleFunction), "Functions"),
                             (typeof(UndertaleSound), "Sounds"),
-                            (typeof(UndertaleAudioGroup), "Audio groups"),
                             (typeof(UndertaleSprite), "Sprites"),
                             (typeof(UndertaleExtension), "Extensions"),
                             (typeof(UndertaleExtensionFile), "Extension files"),
@@ -203,6 +202,15 @@ namespace UndertaleModTool.Windows
                             (typeof(UndertaleScript), "Scripts"),
                             (typeof(UndertaleShader), "Shaders"),
                             (typeof(UndertaleTimeline), "Timelines")
+                        }
+                    },
+                    new TypesForVersion
+                    {
+                        // Bytecode version 14
+                        Version = (14, uint.MaxValue, uint.MaxValue),
+                        Types = new[]
+                        {
+                            (typeof(UndertaleAudioGroup), "Audio groups")
                         }
                     },
                     new TypesForVersion
@@ -364,7 +372,8 @@ namespace UndertaleModTool.Windows
                 {
                     new TypesForVersion()
                     {
-                        Version = (1, 0, 0),
+                        // Bytecode version 14
+                        Version = (14, uint.MaxValue, uint.MaxValue),
                         Types = new[]
                         {
                             (typeof(UndertaleSound), "Sounds")
@@ -459,7 +468,7 @@ namespace UndertaleModTool.Windows
             { typeof(UndertaleFunction), ("Functions", (1, 0, 0)) },
             { typeof(UndertaleVariable), ("Variables", (1, 0, 0)) },
             { typeof(UndertaleEmbeddedAudio), ("Embedded audio", (1, 0, 0)) },
-            { typeof(UndertaleAudioGroup), ("Audio groups", (1, 0, 0)) },
+            { typeof(UndertaleAudioGroup), ("Audio groups", (14, uint.MaxValue, uint.MaxValue)) }, // Bytecode version 14
             { typeof(UndertaleParticleSystem), ("Particle systems", (2023, 2, 0)) },
             { typeof(UndertaleParticleSystemEmitter), ("Particle system emitters", (2023, 2, 0)) }
         };

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -24,9 +24,9 @@ namespace UndertaleModTool.Windows
             // The asset types that were introduced in GM 2023+ are not available in LTS 2022.
             // It seems obvious, but the general info says that it's a GM 2023+ for a LTS 2022 game.
             // For example, particle systems - they are missing in LTS 2022, even if the general info says it's GM 2023.6.
-            // So we treat that version as GM 2022.0, as it should be
+            // So we treat that version as GM 2022.9, as it should be
             if (gameInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
-                GameMakerVersion = (2022, 0, 0);
+                GameMakerVersion = (2022, 9, 0);
         }
 
         public bool HasGMVersion => GameMakerVersion.HasValue;

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMap.cs
@@ -21,6 +21,10 @@ namespace UndertaleModTool.Windows
         public GameVersion(UndertaleGeneralInfo gameInfo)
             : this((gameInfo.Major, gameInfo.Minor, gameInfo.Release), gameInfo.BytecodeVersion)
         {
+            // The asset types that were introduced in GM 2023+ are not available in LTS 2022.
+            // It seems obvious, but the general info says that it's a GM 2023+ for a LTS 2022 game.
+            // For example, particle systems - they are missing in LTS 2022, even if the general info says it's GM 2023.6.
+            // So we treat that version as GM 2022.0, as it should be
             if (gameInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
                 GameMakerVersion = (2022, 0, 0);
         }
@@ -111,6 +115,7 @@ namespace UndertaleModTool.Windows
                     new TypesForVersion
                     {
                         Version = (1, 0, 0),
+                        BeforeVersion = (2, 0, 0),
                         Types = new[]
                         {
                             (typeof(UndertaleRoom.Background), "Room backgrounds"),
@@ -122,8 +127,6 @@ namespace UndertaleModTool.Windows
                         Version = (2, 0, 0),
                         Types = new[]
                         {
-                            (typeof(UndertaleRoom.Background), null),
-                            (typeof(UndertaleRoom.Tile), null),
                             (typeof(UndertaleRoom.Layer), "Room tile layers")
                         }
                     },
@@ -518,8 +521,8 @@ namespace UndertaleModTool.Windows
             IEnumerable<(Type, string)> outTypes = Enumerable.Empty<(Type, string)>();
             foreach (var typeForVer in typesForVer)
             {
-                bool isAtLeast = typeForVer.Version.CompareTo(version) <= 0;
-                bool isAboveMost = typeForVer.BeforeVersion.CompareTo(version) <= 0;
+                bool isAtLeast = version.CompareTo(typeForVer.Version) >= 0;
+                bool isAboveMost = version.CompareTo(typeForVer.BeforeVersion) >= 0;
 
                 if (isAtLeast && !isAboveMost)
                     outTypes = typeForVer.Types.UnionBy(outTypes, x => x.Item1);
@@ -533,13 +536,20 @@ namespace UndertaleModTool.Windows
                            .ToArray();
         }
 
-        public static Dictionary<Type, string> GetReferenceableTypes(GameVersion version)
+        public static Dictionary<Type, string> GetReferenceableTypes(GameVersion version, bool isYYC)
         {
             if (version == currVersion && currVersion != default)
                 return referenceableTypes;
 
-            referenceableTypes = referenceableTypesOrig.Where(x => x.Value.Item2.CompareTo(version) <= 0)
-                                                       .ToDictionary(x => x.Key, x => x.Value.Item1);
+            // Filter out code-related types, because YYC game = no code in "data.win"
+            IEnumerable<KeyValuePair<Type, (string, GameVersion)>> typesOrigSrc;
+            if (isYYC)
+                typesOrigSrc = referenceableTypesOrig.ExceptBy(CodeTypes, x => x.Key);
+            else
+                typesOrigSrc = referenceableTypesOrig;
+
+            referenceableTypes = typesOrigSrc.Where(x => x.Value.Item2.CompareTo(version) <= 0)
+                                             .ToDictionary(x => x.Key, x => x.Value.Item1);
             currVersion = version;
 
             if (referenceableTypes.Count == 0)
@@ -557,6 +567,40 @@ namespace UndertaleModTool.Windows
                 return false;
 
             return typeMap.ContainsKey(type);
+        }
+
+        public static HashSet<Type> GetSupportedReferenceTypes(GameVersion version, bool isYYC)
+        {
+            HashSet<Type> supportedTypes = new();
+
+            // Filter out code-related input types, because YYC game = no code in "data.win"
+            IEnumerable<TypesForVersion[]> typeMapSrc;
+            if (isYYC)
+                typeMapSrc = typeMap.ExceptBy(CodeTypes, x => x.Key).Select(x => x.Value);
+            else
+                typeMapSrc = typeMap.Values;
+
+            foreach (var versions in typeMapSrc)
+            {
+                foreach (var typesForVersion in versions)
+                {
+                    bool isAtLeast = version.CompareTo(typesForVersion.Version) >= 0;
+                    bool isAboveMost = version.CompareTo(typesForVersion.BeforeVersion) >= 0;
+
+                    if (!isAtLeast || isAboveMost)
+                        continue;
+
+                    foreach ((Type type, string displayName) in typesForVersion.Types)
+                    {
+                        if (isYYC && CodeTypes.Contains(type))
+                            continue;
+
+                        supportedTypes.Add(type);
+                    }
+                }
+            }
+
+            return supportedTypes;
         }
     }
 }

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1651,6 +1651,10 @@ namespace UndertaleModTool.Windows
             if (outDict.Count == 0)
                 return null;
 
+            // Sort the output dictionary by the asset type name, for consistent order
+            outDict = outDict.OrderBy(x => x.Key)
+                             .ToDictionary(x => x.Key, x => x.Value);
+
             return outDict;
         }
 
@@ -1660,6 +1664,7 @@ namespace UndertaleModTool.Windows
 
             Dictionary<string, List<object>> outDict = new();
 
+            Dictionary<object, int> assetIndexes = new();
             List<(IList, string)> assetLists = new();
             foreach (var typePair in typesDict)
             {
@@ -1668,10 +1673,16 @@ namespace UndertaleModTool.Windows
 
                 assetLists.Add((resList, typePair.Value));
             }
-            List<(UndertaleResource, string)> assets = new(assetLists.Select(x => x.Item1.Count).Sum());
+            List<(UndertaleResource, string)> assets = new(assetLists.Sum(x => x.Item1.Count));
             foreach (var list in assetLists)
-                assets.AddRange(list.Item1.Cast<UndertaleResource>()
-                                          .Select(x => (x, list.Item2)));
+            {
+                for (int i = 0; i < list.Item1.Count; i++)
+                {
+                    var asset = list.Item1[i];
+                    assetIndexes[asset] = i;
+                    assets.Add(((UndertaleResource)asset, list.Item2));
+                }
+            }
 
             // If it's not a YYC game
             if (data.Code is not null)
@@ -1712,7 +1723,7 @@ namespace UndertaleModTool.Windows
                 mainWindow.SetProgressBar(null, "Assets", 0, assets.Count);
                 mainWindow.StartProgressBarUpdater();
 
-                List<Dictionary<string, List<object>>> dicts = new();
+                ConcurrentBag<Dictionary<string, List<object>>> dicts = new();
 
                 if (assets.Count > 0) // A Partitioner can't be created on an empty list.
                 {
@@ -1787,6 +1798,18 @@ namespace UndertaleModTool.Windows
                         }
                     }
                 }
+
+                // Sort each asset list by the asset ID (the index in the source asset list)
+                foreach (var assetList in outDict.Values)
+                {
+                    assetList.Sort((left, right) => {
+                        return assetIndexes[left].CompareTo(assetIndexes[right]);
+                    });
+                }
+
+                // Also sort the output dictionary by the asset type name (so the asset group order is also consistent)
+                outDict = outDict.OrderBy(x => x.Key)
+                                 .ToDictionary(x => x.Key, x => x.Value);
             }
             finally
             {

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -14,51 +14,27 @@ namespace UndertaleModTool.Windows
 {
     public class HashSetTypesOverride : HashSet<Type>
     {
-        private static bool containsEverything, isYYC;
-        private static Dictionary<Type, PredicateForVersion[]> typeMap;
-        private static UndertaleData gameData;
-        private static GameVersion gameVersion;
-        private static byte bytecodeVer;
+        private static bool containsEverything;
+        private static HashSet<Type> supportedTypes;
 
-        public static void MakeContainEverything(UndertaleData gameData, Dictionary<Type, PredicateForVersion[]> typeMap)
+        public static void MakeContainEverything(GameVersion version, bool isYYC)
         {
             containsEverything = true;
-            HashSetTypesOverride.typeMap = typeMap;
-            HashSetTypesOverride.gameData = gameData;
-
-            if (gameData is null)
-                return;
-
-            isYYC = gameData.Code is null;
-            gameVersion = new(gameData.GeneralInfo);
-            bytecodeVer = gameData.GeneralInfo.BytecodeVersion;
-        }
-
-        private static bool IsTypeSupported(Type assetType)
-        {
-            if (typeMap is null || gameVersion == default)
-                return false;
-
-            // TODO
-            throw new NotImplementedException();
+            supportedTypes = UndertaleResourceReferenceMap.GetSupportedReferenceTypes(version, isYYC);
         }
 
         public new bool Contains(Type item)
         {
-            if (!containsEverything)
-                return base.Contains(item);
+            if (containsEverything)
+                return supportedTypes.Contains(item);
 
-            return !isYYC || !UndertaleResourceReferenceMap.CodeTypes.Contains(item)
-                   || IsTypeSupported(item);
+            return base.Contains(item);
         }
 
         public static void Restore()
         {
             containsEverything = false;
-            gameData = null;
-            isYYC = false;
-            gameVersion = default;
-            bytecodeVer = 0;
+            supportedTypes = null;
         }
     }
 
@@ -68,7 +44,6 @@ namespace UndertaleModTool.Windows
 
         public GameVersion Version { get; set; }
         public GameVersion BeforeVersion { get; set; } = new((uint.MaxValue, uint.MaxValue, uint.MaxValue), byte.MaxValue);
-        public bool DisableForLTS2022 { get; set; } = false;
         public PredicateDelegate Predicate { get; set; }
     }
 
@@ -213,8 +188,7 @@ namespace UndertaleModTool.Windows
                     },
                     new PredicateForVersion()
                     {
-                        Version = (2023, 2, 0),
-                        DisableForLTS2022 = true,
+                        Version = (2023, 2, 0), // Not present if it's LTS 2022
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleParticleSystemEmitter)))
@@ -1072,8 +1046,7 @@ namespace UndertaleModTool.Windows
                     },
                     new PredicateForVersion()
                     {
-                        Version = (2023, 2, 0),
-                        DisableForLTS2022 = true,
+                        Version = (2023, 2, 0), // Not present if it's LTS 2022
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (objSrc is not UndertaleString obj)
@@ -1549,8 +1522,7 @@ namespace UndertaleModTool.Windows
                 {
                     new PredicateForVersion()
                     {
-                        Version = (2023, 2, 0),
-                        DisableForLTS2022 = true,
+                        Version = (2023, 2, 0), // Not present if it's LTS 2022
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.ParticleSystemInstance)))
@@ -1590,8 +1562,7 @@ namespace UndertaleModTool.Windows
                 {
                     new PredicateForVersion()
                     {
-                        Version = (2023, 2, 0),
-                        DisableForLTS2022 = true,
+                        Version = (2023, 2, 0), // Not present if it's LTS 2022
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (objSrc is not UndertaleParticleSystemEmitter obj)
@@ -1622,9 +1593,25 @@ namespace UndertaleModTool.Windows
             }
         };
 
+        public static void SetCurrentGameData(UndertaleData data)
+        {
+            UndertaleResourceReferenceMethodsMap.data = data;
+        }
+        public static void ClearCurrentGameData()
+        {
+            UndertaleResourceReferenceMethodsMap.data = null;
+        }
 
-
+        // For singular use, sets and clears the current game data.
         public static Dictionary<string, List<object>> GetReferencesOfObject(object obj, UndertaleData data, HashSetTypesOverride types, bool checkOne = false)
+        {
+            SetCurrentGameData(data);
+            var result = GetReferencesOfObject(obj, types, checkOne);
+            ClearCurrentGameData();
+
+            return result;
+        }
+        public static Dictionary<string, List<object>> GetReferencesOfObject(object obj, HashSetTypesOverride types, bool checkOne = false)
         {
             if (obj is null)
                 return null;
@@ -1632,37 +1619,31 @@ namespace UndertaleModTool.Windows
             if (!typeMap.TryGetValue(obj.GetType(), out PredicateForVersion[] predicatesForVer))
                 return null;
 
-            UndertaleResourceReferenceMethodsMap.data = data;
-
             bool onlyEmptyResult = true;
 
             GameVersion ver = new(data.GeneralInfo);
             Dictionary<string, List<object>> outDict = new();
             foreach (var predicateForVer in predicatesForVer)
             {
-                bool isAtLeast = predicateForVer.Version.CompareTo(ver) <= 0;
-                bool isAboveMost = predicateForVer.BeforeVersion.CompareTo(ver) <= 0;
+                bool isAtLeast = ver.CompareTo(predicateForVer.Version) >= 0;
+                bool isAboveMost = ver.CompareTo(predicateForVer.BeforeVersion) >= 0;
 
-                bool disableDueToLTS = false;
-                if (data.GeneralInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)
-                    disableDueToLTS = predicateForVer.DisableForLTS2022;
+                if (!isAtLeast || isAboveMost)
+                    continue;
 
-                if (isAtLeast && !isAboveMost && !disableDueToLTS)
+                var result = predicateForVer.Predicate(obj, types, checkOne);
+                if (result is null)
                 {
-                    var result = predicateForVer.Predicate(obj, types, checkOne);
-                    if (result is null)
-                    {
-                        onlyEmptyResult = false;
-                        continue;
-                    }
-                    if (onlyEmptyResult && result == emptyResultArr)
-                        continue;
-
                     onlyEmptyResult = false;
+                    continue;
+                }
+                if (onlyEmptyResult && result == emptyResultArr)
+                    continue;
 
-                    foreach (var entry in result)
-                        outDict.Add(entry.Key, new(entry.Value));
-                }  
+                onlyEmptyResult = false;
+
+                foreach (var entry in result)
+                    outDict.Add(entry.Key, new(entry.Value));
             }
 
             if (onlyEmptyResult)
@@ -1675,7 +1656,7 @@ namespace UndertaleModTool.Windows
 
         public static async Task<Dictionary<string, List<object>>> GetUnreferencedObjects(UndertaleData data, Dictionary<Type, string> typesDict)
         {
-            UndertaleResourceReferenceMethodsMap.data = data;
+            SetCurrentGameData(data);
 
             Dictionary<string, List<object>> outDict = new();
 
@@ -1733,7 +1714,9 @@ namespace UndertaleModTool.Windows
                 {
                     ignoreArgumentsVar = true;
 
-                    HashSetTypesOverride.MakeContainEverything(data, typeMap);
+                    GameVersion version = new(data.GeneralInfo);
+                    bool isYYC = data.Code is null;
+                    HashSetTypesOverride.MakeContainEverything(version, isYYC);
 
                     var assetsPart = Partitioner.Create(0, assets.Count);
 
@@ -1746,7 +1729,7 @@ namespace UndertaleModTool.Windows
                             for (int i = range.Item1; i < range.Item2; i++)
                             {
                                 var asset = assets[i];
-                                var assetReferences = GetReferencesOfObject(asset.Item1, data, new HashSetTypesOverride(), true);
+                                var assetReferences = GetReferencesOfObject(asset.Item1, new HashSetTypesOverride(), true);
                                 if (assetReferences is null)
                                 {
                                     if (resultDict.TryGetValue(asset.Item2, out var list))
@@ -1810,7 +1793,8 @@ namespace UndertaleModTool.Windows
                 stringReferences = null;
                 funcReferences = null;
                 variReferences = null;
-
+                
+                ClearCurrentGameData();
                 HashSetTypesOverride.Restore();
             }
 

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -64,10 +64,12 @@ namespace UndertaleModTool.Windows
 
     public class PredicateForVersion
     {
+        public delegate Dictionary<string, object[]> PredicateDelegate(object objSrc, HashSetTypesOverride types, bool checkOne);
+
         public GameVersion Version { get; set; }
         public GameVersion BeforeVersion { get; set; } = new((uint.MaxValue, uint.MaxValue, uint.MaxValue), byte.MaxValue);
         public bool DisableForLTS2022 { get; set; } = false;
-        public Func<object, HashSetTypesOverride, bool, Dictionary<string, object[]>> Predicate { get; set; }
+        public PredicateDelegate Predicate { get; set; }
     }
 
     public static class UndertaleResourceReferenceMethodsMap

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -820,17 +820,24 @@ namespace UndertaleModTool.Windows
                                     outDict["Sequences"] = checkOne ? sequences.ToEmptyArray() : sequences.ToArray();
                             }
 
-                            // TODO: make these "IEnumerable<object[]>"
+                            // TODO: make these "IEnumerable<object[]>"?
                             List<object[]> sequenceTracks = new();
                             List<object[]> seqStringKeyframes = new();
                             void ProcessTrack(UndertaleSequence seq, Track track, List<object> trackChain)
                             {
+                                if (checkOne && (sequenceTracks.Count > 0 || seqStringKeyframes.Count > 0))
+                                    return; // Stop recursion, we already found one reference
+
                                 trackChain = new(trackChain);
                                 trackChain.Insert(0, track);
                                 if (types.Contains(typeof(Track)))
                                 {
                                     if (track.Name == obj || track.ModelName == obj)
+                                    {
                                         sequenceTracks.Add(trackChain.Append(seq).ToArray());
+                                        if (checkOne)
+                                            return; // No need for getting all of the references
+                                    }
                                 }
 
                                 if (types.Contains(typeof(StringKeyframes)))
@@ -842,14 +849,22 @@ namespace UndertaleModTool.Windows
                                             foreach (var strPair in keyframe.Channels)
                                             {
                                                 if (strPair.Value.Value == obj)
+                                                {
                                                     seqStringKeyframes.Add(new object[] { strPair.Channel }.Concat(trackChain).Append(seq).ToArray());
+                                                    if (checkOne)
+                                                        return; // No need for getting all of the references
+                                                }
                                             }
                                         }
                                     }
                                 }
 
                                 foreach (var subTrack in track.Tracks)
+                                {
                                     ProcessTrack(seq, subTrack, trackChain);
+                                    if (checkOne && (sequenceTracks.Count > 0 || seqStringKeyframes.Count > 0))
+                                        return;
+                                }
                             };
                             foreach (var seq in data.Sequences.SkipNullItems())
                             {
@@ -857,6 +872,8 @@ namespace UndertaleModTool.Windows
                                 {
                                     List<object> trackChain = new();
                                     ProcessTrack(seq, track, trackChain);
+                                    if (checkOne && (sequenceTracks.Count > 0 || seqStringKeyframes.Count > 0))
+                                        break;
                                 }
                             }
                             if (sequenceTracks.Count > 0)
@@ -968,10 +985,13 @@ namespace UndertaleModTool.Windows
                             if (objSrc is not UndertaleString obj)
                                 return null;
 
-                            // TODO: make this "IEnumerable<object[]>"
+                            // TODO: make this "IEnumerable<object[]>"?
                             List<object[]> textKeyframesList = new();
                             void ProcessTrack(UndertaleSequence seq, Track track, List<object> trackChain)
                             {
+                                if (checkOne && textKeyframesList.Count > 0)
+                                    return; // Stop recursion, we already found one reference
+
                                 trackChain = new(trackChain);
                                 trackChain.Insert(0, track);
 
@@ -980,13 +1000,23 @@ namespace UndertaleModTool.Windows
                                     foreach (var keyframe in textKeyframes.List)
                                     {
                                         foreach (var textPair in keyframe.Channels)
+                                        {
                                             if (textPair.Value.Text == obj)
+                                            {
                                                 textKeyframesList.Add(new object[] { textPair.Channel }.Concat(trackChain).Append(seq).ToArray());
+                                                if (checkOne)
+                                                    return; // No need for getting all of the references
+                                            }
+                                        }
                                     }
                                 }
 
                                 foreach (var subTrack in track.Tracks)
+                                {
                                     ProcessTrack(seq, subTrack, trackChain);
+                                    if (checkOne && textKeyframesList.Count > 0)
+                                        return;
+                                }
                             };
 
                             foreach (var seq in data.Sequences.SkipNullItems())
@@ -995,6 +1025,8 @@ namespace UndertaleModTool.Windows
                                 {
                                     List<object> trackChain = new();
                                     ProcessTrack(seq, track, trackChain);
+                                    if (checkOne && textKeyframesList.Count > 0)
+                                        break;
                                 }
                             }
                             if (textKeyframesList.Count > 0)
@@ -1130,10 +1162,13 @@ namespace UndertaleModTool.Windows
                             if (objSrc is not UndertaleGameObject obj)
                                 return null;
 
-                            // TODO: make this "IEnumerable<object[]>"
+                            // TODO: make this "IEnumerable<object[]>"?
                             List<object[]> instKeyframesList = new();
                             void ProcessTrack(UndertaleSequence seq, Track track, List<object> trackChain)
                             {
+                                if (checkOne && instKeyframesList.Count > 0)
+                                    return; // Stop recursion, we already found one reference
+
                                 trackChain = new(trackChain);
                                 trackChain.Insert(0, track);
 
@@ -1143,12 +1178,20 @@ namespace UndertaleModTool.Windows
                                     {
                                         foreach (var instPair in keyframe.Channels)
                                             if (instPair.Value.Resource.Resource == obj)
+                                            {
                                                 instKeyframesList.Add(new object[] { instPair.Channel }.Concat(trackChain).Append(seq).ToArray());
+                                                if (checkOne)
+                                                    return; // No need for getting all of the references
+                                            }
                                     }
                                 }
 
                                 foreach (var subTrack in track.Tracks)
+                                {
                                     ProcessTrack(seq, subTrack, trackChain);
+                                    if (checkOne && instKeyframesList.Count > 0)
+                                        return;
+                                }
                             };
 
                             foreach (var seq in data.Sequences.SkipNullItems())
@@ -1157,6 +1200,8 @@ namespace UndertaleModTool.Windows
                                 {
                                     List<object> trackChain = new();
                                     ProcessTrack(seq, track, trackChain);
+                                    if (checkOne && instKeyframesList.Count > 0)
+                                        break;
                                 }
                             }
                             if (instKeyframesList.Count > 0)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -36,7 +36,7 @@ namespace UndertaleModTool.Windows
 
         private static bool IsTypeSupported(Type assetType)
         {
-            if (typeMap is null || gameVersion is null)
+            if (typeMap is null || gameVersion == default)
                 return false;
 
             // TODO
@@ -57,15 +57,15 @@ namespace UndertaleModTool.Windows
             containsEverything = false;
             gameData = null;
             isYYC = false;
-            gameVersion = null;
+            gameVersion = default;
             bytecodeVer = 0;
         }
     }
 
     public class PredicateForVersion
     {
-        public (uint Major, uint Minor, uint Release) Version { get; set; }
-        public (uint Major, uint Minor, uint Release) BeforeVersion { get; set; } = (uint.MaxValue, uint.MaxValue, uint.MaxValue);
+        public GameVersion Version { get; set; }
+        public GameVersion BeforeVersion { get; set; } = new((uint.MaxValue, uint.MaxValue, uint.MaxValue), byte.MaxValue);
         public bool DisableForLTS2022 { get; set; } = false;
         public Func<object, HashSetTypesOverride, bool, Dictionary<string, object[]>> Predicate { get; set; }
     }
@@ -673,7 +673,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         // Bytecode version 15
-                        Version = (15, uint.MaxValue, uint.MaxValue),
+                        Version = new(15),
                         BeforeVersion = (2024, 8, 0),
                         Predicate = (objSrc, types, checkOne) =>
                         {
@@ -693,7 +693,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         // Bytecode version 16
-                        Version = (16, uint.MaxValue, uint.MaxValue),
+                        Version = new(16),
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleLanguage)))
@@ -1336,7 +1336,7 @@ namespace UndertaleModTool.Windows
                     new PredicateForVersion()
                     {
                         // Bytecode version 16
-                        Version = (16, uint.MaxValue, uint.MaxValue),
+                        Version = new(16),
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleRoom.GameObject)))
@@ -1412,7 +1412,7 @@ namespace UndertaleModTool.Windows
                 {
                     new PredicateForVersion()
                     {
-                        Version = (14, uint.MaxValue, uint.MaxValue), // Bytecode version 14
+                        Version = new(14), // Bytecode version 14
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleSound)))
@@ -1634,21 +1634,12 @@ namespace UndertaleModTool.Windows
 
             bool onlyEmptyResult = true;
 
-            var ver = (data.GeneralInfo.Major, data.GeneralInfo.Minor, data.GeneralInfo.Release);
+            GameVersion ver = new(data.GeneralInfo);
             Dictionary<string, List<object>> outDict = new();
             foreach (var predicateForVer in predicatesForVer)
             {
-                bool isAtLeast = false;
-                if (predicateForVer.Version.Minor == uint.MaxValue)
-                    isAtLeast = predicateForVer.Version.Major <= data.GeneralInfo.BytecodeVersion;
-                else
-                    isAtLeast = predicateForVer.Version.CompareTo(ver) <= 0;
-
-                bool isAboveMost = false;
-                if (predicateForVer.BeforeVersion.Minor == uint.MaxValue)
-                    isAboveMost = predicateForVer.BeforeVersion.Major <= data.GeneralInfo.BytecodeVersion;
-                else
-                    isAboveMost = predicateForVer.BeforeVersion.CompareTo(ver) <= 0;
+                bool isAtLeast = predicateForVer.Version.CompareTo(ver) <= 0;
+                bool isAboveMost = predicateForVer.BeforeVersion.CompareTo(ver) <= 0;
 
                 bool disableDueToLTS = false;
                 if (data.GeneralInfo.Branch == UndertaleGeneralInfo.BranchType.LTS2022_0)

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1673,32 +1673,36 @@ namespace UndertaleModTool.Windows
                 assets.AddRange(list.Item1.Cast<UndertaleResource>()
                                           .Select(x => (x, list.Item2)));
 
-            stringReferences = new();
-            funcReferences = new();
-            variReferences = new();
-            foreach (var code in data.Code)
+            // If it's not a YYC game
+            if (data.Code is not null)
             {
-                var strings = new HashSet<UndertaleString>();
-                var functions = new HashSet<UndertaleFunction>();
-                var variables = new HashSet<UndertaleVariable>();
-                foreach (var inst in code.Instructions)
+                stringReferences = new();
+                funcReferences = new();
+                variReferences = new();
+                foreach (var code in data.Code)
                 {
-                    if (inst.ValueString?.Resource is UndertaleString str)
-                        strings.Add(str);
+                    var strings = new HashSet<UndertaleString>();
+                    var functions = new HashSet<UndertaleFunction>();
+                    var variables = new HashSet<UndertaleVariable>();
+                    foreach (var inst in code.Instructions)
+                    {
+                        if (inst.ValueString?.Resource is UndertaleString str)
+                            strings.Add(str);
 
-                    if (inst.ValueVariable is UndertaleVariable variable)
-                        variables.Add(variable);
+                        if (inst.ValueVariable is UndertaleVariable variable)
+                            variables.Add(variable);
 
-                    if (inst.ValueFunction is UndertaleFunction function)
-                        functions.Add(function);
+                        if (inst.ValueFunction is UndertaleFunction function)
+                            functions.Add(function);
+                    }
+
+                    if (strings.Count != 0)
+                        stringReferences[code] = strings;
+                    if (functions.Count != 0)
+                        funcReferences[code] = functions;
+                    if (variables.Count != 0)
+                        variReferences[code] = variables;
                 }
-
-                if (strings.Count != 0)
-                    stringReferences[code] = strings;
-                if (functions.Count != 0)
-                    funcReferences[code] = functions;
-                if (variables.Count != 0)
-                    variReferences[code] = variables;
             }
 
             mainWindow.IsEnabled = false;

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1334,7 +1334,7 @@ namespace UndertaleModTool.Windows
                 {
                     new PredicateForVersion()
                     {
-                        Version = (1, 0, 0),
+                        Version = (14, uint.MaxValue, uint.MaxValue), // Bytecode version 14
                         Predicate = (objSrc, types, checkOne) =>
                         {
                             if (!types.Contains(typeof(UndertaleSound)))

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -14,19 +14,52 @@ namespace UndertaleModTool.Windows
 {
     public class HashSetTypesOverride : HashSet<Type>
     {
-        private readonly bool containsEverything, isYYC;
-        public HashSetTypesOverride(bool containsEverything = false, bool isYYC = false)
+        private static bool containsEverything, isYYC;
+        private static Dictionary<Type, PredicateForVersion[]> typeMap;
+        private static UndertaleData gameData;
+        private static GameVersion gameVersion;
+        private static byte bytecodeVer;
+
+        public static void MakeContainEverything(UndertaleData gameData, Dictionary<Type, PredicateForVersion[]> typeMap)
         {
-            this.containsEverything = containsEverything;
-            this.isYYC = isYYC;
+            containsEverything = true;
+            HashSetTypesOverride.typeMap = typeMap;
+            HashSetTypesOverride.gameData = gameData;
+
+            if (gameData is null)
+                return;
+
+            isYYC = gameData.Code is null;
+            gameVersion = new(gameData.GeneralInfo);
+            bytecodeVer = gameData.GeneralInfo.BytecodeVersion;
         }
+
+        private static bool IsTypeSupported(Type assetType)
+        {
+            if (typeMap is null || gameVersion is null)
+                return false;
+
+            // TODO
+            throw new NotImplementedException();
+        }
+
         public new bool Contains(Type item)
         {
             if (!containsEverything)
                 return base.Contains(item);
 
-            return !isYYC || !UndertaleResourceReferenceMap.CodeTypes.Contains(item);
-        } 
+            return !isYYC || !UndertaleResourceReferenceMap.CodeTypes.Contains(item)
+                   || IsTypeSupported(item);
+        }
+
+        public static void Restore()
+        {
+            containsEverything = false;
+            gameData = null;
+            isYYC = false;
+            gameVersion = null;
+            bytecodeVer = 0;
+        }
     }
 
     public class PredicateForVersion
@@ -1707,6 +1740,8 @@ namespace UndertaleModTool.Windows
                 {
                     ignoreArgumentsVar = true;
 
+                    HashSetTypesOverride.MakeContainEverything(data, typeMap);
+
                     var assetsPart = Partitioner.Create(0, assets.Count);
 
                     await Task.Run(() =>
@@ -1718,8 +1753,7 @@ namespace UndertaleModTool.Windows
                             for (int i = range.Item1; i < range.Item2; i++)
                             {
                                 var asset = assets[i];
-                                var assetReferences = GetReferencesOfObject(asset.Item1, data,
-                                                                            new HashSetTypesOverride(true, data.Code is null), true);
+                                var assetReferences = GetReferencesOfObject(asset.Item1, data, new HashSetTypesOverride(), true);
                                 if (assetReferences is null)
                                 {
                                     if (resultDict.TryGetValue(asset.Item2, out var list))
@@ -1783,6 +1817,8 @@ namespace UndertaleModTool.Windows
                 stringReferences = null;
                 funcReferences = null;
                 variReferences = null;
+
+                HashSetTypesOverride.Restore();
             }
 
             if (outDict.Count == 0)


### PR DESCRIPTION
## Description
1. It turns out that I missed that the audio groups are introduced in GameMaker versions with bytecode 14+.
So this type showed for such versions in the referenceable asset list, and this caused the null reference exception.
This PR fixes that.
2. Added a `GameVersion` constructor that accepts `UndertaleGeneralInfo` (and it also has the LTS 2022 logic).
3. Improved performance of "Find unreferenced assets" by adding early `return`s/`break`s for tracks (`void ProcessTrack() ...`), so it stops as soon as it finds a one reference inside a track.
4. Changed the `GameVersion` type to `readonly record struct` for better performance.
5. Simplified the bytecode version checking (comparison) in `GameVersion` by adding a proper support for that (instead of doing `(bytecodeVersion, uint.MaxValue, uint.MaxValue)`).
6. Added `PredicateDelegate` for a better readability of `PredicateForVersion`.
7. Now `UndertaleBackground` uses `BeforeVersion` (as it should) instead of using `null` names.
8. Made the version comparison more readable by changing the operands order.
9. Simplified asset type filtering for YYC.
10. Removed now redundant `PredicateForVersion.DisableForLTS2022` property and check.
11. Minor code changes (made early `continue` in a loop).
12. Treat LTS 2022 GM version as 2022.9, as it's actually like that internally; fixes #2475
13. Fixed a (theoretically possible) bug when `GetReferenceableTypes()` can return stale results for games with same GM version, but different YYC types (first loaded game data has code, second - doesn't).
14. Fixed an error for YYC games when you try to find unreferenced assets - it tried to access `data.Code` (fixes #2477).
15. Sort the results by group names and each asset list by asset ID - closes #2478.

### Caveats
None, I guess.

### Notes
Closes (partially) #2319 (the error part)