### PR TITLE
fix data file version being wrongfully increased from 2024.13 to 2026.1 when it has 0 objects

### DIFF
--- a/UndertaleModLib/UndertaleChunks.cs
+++ b/UndertaleModLib/UndertaleChunks.cs
@@ -1280,7 +1280,6 @@ namespace UndertaleModLib
             }
 
             long positionToReturn = reader.Position;
-            bool managedFieldPresent = false;
 
             if (reader.ReadUInt32() > 0) // Object count
             {
@@ -1289,7 +1288,7 @@ namespace UndertaleModLib
                 uint vertexCount = reader.ReadUInt32();
 
                 // If any of these checks fail, the managed field is probably present
-                managedFieldPresent = true;
+                bool managedFieldPresent = true;
 
                 // Bounds check on vertex data
                 if (reader.Position + 12 + vertexCount * 8 < positionToReturn + this.Length)
@@ -1304,17 +1303,18 @@ namespace UndertaleModLib
                             managedFieldPresent = false;
                     }
                 }
-            }
-            if (managedFieldPresent)
-            {
-                if (!reader.undertaleData.IsVersionAtLeast(2022, 5))
+
+                if (managedFieldPresent)
                 {
-                    reader.undertaleData.SetGMS2Version(2022, 5);
+                    if (!reader.undertaleData.IsVersionAtLeast(2022, 5))
+                    {
+                        reader.undertaleData.SetGMS2Version(2022, 5);
+                    }
                 }
-            }
-            else if (reader.undertaleData.IsVersionAtLeast(2024, 13))
-            {
-                reader.undertaleData.SetGMS2Version(2026, 1);
+                else if (reader.undertaleData.IsVersionAtLeast(2024, 13))
+                {
+                    reader.undertaleData.SetGMS2Version(2026, 1);
+                }
             }
 
             reader.Position = positionToReturn;


### PR DESCRIPTION
## Description
In 2153d7003d8fa9f6072b18e67b8c787b7eb5e9aa, code was added to bump the data file's version from 2024.13 to 2026.1 if the Managed field was not detected. However, the code assumes the field is missing even if the data file has 0 objects. 

This means that every 2024.13 game that has no game objects gets its version bumped to 2026.1, which can cause loading issues. This PR simply makes it so the version upgrades don't happen if there aren't any objects.

Here's a data file created from a blank 2024.13 project: [sample.zip](https://github.com/user-attachments/files/31392297/sample.zip). It loads without issue on 0.9.1.2 and on this PR's commit, but loads with warnings on 0.9.2.0.

### Caveats
None
