### PR TITLE
The "Search in code" is truly parallel (multithreaded) again, and more

### DIFF
--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2307,13 +2307,14 @@ namespace UndertaleModTool
             ScriptExecutionSuccess = true;
             ScriptErrorMessage = "";
             ScriptErrorType = "";
+
             InitializeScriptDialog();
-            this.IsEnabled = false; // Prevent interaction while the script is running.
+            this.IsEnabled = false;   // Prevent interaction while the script is running.
 
             await RunScriptNow(path); // Runs the script now.
-            HideProgressBar(); // Hide the progress bar.
-            scriptDialog = null;
-            this.IsEnabled = true; // Allow interaction again.
+
+            CloseProgressBar();       // Closes the progress bar entirely.
+            this.IsEnabled = true;    // Allow interaction again.
         }
 
         private async Task RunScriptNow(string path)

--- a/UndertaleModTool/MainWindow.xaml.cs
+++ b/UndertaleModTool/MainWindow.xaml.cs
@@ -2130,6 +2130,11 @@ namespace UndertaleModTool
         {
             scriptDialog?.TryHide();
         }
+        public void CloseProgressBar()
+        {
+            scriptDialog?.TryClose();
+            scriptDialog = null;
+        }
 
         public void AddProgress(int amount)
         {
@@ -3112,12 +3117,12 @@ result in loss of work.");
             // Try to get index
             int foundIndex = obj is UndertaleResource res ? Data.IndexOf(res, false) : -1;
 
-			// Determine ID
-			string idString;
+            // Determine ID
+            string idString;
             if (foundIndex == -2)
-			{	
+            {	
                 idString = "None";
-        	}
+            }
             else if (foundIndex == -1)
             {
                 idString = "N/A";

--- a/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
+++ b/UndertaleModTool/Windows/FindReferencesTypesDialog/UndertaleResourceReferenceMethodsMap.cs
@@ -1732,7 +1732,7 @@ namespace UndertaleModTool.Windows
             finally
             {
                 await mainWindow.StopProgressBarUpdater();
-                mainWindow.HideProgressBar();
+                mainWindow.CloseProgressBar();
 
                 mainWindow.IsEnabled = true;
                 stringReferences = null;

--- a/UndertaleModTool/Windows/SearchInCodeWindow.xaml.cs
+++ b/UndertaleModTool/Windows/SearchInCodeWindow.xaml.cs
@@ -41,7 +41,6 @@ namespace UndertaleModTool.Windows
 
         private Regex keywordRegex, nameRegex;
         private GlobalDecompileContext decompileContext;
-        private LoaderDialog loaderDialog;
         private UndertaleCodeEditor.CodeEditorTab editorTab;
 
         public readonly record struct Result(string Code, int LineNumber, string LineText);
@@ -173,10 +172,7 @@ namespace UndertaleModTool.Windows
 
             isSearchInProgress = true;
 
-            loaderDialog = new("Searching...", null);
-            loaderDialog.Owner = this;
-            loaderDialog.PreventClose = true;
-            loaderDialog.Show();
+            mainWindow.InitializeProgressDialog("Searching...", null);
 
             Results.Clear();
 
@@ -192,22 +188,20 @@ namespace UndertaleModTool.Windows
                 decompileContext = new GlobalDecompileContext(mainWindow.Data);
             }
 
-            loaderDialog.SavedStatusText = "Code entries";
-            loaderDialog.Update(null, "Code entries", 0, codeEntriesToSearch.Count);
+            mainWindow.SetProgressBar(null, "Code entries", 0, codeEntriesToSearch.Count);
+            mainWindow.StartProgressBarUpdater();
 
             await Task.Run(() => Parallel.ForEach(codeEntriesToSearch, SearchInUndertaleCode));
             await Task.Run(SortResults);
 
-            loaderDialog.Maximum = null;
-            loaderDialog.Update("Generating result list...");
+            await mainWindow.StopProgressBarUpdater();
+            mainWindow.UpdateProgressStatus("Generating result list...");
 
             editorTab = isInAssembly ? UndertaleCodeEditor.CodeEditorTab.Disassembly : UndertaleCodeEditor.CodeEditorTab.Decompiled;
 
             ShowResults();
 
-            loaderDialog.PreventClose = false;
-            loaderDialog.Close();
-            loaderDialog = null;
+            mainWindow.CloseProgressBar();
 
             mainWindow.IsEnabled = true;
             this.IsEnabled = true;
@@ -246,7 +240,7 @@ namespace UndertaleModTool.Windows
             }
 
             Interlocked.Increment(ref progressCount);
-            Dispatcher.Invoke(() => loaderDialog.ReportProgress(progressCount));
+            mainWindow.IncrementProgressParallel();
         }
 
         private void SearchInCodeText(string codeName, string codeText)
@@ -468,7 +462,7 @@ namespace UndertaleModTool.Windows
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
-            e.Cancel = (loaderDialog is not null);
+            e.Cancel = isSearchInProgress;
         }
     }
 }


### PR DESCRIPTION
## Description
1. Instead of manually advancing the progress bar on each code entry in the "Search in code" by invoking the UI thread, it now uses the progress bar updater (a background task), like it was in "Search.csx" script.
This makes it work noticeably faster (~40% in some cases, see below).
Fixes #2237.

I tested this on "123" search query in Deltarune Chapter 5 (UTMT built in the "Release" mode) and here is a comparison:
_The first search, the second and third, in seconds:
Before: **2.160**, 2.045, 1.392.
After: **1.523**, 1.334, 0.710._

2. Added a new `CloseProgressBar()` method; the progress bar window is properly closed (`scriptDialog.TryClose()`) instead of hiding it.
Fixes #1616.

3. Fixed the "MainWindow.xaml.cs" formatting - now it's spaces ("SPC") and `\n` line endings ("LF").

### Caveats
None.